### PR TITLE
Fixes for ANALYZER-1734, ANALYZER-1699 and ANALYZER-1716

### DIFF
--- a/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
@@ -56,10 +56,6 @@ pen.define([
                     return msg;
                 },
                 
-                configProperty: function(name){
-                    return cv.analyzerProperties[name];
-                },
-                
                 /**
                  * Returns the label of a given formula.
                  * Only available when interaction is enabled.

--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -2317,12 +2317,12 @@ function(def, pvc, pv){
         _getColorPalete: function(){
             //this._vizOptions.palette.colors.slice(0, seriesCount);
             if(!_colorPalete){
-                var colorPalete = this._vizHelper.configProperty('chart.series.colors');
-                if(colorPalete){
-                    _colorPalete = colorPalete.split(/\s*,\s*/);
-                } else {
-                    _colorPalete = _defaultColorPalete;
-                }
+//                var colorPalete = this._vizOptions['chart.series.colors'];
+//                if(colorPalete){
+//                    _colorPalete = colorPalete.split(/\s*,\s*/);
+//                } else {
+                  _colorPalete = _defaultColorPalete;
+//                }
             }
             return _colorPalete;
         },
@@ -2676,7 +2676,7 @@ function(def, pvc, pv){
         
         _limitSelection: function(selections){
             // limit selection
-            var filterSelectionMaxCount = this._vizHelper.configProperty('filter.selection.max.count') || 200;
+            var filterSelectionMaxCount = this._vizOptions['filter.selection.max.count'] || 200;
             var selections2 = selections;
             var L = selections.length;
             var deselectCount = L - filterSelectionMaxCount;


### PR DESCRIPTION
(ANALYZER-1734)  Need to port cgg plugin to Sugar

(ANALYZER-1699) Stack overflow error when too many charting points have been selected
- Removed analyzer.CCCVizHelper#configProperty method
- Now reading the analyzer.property "filter.selection.max.count" directly from the visualization options.

(ANALYZER-1716) Setting chart series color in Analyzer doesn't work in Pentaho 4.8GA
- Fixed palette determination code crashing in CGG. Now always using the default Analyzer palette, until the way that series colors will be supplied by the VizController is worked out.
