### PR TITLE
ANALYZER-1716, ANALYZER-1595 and ANALYZER-166

### DIFF
--- a/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
@@ -382,6 +382,14 @@ pen.define([
                     var totalGems = colorBy.gems.length + sizeBy.gems.length;
                     colorBy.required = (totalGems == 0);
                     sizeBy.required = (totalGems == 0);
+                    
+                    var visible = sizeBy.gems.length > 0; // TODO < 0 exists?
+//                    if(visible){
+//                        var vizController = this.report.visualizationController;
+//                        var chart = vizController && vizController.chart;
+//                        visible = !!chart && chart.hasNegativeSizeByValues;
+//                    }
+                    config.byId("sizeByNegativeMode").ui.hidden = !visible;
                 }
             });
             
@@ -447,7 +455,7 @@ pen.define([
                 
                 updateConfiguration: function(config){
                     this._updateColorRoleOptions(config);
-                    
+                    this._updateSizeRoleOptions(config);
                     this.inherited(arguments);
                 },
                 
@@ -462,6 +470,20 @@ pen.define([
                     config.byId("reverseColors").ui.hidden = !visible;
                     config.byId("colorSet").ui.hidden = !visible;
                     config.byId("pattern").ui.hidden = !visible;
+                },
+                
+                _updateSizeRoleOptions: function(config){
+                    var sizeBy = config.byId("size");
+                    
+                    // Show/hide size option
+                    var visible = sizeBy.gems.length > 0; // TODO < 0 exists?
+//                    if(visible){
+//                        var vizController = this.report.visualizationController;
+//                        var chart = vizController && vizController.chart;
+//                        visible = !!chart && chart.hasNegativeSizeByValues;
+//                    }
+                    
+                    config.byId("sizeByNegativeMode").ui.hidden = !visible;
                 }
             });
     


### PR DESCRIPTION
[ANALYZER-1716] Setting chart series color in Analyzer doesn't work in Pentaho 4.8GA - merge of 4.8 fix to sugar
[ANALYZER-1595] Visualizations need to handle null/missing/NaN/NA Measure values consistently when used as size by and color by values.
[ANALYZER-1660] Visualizations need to handle negative Measure values consistently when used as size by and color by values.

Still not updating the properties panel when negative values exist.
