### PR TITLE
[ANALYZER-1817] and [ANALYZER-1818], related to GEO map visualization

### DIFF
--- a/package-res/resources/web/vizapi/DataTable.js
+++ b/package-res/resources/web/vizapi/DataTable.js
@@ -241,32 +241,43 @@ pentaho.DataTable.prototype.getFormattedValue = function(rowIdx,columnIdx) {
     getColumnRange
     Returns a range object describing the minimum and maximum values from the specified column
     columnIdx   The column number (zero based)
-    returns     A range object - { min: 123, max: 456 }
+    options      A keyword arguments object.
+    options.key  A function that extracts the values from the column data.
+    returns      A range object - { min: 123, max: 456 }.
+                 When there is no data, or all data is null or NaN, the returned
+                 range object will have both its properties, 'min' and 'max', 
+                 with the value undefined.
 */
-pentaho.DataTable.prototype.getColumnRange = function(columnIdx) {
+pentaho.DataTable.prototype.getColumnRange = function(columnIdx, options) {
 
     var min;
     var max;
     var set = false;
+    var key = options && options.key;
+    
     for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
         // get the value from this row
         var value = this.getValue( rowNo, columnIdx );
-        if( !set && (value || value == 0) ) {
-            // we have found our first value, set the min and max
-            min = value;
-            max = value;
-            set = true;
-        } else {
-            if( value < min ) {
-                // adjust the minimum
-                min = value;
+        if(value != null) {
+            if(key){
+                value = key(value);
             }
-            if( value > max ) {
-                // adjust the maximum
+            
+            if(!set) {
+                min = value;
                 max = value;
+                set = true;
+            } else {
+                if( value < min ) {
+                    min = value;
+                }
+                if( value > max ) {
+                    max = value;
+                }
             }
         }
     }
+    
     // return the range 
     var range = {
         min: min,
@@ -461,25 +472,38 @@ pentaho.DataView.prototype.setColumns = function(columns) {
     getColumnRange
     Returns a range object describing the minimum and maximum values from the specified column
     columnIdx   The column number (zero based)
-    returns     A range object - { min: 123, max: 456 }
+    options      A keyword arguments object.
+    options.key  A function that extracts the values from the column data.
+    returns      A range object - { min: 123, max: 456 }.
+                 When there is no data, or all data is null or NaN, the returned
+                 range object will have both its properties, 'min' and 'max', 
+                 with the value undefined.
 */
-pentaho.DataView.prototype.getColumnRange = function(columnIdx) {
+pentaho.DataView.prototype.getColumnRange = function(columnIdx, options) {
 
     var min;
     var max;
     var set = false;
+    var key = options && options.key;
+    
     for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
         var value = this.getValue( rowNo, columnIdx );
-        if( !set && (value || value == 0) ) {
-            min = value;
-            max = value;
-            set = true;
-        } else {
-            if( value < min ) {
-                min = value;
+        if(value != null) {
+            if(key){
+                value = key(value);
             }
-            if( value > max ) {
+            
+            if(!set) {
+                min = value;
                 max = value;
+                set = true;
+            } else {
+                if( value < min ) {
+                    min = value;
+                }
+                if( value > max ) {
+                    max = value;
+                }
             }
         }
     }

--- a/package-res/resources/web/vizapi/VizController.js
+++ b/package-res/resources/web/vizapi/VizController.js
@@ -690,6 +690,16 @@ pentaho.VizController.getRgbGradientFromMultiColorHex = function(value, min, max
   return pentaho.VizController.getRrbColor(cols[0], cols[1], cols[2]);
 }
 
+// Adapted from protovis
+pentaho.VizController.getDarkerFromColorHex = function(color, k) {
+  var comps = pentaho.VizController.convertToRGB(color);
+  k = Math.pow(0.7, k != null ? k : 1);
+  return pentaho.VizController.getRrbColor(
+        Math.max(0, Math.floor(k * comps[0])),
+        Math.max(0, Math.floor(k * comps[1])),
+        Math.max(0, Math.floor(k * comps[2])));
+};
+
 pentaho.VizController.getRgbStepFromMultiColorHex = function(value, min, max, colors) {
 
   var steps = colors.length-1;

--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -1508,7 +1508,7 @@ function(def, pvc, pv){
         extensionPoints: {
             axisRule_strokeStyle:   ruleStrokeStyle,
             axisTicks_strokeStyle:  lineStrokeStyle,
-            
+            dot_lineWidth: 1.5,
             legendArea_lineWidth:       1,
             legendArea_strokeStyle:     '#c0c0c0',
             legendLabel_textDecoration: null,


### PR DESCRIPTION
[ANALYZER-1817] Geo Map visualization needs to handle null/missing/NaN/NA Measure values consistently when used as size by and color by values
[ANALYZER-1818] Geo Map visualization needs to handle negative Measure values consistently when used as size by and color by values
[FIX] pentaho.DataTable/DataView#getColumnRange - null values could cause the result to return a null minimum and a non-null maximum.
[FEAT] pentaho.DataTable#getColumnRange ABS - Added argument options, supporting option 'key', that can receive a function that extracts the value from each DataTable's original value. This is used to obtain a range for the absolute value of the size by measure.
[FEAT] pentaho.VizController.getDarkerFromColorHex - Added new method that serves to darken a color given as an array of RGB components. Based on protovis' pv.Color#darker method.
[CHG] ccc_wrapper Scatter HeatGrid - Slightly increased the dots' line width, so that the GeoMap and the CCC visualizations look the same.
