### PR TITLE
PRD-4271: Removed check to refresh prompt

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting.js
+++ b/package-res/resources/web/prompting/pentaho-prompting.js
@@ -598,11 +598,7 @@ pen.define(['cdf/cdf-module', 'common-ui/prompting/pentaho-prompting-bind', 'com
        * Called when a parameter value changes.
        */
       this.parameterChanged = function(param, name, value) {
-        // Only refresh the report if the 'Auto Submit' checkbox is set.
-        if (this.getAutoSubmitSetting() == true)
-        {
-          this.refreshPrompt();
-        }
+        this.refreshPrompt();
       };
 
 


### PR DESCRIPTION
We need to hit server twice.  Once to update parameter information for parameter cascading and second time for rendering report.
