### PR TITLE
Expose repo and dataapi js as requirejs dependencies

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -1,2 +1,27 @@
 requireCfg['paths']['common-ui'] = CONTEXT_PATH+'content/common-ui/resources/web';
 requireCfg['paths']['local'] = CONTEXT_PATH+'content/common-ui/resources/web/util/local';
+
+requireCfg['paths']['common-repo'] = CONTEXT_PATH+'api/repos/common-ui/resources/web/repo';
+requireCfg['paths']['common-data'] = CONTEXT_PATH+'api/repos/common-ui/resources/web/dataapi';
+
+requireCfg['shim']['common-repo/module'] = [
+	'common-repo/state',
+	'common-repo/pentaho-ajax',
+	'common-repo/pentaho-thin-app'
+];
+
+requireCfg['shim']['common-data/module'] = [
+	'common-repo/module',
+	'common-data/oop',
+	'common-data/app',
+	'common-data/controller',
+	'common-data/xhr',    
+	'common-data/cda',
+	'common-data/models-mql'
+];
+
+requireCfg['shim']['common-data/app'] = ['common-data/oop'];
+requireCfg['shim']['common-data/controller'] = ['common-data/oop', 'common-data/app'];
+requireCfg['shim']['common-data/xhr'] = ['common-data/oop'];
+requireCfg['shim']['common-data/cda'] = ['common-data/oop'];
+requireCfg['shim']['common-data/models-mql'] = ['common-data/oop', 'common-data/controller'];

--- a/package-res/resources/web/dataapi/module.js
+++ b/package-res/resources/web/dataapi/module.js
@@ -1,0 +1,1 @@
+// dataapi main module

--- a/package-res/resources/web/repo/module.js
+++ b/package-res/resources/web/repo/module.js
@@ -1,0 +1,1 @@
+// repo main module


### PR DESCRIPTION
this will allow other plugins to declare the set of repo/dataapi js files as a group dependency. example:

pen.require(['common-repo/module', 'common-data/module'],function(){
  // do something
});
