### PR TITLE
BISERVER-8807 - IE9 - IE9 Standards Mode - When hovering over the Produc...

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting.css
+++ b/package-res/resources/web/prompting/pentaho-prompting.css
@@ -25,7 +25,11 @@ div.prompt-panel div.parameter-label {
 
 div.prompt-panel div.parameter-wrapper {
   overflow: auto;
-  margin: 4px;
+
+  /* [BISERVER-8807] - Fix IE9 bug with tables growing when css styles added dynamically
+   * http://stackoverflow.com/questions/5788726/add-remove-css-will-cause-ie9-to-increase-the-tables-height
+   */
+  margin: auto 4px 4px 4px;
 }
 
 div.prompt-panel div.flow div.parameter {


### PR DESCRIPTION
...t Line toggle buttons, the parameter section grows... shrinking the report content area

Fix IE9 bug with tables growing when css styles added dynamically

It seems that we weren't the only ones seeing this problem:
- http://stackoverflow.com/questions/5788726/add-remove-css-will-cause-ie9-to-increase-the-tables-height

set the top pargin of the containing panel to auto fixes the issue.
