### PR TITLE
PDI-9448 - Removed dependency on obsolete kettle-db jar

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -41,7 +41,6 @@
 		<!-- Pentaho dependencies -->
 		<dependency org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true" transitive="false" conf="default->default" />
 		<dependency org="pentaho-kettle" name="kettle-core" rev="${dependency.kettle.revision}" changing="true" transitive="false" conf="default->default" />
-		<dependency org="pentaho-kettle" name="kettle-db" rev="${dependency.kettle.revision}" changing="true" transitive="false" conf="default->default" />
         
 		<dependency org="pentaho" name="pentaho-platform-api" rev="${dependency.pentaho-platform.revision}" changing="true" transitive="false" conf="default->default" />
 		<dependency org="pentaho" name="pentaho-platform-core" rev="${dependency.pentaho-platform.revision}" changing="true" transitive="false" conf="default->default" />


### PR DESCRIPTION
PDI-9448 - Removed dependency on obsolete kettle-db jar
