### PR TITLE
PRD-4101, PRD-4424 Common-UI / Prompting

### DIFF
--- a/package-res/resources/web/util/BusyIndicator.js
+++ b/package-res/resources/web/util/BusyIndicator.js
@@ -11,7 +11,7 @@ pen.define(["common-ui/util/Glasspane", "common-ui/util/PentahoSpinner"], functi
 
     show: function(/*String*/ title, /*String*/ message) {
       if(this.isShowing) {
-        console.log("still showing spinner, don't need another");
+        if(typeof console !== 'undefined' && console.log) { console.log("still showing spinner, don't need another"); }
         return;
       }
       this.isShowing = true;


### PR DESCRIPTION
PRD-4101: Report having parameter with display type as Text box behaves abnormally when Auto Submit is unchecked.
PRD-4424: Clicking View report twice to generate report in FF
#### Common-UI / Prompting
- Removed references to the discontinued ParamDefinition.subscribe property and the renderMode='SCHEDULE'.
- Refactored some code blocks
- Submit button "mouseDown" event now calls "expressionStart" so that it is possible to know when a focus out is occurring due to a submit-click.
- Fix to StaticAutocompleteBoxComponent change event firing when focus leaves the field without the value having been changed.
- Changed the way that the removeDashboardComponents method used to directly modify Dashboards.components array; now uses Dashboards.removeComponent
- Depends on CDF commit https://github.com/webdetails/cdf/commit/e1dc5878a7337b6ff98c06bd5b0d7dae407434c4
