### PR TITLE
BISERVER-8967 - Making the busy indicator message wrap if it grows too long

### DIFF
--- a/package-res/resources/web/util/BusyIndicator.js
+++ b/package-res/resources/web/util/BusyIndicator.js
@@ -41,12 +41,14 @@ pen.define(["common-ui/util/Glasspane", "common-ui/util/PentahoSpinner"], functi
             // only create the DOM element if it's not already there
             this.$busyIndicator = $(
                 "<div class='busy-indicator-container waitPopup'>" +
-                    "  <div class='pentaho-busy-indicator-spinner'></div>" +
-                    "  <div class='pentaho-busy-indicator-msg-contianer'>" +
-                    "    <div class='pentaho-busy-indicator-title waitPopup_title'>" + title + "</div>" +
-                    "    <div class='pentaho-busy-indicator-message waitPopup_msg'>" + message + "</div>" +
-                    "  </div>" +
-                    "</div>"
+                "  <div class='busy-indicator-container-wrapper'>" +
+                "    <div class='pentaho-busy-indicator-spinner'></div>" +
+                "    <div class='pentaho-busy-indicator-msg-contianer'>" +
+                "      <div class='pentaho-busy-indicator-title waitPopup_title'>" + title + "</div>" +
+                "      <div class='pentaho-busy-indicator-message waitPopup_msg'>" + message + "</div>" +
+                "    </div>" +
+                "  </div>" +
+                "</div>"
             );
 
             $(window.top.document.body).append(this.$busyIndicator);
@@ -59,7 +61,7 @@ pen.define(["common-ui/util/Glasspane", "common-ui/util/PentahoSpinner"], functi
 
             var that = this;
             this.$busyIndicator.fadeIn(this.fadeInDuration, function() {
-                var container = $(window.top.document).find(".busy-indicator-container > .pentaho-busy-indicator-spinner");
+                var container = $(window.top.document).find(".busy-indicator-container-wrapper > .pentaho-busy-indicator-spinner");
                 that.spinner.spin(container.get(0));
             });
         },

--- a/package-res/resources/web/util/PentahoSpinner.js
+++ b/package-res/resources/web/util/PentahoSpinner.js
@@ -45,7 +45,7 @@ pen.define(['common-ui/util/spin.min', 'common-ui/util/Glasspane'], function(spi
         corners: 1, // Corner roundness (0..1)
         rotate: 90, // The rotation offset
         // color will be overriden by themed css (globalOnyx.css for example) -- .spinner div > div{...}
-        color: '#FFF', // #rgb or #rrggbb
+        color: '#999', // #rgb or #rrggbb
         speed: 1, // Rounds per second
         trail: 100, // Afterglow percentage
         shadow: false, // Whether to render a shadow
@@ -67,7 +67,7 @@ pen.define(['common-ui/util/spin.min', 'common-ui/util/Glasspane'], function(spi
         corners: 1, // Corner roundness (0..1)
         rotate: 90, // The rotation offset
         // color will be overriden by themed css (globalOnyx.css for example) -- .spinner div > div{...}
-        color: '#FFF', // #rgb or #rrggbb
+        color: '#999', // #rgb or #rrggbb
         speed: 1, // Rounds per second
         trail: 100, // Afterglow percentage
         shadow: false, // Whether to render a shadow
@@ -89,7 +89,7 @@ pen.define(['common-ui/util/spin.min', 'common-ui/util/Glasspane'], function(spi
         corners: 1, // Corner roundness (0..1)
         rotate: 90, // The rotation offset
         // color will be overriden by themed css (globalOnyx.css for example) -- .spinner div > div{...}
-        color: '#FFF', // #rgb or #rrggbb
+        color: '#999', // #rgb or #rrggbb
         speed: 1, // Rounds per second
         trail: 100, // Afterglow percentage
         shadow: false, // Whether to render a shadow


### PR DESCRIPTION
Also default the spinner color to #999 to account for the IE8 VML fallback option that doesn't allow for a css override of color like the css3 implementation.
