### PR TITLE
PRD-3687 - Reports with multi-select list refreshes for every single select. Changed the time-out + focusout strategy to a focus-out only strategy.

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting-builders.js
+++ b/package-res/resources/web/prompting/pentaho-prompting-builders.js
@@ -242,7 +242,7 @@ pen.define(['cdf/cdf-module', 'common-ui/prompting/pentaho-prompting-bind'], fun
       return $.extend(widget, {
         type: args.param.multiSelect ? 'SelectMultiComponent' : 'SelectComponent',
         size: args.param.attributes['parameter-visible-items'] || 5,
-        changeMode: 'focus',
+        changeMode: 'timeout-focus',
         preExecution: function() {
           // SelectComponent defines defaultIfEmpty = true for non-multi selects.
           // We can't override any properties of the component so we must set them just before update() is called. :(


### PR DESCRIPTION
Reverts previous commit https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/0fbfdb39299051381708bd644c612d4c5e99958a that replaced the "timeout" strategy with a "focusout" strategy.

This change depends on CDF/5.0 commit: https://github.com/webdetails/cdf/commit/a7d1ea8164a50e44e222cc41d02f8eff5d04c50e
which restores and improves the "timeout-focus" change strategy.
