### PR TITLE
BISERVER-9984 - IR and Analyzer broken in Chrome v29

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/ExpressionTree/ExpressionTree.html
+++ b/package-res/resources/web/dojo/pentaho/common/ExpressionTree/ExpressionTree.html
@@ -1,10 +1,8 @@
 <div data-dojo-attach-point="expressionNode" class="pentaho-expression pentaho-clearfix">
 	<div data-dojo-attach-point="operatorNode" class="pentaho-operator">
 		<div data-dojo-attach-point="operatorSelectNode" class="pentaho-operatorSelect">
-			<div data-dojo-attach-point="operatorSelect" data-dojo-type="dijit.form.Select"
-				data-dojo-attach-event="onChange:onOperatorChange">
-				<span value="${defaultOperator.value}">${defaultOperator.label}</span>
-			</div>
+      <!-- Chrome 29 can't handle whitespace between element tags of anything translated into a SELECT -->
+			<div data-dojo-attach-point="operatorSelect" data-dojo-type="dijit.form.Select" data-dojo-attach-event="onChange:onOperatorChange"><span value="${defaultOperator.value}">${defaultOperator.label}</span></div>
 		</div>
 	</div>
 	<div data-dojo-attach-point="bracketNode" class="pentaho-bracket"></div>

--- a/package-res/resources/web/dojo/pentaho/common/datasourceselect.html
+++ b/package-res/resources/web/dojo/pentaho/common/datasourceselect.html
@@ -30,8 +30,8 @@
     </tr>
     <tr>
         <td colspan="3">
-            <div dojoType="pentaho.common.ListBox" dojoAttachPoint="modelList" name="model" size="6" class="listbox" width="100%" height="100px" style="overflow:auto;width:100%">
-            </div>
+          <!-- Chrome 29 can't handle whitespace between element tags of anything translated into a SELECT -->
+          <div dojoType="pentaho.common.ListBox" dojoAttachPoint="modelList" name="model" size="6" class="listbox" width="100%" height="100px" style="overflow:auto;width:100%"></div>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
removed whitespace between dom items using dijit.form.Select. Chrome 29 treats that whitespace as #text nodes within the list and throws errors as a result :(
