### PR TITLE
BISERVER-8660 Plugin static file caching is not consistently set

### DIFF
--- a/package-res/settings.xml
+++ b/package-res/settings.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <!-- set this to true for production, and false for development/localization -->
-    <cache-messages>false</cache-messages>
-    
+    <cache-messages>true</cache-messages>
     <!-- how far ahead to set the browser's cache -->
-    <max-age>0</max-age>
-    
-    <cache>false</cache>
+    <max-age>2628001</max-age>
+    <cache>true</cache>
 </settings>


### PR DESCRIPTION
Plugin static file caching is not consistently set, resulting in a performance hit in production environments
