### PR TITLE
[PRD-3687] - Reports with multi-select list refreshes for every single select.

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting-components.js
+++ b/package-res/resources/web/prompting/pentaho-prompting-components.js
@@ -377,6 +377,8 @@ pen.define(['common-ui/prompting/pentaho-prompting-bind', 'common-ui/prompting/p
       this.onChangeHandle = dojo.connect(dateTextBox, "onChange", function() {
         Dashboards.processChange(this.name);
       }.bind(this));
+
+      this._doAutoFocus();
     },
 
     getValue: function() {
@@ -460,6 +462,8 @@ pen.define(['common-ui/prompting/pentaho-prompting-bind', 'common-ui/prompting/p
           Dashboards.processChange(this.name);
         }
       }.bind(this));
+
+      this._doAutoFocus();
     },
 
     getValue: function() {
@@ -500,6 +504,8 @@ pen.define(['common-ui/prompting/pentaho-prompting-bind', 'common-ui/prompting/p
       input.focusout(function() {
         Dashboards.processChange(this.name);
       }.bind(this));
+
+      this._doAutoFocus();
     },
 
     getValue: function() {

--- a/package-res/resources/web/prompting/pentaho-prompting.js
+++ b/package-res/resources/web/prompting/pentaho-prompting.js
@@ -663,6 +663,34 @@ pen.define([ 'cdf/cdf-module', 'common-ui/prompting/pentaho-prompting-bind', 'co
             // We'll clear the old components with a special component in front of all other components during init().
             var postponeClear = this.paramDefn.showParameterUI();
             pentaho.common.prompting.removeDashboardComponents(this.components, postponeClear);
+
+            // Create dictionary by parameter name, of topValue of multi-select listboxes, for restoring later, when possible.
+            // But not for mobile, cause the UIs vary. Would need more time to check each.
+            var topValuesByParam;
+            if(!(/android|ipad|iphone/i).test(navigator.userAgent)) {
+              topValuesByParam = this._multiListBoxTopValuesByParam = {};
+            }
+            
+            var focusedParam;
+            window.CompositeComponent.mapComponentsList(this.components, function(c) {
+              if(!c.components && c.param && c.promptType === 'prompt') {
+                if(!focusedParam) {
+                  var ph = c.placeholder();
+                  if($(":focus", ph).length) {
+                    focusedParam = c.param.name;
+                  }
+                }
+                
+                if(topValuesByParam && c.type === 'SelectMultiComponent') {
+                  var topValue = c.topValue();
+                  if(topValue != null) {
+                    topValuesByParam['_' + c.param.name] = topValue;
+                  }
+                }
+              }
+            });
+            
+            this._focusedParam = focusedParam;
           }
 
           this.init(noAutoAutoSubmit);
@@ -685,6 +713,12 @@ pen.define([ 'cdf/cdf-module', 'common-ui/prompting/pentaho-prompting-bind', 'co
           
           var layout = pentaho.common.prompting.builders.WidgetBuilder.build(this, 'prompt-panel');
           
+          var topValuesByParam = this._multiListBoxTopValuesByParam;
+          if(topValuesByParam) { delete this._multiListBoxTopValuesByParam; }
+
+          var focusedParam = this._focusedParam;
+          if(focusedParam) { delete this._focusedParam; }
+
           window.CompositeComponent.mapComponents(layout, function(c) { 
             components.push(c);
            
@@ -692,6 +726,21 @@ pen.define([ 'cdf/cdf-module', 'common-ui/prompting/pentaho-prompting-bind', 'co
             // It will take care of firing this itself (based on auto-submit)
             if (fireSubmit && c.promptType == 'submit') {
               fireSubmit = false;
+            }
+
+            if(!c.components && c.param && c.promptType === 'prompt') {
+              var name = c.param.name;
+              if(focusedParam && focusedParam === name) {
+                focusedParam = null;
+                c.autoFocus = true;
+              }
+
+              if(topValuesByParam && c.type === 'SelectMultiComponent') {
+                var topValue = topValuesByParam['_' + name];
+                if(topValue != null) {
+                  c.autoTopValue = topValue;
+                }
+              }
             }
           });
           


### PR DESCRIPTION
- Restore top value of multi-select list-boxes for prompting panels.
- Restore focused parameter upon prompt refresh.

@rfellows this is yet another change made to the multi-select behavior as requested by Marc Batchelor, for the 4.8 and 4.5 SPs.
