### PR TITLE
BISERVER-10541 - Adding bower configuration.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "pentaho-common-ui",
+  "version": "0.0.1",
+  "homepage": "https://github.com/rfellows/pentaho-platform-plugin-common-ui",
+  "authors": [
+    "Rob Fellows <rfellows@pentaho.com>"
+  ],
+  "main": "package-res/resources/web/require.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "build-res",
+    "dev-res",
+    "jscoverage",
+    "test-src",
+    "src",
+    "bin",
+    "build*",
+    "codegen-lib",
+    "dist",
+    "ivy*",
+    "js-test",
+    "lib",
+    "package-ivy.xml",
+    "package.json",
+    "karma*",
+    "test-*",
+    "package-res/*.xml",
+    "package-res/resources/chartseriescolor",
+    "package-res/resources/themes",
+    "package-res/resources/web/test"
+  ]
+}


### PR DESCRIPTION
This allows other projects to resolve the common-ui javascript dependencies via:

```
bower install git@github.com:pentaho/pentaho-platform-plugin-common-ui.git
```

_This DOES NOT set common-ui up to use bower to resolve it's own dependencies._
