### PR TITLE
BISERVER-10415 - fix for issue with 'moduleName' not being defined

### DIFF
--- a/package-res/resources/web/plugin-handler/animatedAngularPluginHandler.js
+++ b/package-res/resources/web/plugin-handler/animatedAngularPluginHandler.js
@@ -30,22 +30,22 @@ pen.define(deps, function(AngularPluginHandler) {
 		// Provide url linking directly on the plugin, which provides the modulename necessary
 		// for namespace navigation 
 		this.goto = function(url) {
-			goto(url, moduleName);
+			goto(url, this.moduleName);
 		}
 		this.goHome = function() {
-			goHome(moduleName);
+			goHome(this.moduleName);
 		}
 		this.goNext = function(url) {
-			goNext(url, moduleName);
+			goNext(url, this.moduleName);
 		}
 		this.goPrevious = function(url) {
-			goPrevious(url, moduleName);		
+			goPrevious(url, this.moduleName);		
 		}
 		this.open = function(url) {
-			open(url, moduleName);
+			open(url, this.moduleName);
 		}
 		this.close = function() {
-			close(moduleName);
+			close(this.moduleName);
 		}
 	}
 	


### PR DESCRIPTION
Now that moduleName is part of the config object and not passed as a separate argument into the Plugin constructor this change is required. we can use this.moduleName since we first:

```
$.extend(this, new AngularPluginHandler.Plugin(config));
```
