### PR TITLE
PRD-4751

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/Calendar.js
+++ b/package-res/resources/web/dojo/pentaho/common/Calendar.js
@@ -122,7 +122,6 @@ dojo.declare("pentaho.common.Calendar",
 			dojo.stopEvent(evt);
 			for(var node = evt.target; node && !node.dijitDateValue; node = node.parentNode);
 			if(node && !dojo.hasClass(node, "dijitCalendarDisabledDate")){
-				this.set('value', node.dijitDateValue);
 				dojo.addClass(node, "pentaho-listitem-selected");
 			}
 		}


### PR DESCRIPTION
Removed double date update. The setValue was creating a second (and undesired) click in the same position of the calendar
