### PR TITLE
[BISERVER-2504]

### DIFF
--- a/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_analyzer_plugin.js
@@ -454,7 +454,8 @@ define([
                 
                 'ccc_scatter',
                 'ccc_barline',
-                'ccc_heatgrid'
+                'ccc_heatgrid',
+                'ccc_sunburst'
                 
                 //'ccc_treemap' - See ANALYZER-1983
                 


### PR DESCRIPTION
Recovered support for sunburst chart. Was removed during dojo19 upgrade
