### PR TITLE
[ANALYZER-2478] On the first load, the middle panel doesn't render

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -23,12 +23,11 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
   ,"dojo/data/ItemFileReadStore"
   ,"dijit/form/Select"
   ,"dijit/form/CheckBox"
-  ,"dojo/dnd/Source"
   ,"dijit/TitlePane"
   ,"pentaho/common/Messages", "dojo/_base/array", "dojo/_base/lang", "dojo/html", "dojo/dom-construct",
   "dojo/string", "dojo/dom-class", "pentaho/common/propertiesPanel/Configuration", "dijit/registry", "dojo/dnd/Target",
   "dojo/dnd/Source", "dojo/Evented", "dojo/topic", "dojo/dnd/Manager", "dojo/dom", "dojo/dom-geometry", "dojo/aspect"],
-    function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, on, query, ContentPane, BorderContainer, HorizontalSlider, TextBox, ComboBox, ItemFileReadStore, Select, CheckBox, Source, TitlePane, Messages, array, lang, html, construct, string, domClass, Configuration, registry, Target, Source, Evented, topic, ManagerClass,
+    function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, on, query, ContentPane, BorderContainer, HorizontalSlider, TextBox, ComboBox, ItemFileReadStore, Select, CheckBox, TitlePane, Messages, array, lang, html, construct, string, domClass, Configuration, registry, Target, Source, Evented, topic, ManagerClass,
               dom, geometry, aspect) {
 
       var Panel = declare("pentaho.common.propertiesPanel.Panel",


### PR DESCRIPTION
- Only manifested on IE when the debugger wasn't debugging (although it could be opened)
- Duplicate argument in module definition function's argument list
