### PR TITLE
[TEST] - Cleaning up unit tests to work with PhantomJS.

### DIFF
--- a/package-res/resources/web/test/karma/unit/angular-directives/dateTimePickerSpec.js
+++ b/package-res/resources/web/test/karma/unit/angular-directives/dateTimePickerSpec.js
@@ -15,7 +15,7 @@ define(deps, function(angular, templateUtil) {
 
         beforeEach(inject(function ($rootScope, $httpBackend, $templateCache) {
             scope = $rootScope.$new();
-            scope.startDate = new Date("2014-04-01 11:15:00 PM");
+            scope.startDate = new Date(2014,4,1,23,15,0);
             httpBackend = $httpBackend;
             templateCache = $templateCache;
 

--- a/package-res/resources/web/test/karma/unit/angular-directives/weeklyRecurrenceSpec.js
+++ b/package-res/resources/web/test/karma/unit/angular-directives/weeklyRecurrenceSpec.js
@@ -139,11 +139,12 @@ define(deps, function (angular, templateUtil) {
                         expect(scope.model.startTime.getHours()).toBe(10);
                         expect(scope.model.startTime.getMinutes()).toBe(59);
 
-                        isolateScope.selectedDate = new Date("2014-04-01 11:15:00 PM");
+                        var myDate = new Date(2014,4,1,23,15,0);
+                        isolateScope.selectedDate = myDate;
 
                         scope.$apply();
 
-                        expect(scope.model.startTime.toString()).toBe( new Date("2014-04-01 11:15:00 PM").toString());
+                        expect(scope.model.startTime).toBe(myDate);
                     });
                 });
             });


### PR DESCRIPTION
PhantomJS isn't as friendly as some browsers when it comes to creating dates from strings (like chrome is)

var myDate = new Date("2014-04-01 11:15:00 PM");

 fails in PhantomJS. most likely because it's not a standard way to create dates. to do this in a cross-browser format you can use the all numbers approach:

 var myDate = new Date(2014,4,1,23,15,0);
