### PR TITLE
BACKLOG-306 - CLONE - Exactly matches filters are showing as "EQUAL" and...

### DIFF
--- a/package-res/resources/web/dojo/dijit/themes/pentaho/form/Select.css
+++ b/package-res/resources/web/dojo/dijit/themes/pentaho/form/Select.css
@@ -2,7 +2,7 @@
   padding: 0;
 }
 .tundra .dijitSelect .dijitButtonNode .dijitArrowButtonInner {
-  margin: 0 4px 0 5px;
+  margin: 0 1px;
 }
 
 /* Make unselected content portion "look" more like a text box and less like a button */


### PR DESCRIPTION
... the filter dropdown is not shown

Fixed width of drop-down list button (with arrow)

Related pull request https://github.com/pentaho/pentaho-commons-gwt-modules/pull/267
