### PR TITLE
PRD-5306 - Parameter Date incorrect when publishing to PUC

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting-components.js
+++ b/package-res/resources/web/prompting/pentaho-prompting-components.js
@@ -408,7 +408,11 @@ define("common-ui/prompting/pentaho-prompting-components", ['common-ui/prompting
             initialValue = this.formatter ? this.formatter.format(this.transportFormatter.parse(v.label)) : v.label;
 
             try {
-              valueParsed = dojo.number.format(v.label, {locale: SESSION_LOCALE.toLowerCase()});
+	      if(isNaN(v.label) || Math.abs(v.label) == Infinity){ 
+                valueParsed =  null; 
+              } else {
+                valueParsed = dojo.number.format(v.label, {locale: SESSION_LOCALE.toLowerCase()});
+              }
             } catch(e) {
               valueParsed = v.label;
             }


### PR DESCRIPTION
Changes:
Added verifying v.label . This verifying was taken from function dojo.number.format(). Without this verifying, the block try was failed and  valueParsed variable was not correct.