### PR TITLE
[ENGOPS-1024] Integrate YUIDoc into Subfloor-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ js-lib/
 lib/
 codegen-lib/
 test-lib/
+doc-js/
 eclipse-bin/
 override.properties
 .classpath

--- a/build-res/subfloor-js.xml
+++ b/build-res/subfloor-js.xml
@@ -74,6 +74,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <property name="js.karma.ci.config" value="config/karma.ci.conf.js"/>
   <property name="js.node.node_modules.dir" value="node_modules"/>
 
+  <!-- List of comma-separated paths to yuidoc configuration files -->
+  <property name="yuidoc.json" value=""/>
+
   <property environment="env"/>
 
   <target name="js.clean"
@@ -397,6 +400,92 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </else>
     </if>
 
+  </target>
+
+  <available file="yuidoc.cmd" filepath="${env.Path}" property="yuidoc-for-windows-is-available"/>
+
+  <!-- Top-level JS Documentation target for MindTouch output -->
+  <target name="doc-js-mindtouch">
+    <antcall target="doc-many-js">
+      <param name="yuidoc.template.dir" value="build-res/yuidoc-theme-mindtouch" />
+    </antcall>
+  </target>
+
+  <!-- Top-level JS Documentation target for default template output -->
+  <target name="doc-js">
+    <antcall target="doc-many-js">
+      <param name="yuidoc.template.dir" value="" />
+    </antcall>
+  </target>
+
+  <target name="doc-many-js" depends="install-antcontrib, npm-install">
+    <if>
+      <not>
+        <equals arg1="${yuidoc.json}" arg2="" />
+      </not>
+      <then>
+        <!-- YUIDoc fails creating out dirs with more than one level.
+             So, we create the standardized output base dir. -->
+        <mkdir dir="doc-js" />
+
+        <foreach param="yuidoc-one.json" list="${yuidoc.json}" target="doc-one-js" />
+
+        <zip destfile="${dist.dir}/js-doc-${project.revision}.zip" basedir="${basedir}/doc-js" />
+      </then>
+    </if>
+  </target>
+  <target name="doc-one-js">
+    <if>
+      <available file="${yuidoc-one.json}"/>
+      <then>
+          <!-- The yuidoc configuration file exists.
+               Check if yuidoc is installed. -->
+          <if>
+            <isset property="isWindows"/>
+            <then>
+              <if>
+                <not>
+                  <isset property="yuidoc-for-windows-is-available"/>
+                </not>
+                <then>
+                  <fail>Run 'npm -g install yuidocjs'</fail>
+                </then>
+              </if>
+              <if>
+                <equals arg1="${yuidoc.template.dir}" arg2="" />
+                <then>
+                  <exec executable="yuidoc.cmd" failonerror="true">
+                    <arg line='--config "${yuidoc-one.json}"' />
+                  </exec>
+                </then>
+                <else>
+                  <exec executable="yuidoc.cmd" failonerror="true">
+                    <arg line='--config "${yuidoc-one.json}" --themedir "${yuidoc.template.dir}"' />
+                  </exec>
+                </else>
+              </if>
+            </then>
+            <else>
+              <if>
+                <equals arg1="${yuidoc.template.dir}" arg2="" />
+                <then>
+                  <exec executable="node_modules/yuidocjs/lib/cli.js" failonerror="true">
+                    <arg line='--config "${yuidoc-one.json}"' />
+                  </exec>
+                </then>
+                <else>
+                  <exec executable="node_modules/yuidocjs/lib/cli.js" failonerror="true">
+                    <arg line='--config "${yuidoc-one.json}" --themedir "${yuidoc.template.dir}"' />
+                  </exec>
+                </else>
+              </if>
+            </else>
+          </if>
+      </then>
+      <else>
+        <fail>There is no YUIDoc configuration file available at ${yuidoc-one.json}.</fail>
+      </else>
+    </if>
   </target>
 
 </project>

--- a/build-res/yuidoc-theme-mindtouch/layouts/main.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/layouts/main.handlebars
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{htmlTitle}}</title>
+    <link rel="stylesheet" href="{{yuiGridsUrl}}">
+    <link rel="stylesheet" href="{{projectAssets}}/vendor/prettify/prettify-min.css">
+    <link rel="stylesheet" href="{{projectAssets}}/css/main.css" id="site_styles">
+    <script src="{{yuiSeedUrl}}"></script>
+</head>
+<body class="yui3-skin-sam">
+
+<div id="doc">
+    <div class="yui3-g">
+
+        <div id="sidebar" class="yui3-u yui3-u-1-4">
+            {{>sidebar}}
+        </div>
+
+        <div id="main" class="yui3-u yui3-u-3-4">
+            <div class="content">{{>layout_content}}</div>
+        </div>
+    </div>
+</div>
+<script src="{{projectAssets}}/vendor/prettify/prettify-min.js"></script>
+<script>prettyPrint();</script>
+<script src="{{projectAssets}}/js/yui-prettify.js"></script>
+</body>
+</html>

--- a/build-res/yuidoc-theme-mindtouch/partials/attrs.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/attrs.handlebars
@@ -1,0 +1,141 @@
+<div id="attr_{{name}}" class="attr item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+    <a name="config_{{name}}"></a> {{! For backwards compatibility }}
+    <h3 class="name"><code>{{name}}</code></h3>
+    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+
+    {{#if deprecated}}
+        <span class="flag deprecated"{{#if deprecationMessage}} title="{{deprecationMessage}}"{{/if}}>deprecated</span>
+    {{/if}}
+
+    {{#if access}}
+        <span class="flag {{access}}">{{access}}</span>
+    {{/if}}
+
+    {{#if final}}
+        <span class="flag final">final</span>
+    {{/if}}
+
+    {{#if static}}
+        <span class="flag static">static</span>
+    {{/if}}
+
+    {{#if optional}}
+        <span class="flag optional">optional</span>
+    {{/if}}
+
+    {{#if required}}
+        <span class="flag required">required</span>
+    {{/if}}
+
+    {{#if readonly}}
+        <span class="flag readonly">readonly</span>
+    {{/if}}
+
+    <div class="meta">
+        {{#if overwritten_from}}
+            <p>Inherited from
+            <a href="{{crossLinkRaw overwritten_from/class}}#attr_{{overwritten_from/name}}">
+                {{overwritten_from/class}}
+            </a>
+            {{#if foundAt}}
+            but overwritten in
+            {{/if}}
+        {{else}}
+            {{#if extended_from}}
+                <p>Inherited from
+                <a href="{{crossLinkRaw extended_from}}#attr_{{name}}">{{extended_from}}</a>:
+            {{else}}
+                {{#providedBy}}
+                    <p>Provided by the <a href="../modules/{{.}}.html">{{.}}</a> module.</p>
+                {{/providedBy}}
+                <p>
+                {{#if foundAt}}
+                Defined in
+                {{/if}}
+            {{/if}}
+        {{/if}}
+        {{#if foundAt}}
+        <a href="{{foundAt}}">{{{file}}}:{{{line}}}</a>
+        {{/if}}
+        </p>
+
+        {{#if deprecationMessage}}
+            <p>Deprecated: {{deprecationMessage}}</p>
+        {{/if}}
+
+        {{#if since}}
+            <p>Available since {{since}}</p>
+        {{/if}}
+    </div>
+
+    <div class="description">
+        {{{attrDescription}}}
+    </div>
+
+    {{#if default}}
+        <p><strong>Default:</strong> {{default}}</p>
+    {{/if}}
+
+    {{#if emit}}
+        <div class="emits box">
+            <h4>Fires event <code>{{name}}Change</code></h4>
+
+            <p>
+            Fires when the value for the configuration attribute `{{{name}}}` is
+            changed. You can listen for the event using the `on` method if you
+            wish to be notified before the attribute's value has changed, or
+            using the `after` method if you wish to be notified after the
+            attribute's value has changed.
+            </p>
+
+            <div class="params">
+                <h4>Parameters:</h4>
+
+                <ul class="params-list">
+                    <li class="param">
+                        <code class="param-name">e</code>
+                        <span class="type">{{#crossLink "EventFacade"}}{{/crossLink}}</span>
+
+                        <div class="param-description">
+                            An Event Facade object with the following
+                            attribute-specific properties added:
+                        </div>
+
+                        <ul class="params-list">
+                            <li class="param">
+                                <code class="param-name">prevVal</code>
+                                <span class="type">Any</span>
+                                <div class="param-description">The value of the attribute, prior to it being set.</div>
+                            </li>
+                            <li class="param">
+                                <code class="param-name">newVal</code>
+                                <span class="type">Any</span>
+                                <div class="param-description">The value the attribute is to be set to.</div>
+                            </li>
+                            <li class="param">
+                                <code class="param-name">attrName</code>
+                                <span class="type">{{#crossLink "String"}}{{/crossLink}}</span>
+                                <div class="param-description">The name of the attribute being set.</div>
+                            </li>
+                            <li class="param">
+                                <code class="param-name">subAttrName</code>
+                                <span class="type">{{#crossLink "String"}}{{/crossLink}}</span>
+                                <div class="param-description">If setting a property within the attribute's value, the name of the sub-attribute property being set.</div>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    {{/if}}
+
+    {{#example}}
+        <div class="example">
+            <h4>Example:</h4>
+
+            <div class="example-content">
+                {{{.}}}
+            </div>
+        </div>
+    {{/example}}
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/classes.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/classes.handlebars
@@ -1,0 +1,204 @@
+<h1>{{name}} Class</h1>
+<div class="box meta">
+    {{#if uses}}
+        <div class="uses">
+            Uses
+            <ul class="inline commas">
+                {{#uses}}
+                    <li><a href="{{.}}.html">{{.}}</a></li>
+                {{/uses}}
+            </ul>
+        </div>
+    {{/if}}
+
+    {{#if extends}}
+        <div class="extends">
+            Extends {{#crossLink extends}}{{/crossLink}}
+        </div>
+    {{/if}}
+
+    {{#if foundAt}}
+        <div class="foundat">
+            Defined in: <a href="{{foundAt}}">{{{file}}}:{{{line}}}</a>
+        </div>
+    {{/if}}
+
+    {{#if module}}
+        {{#if submodule}}
+            Module: {{#crossLinkModule submodule}}{{/crossLinkModule}}<br>
+            Parent Module: {{#crossLinkModule module}}{{/crossLinkModule}}
+        {{else}}
+            Module: {{#crossLinkModule module}}{{/crossLinkModule}}
+        {{/if}}
+    {{/if}}
+
+    {{#if since}}
+        <p>Available since {{since}}</p>
+    {{/if}}
+</div>
+
+{{#if deprecated}}
+    <div class="box deprecated">
+        <p>
+        {{#if deprecationMessage}}
+            <strong>Deprecated:</strong> {{deprecationMessage}}
+        {{else}}
+            This class is deprecated.
+        {{/if}}
+        </p>
+    </div>
+{{/if}}
+
+<div class="box intro">
+    {{{classDescription}}}
+</div>
+
+{{#is_constructor}}
+    <div class="constructor">
+        <h2>Constructor</h2>
+        {{>method}}
+    </div>
+{{/is_constructor}}
+
+<div id="classdocs" class="tabview">
+    <!--<ul class="api-class-tabs">-->
+    <ul class="api-class-tabs">
+        <li class="api-class-tab index"><a href="#index">Index</a></li>
+
+        {{#if methods}}
+            <li class="api-class-tab methods"><a href="#methods">Methods</a></li>
+        {{/if}}
+        {{#if properties}}
+            <li class="api-class-tab properties"><a href="#properties">Properties</a></li>
+        {{/if}}
+        {{#if attrs}}
+            <li class="api-class-tab attrs"><a href="#attrs">Attributes</a></li>
+        {{/if}}
+        {{#if events}}
+            <li class="api-class-tab events"><a href="#events">Events</a></li>
+        {{/if}}
+    </ul>
+
+    <div>
+        <div id="index" class="api-class-tabpanel index">
+            <h2 class="off-left">Item Index</h2>
+
+            {{#if methods}}
+                <div class="index-section methods">
+                    <h3>Methods</h3>
+
+                    <ul class="index-list methods{{#if extends}} extends{{/if}}">
+                        {{#methods}}
+                            <li class="index-item method{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if overwritten_from}} inherited{{/if}}{{#if extended_from}} inherited{{/if}}">
+                                <a href="#method_{{name}}">{{name}}</a>
+
+                                {{#if static}}
+                                    <span class="flag static">static</span>
+                                {{/if}}
+                                {{#if deprecated}}
+                                    <span class="flag deprecated">deprecated</span>
+                                {{/if}}
+                            </li>
+                        {{/methods}}
+                    </ul>
+                </div>
+            {{/if}}
+
+            {{#if properties}}
+                <div class="index-section properties">
+                    <h3>Properties</h3>
+
+                    <ul class="index-list properties{{#if extends}} extends{{/if}}">
+                        {{#properties}}
+                            <li class="index-item property{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if overwritten_from}} inherited{{/if}}{{#if extended_from}} inherited{{/if}}">
+                                <a href="#property_{{name}}">{{name}}</a>
+
+                                {{#if static}}
+                                    <span class="flag static">static</span>
+                                {{/if}}
+                                {{#if deprecated}}
+                                    <span class="flag deprecated">deprecated</span>
+                                {{/if}}
+                            </li>
+                        {{/properties}}
+                    </ul>
+                </div>
+            {{/if}}
+
+            {{#if attrs}}
+                <div class="index-section attrs">
+                    <h3>Attributes</h3>
+
+                    <ul class="index-list attrs{{#if extends}} extends{{/if}}">
+                        {{#attrs}}
+                            <li class="index-item attr{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if overwritten_from}} inherited{{/if}}{{#if extended_from}} inherited{{/if}}">
+                                <a href="#attr_{{name}}">{{name}}</a>
+                            </li>
+                        {{/attrs}}
+                    </ul>
+                </div>
+            {{/if}}
+
+            {{#if events}}
+                <div class="index-section events">
+                    <h3>Events</h3>
+
+                    <ul class="index-list events{{#if extends}} extends{{/if}}">
+                        {{#events}}
+                            <li class="index-item event{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if overwritten_from}} inherited{{/if}}{{#if extended_from}} inherited{{/if}}">
+                                <a href="#event_{{name}}">{{name}}</a>
+
+                                {{#if static}}
+                                    <span class="flag static">static</span>
+                                {{/if}}
+                                {{#if deprecated}}
+                                    <span class="flag deprecated">deprecated</span>
+                                {{/if}}
+                            </li>
+                        {{/events}}
+                    </ul>
+                </div>
+            {{/if}}
+        </div>
+
+        {{#if methods}}
+            <div id="methods" class="api-class-tabpanel">
+                <h2 class="off-left">Methods</h2>
+
+                {{#methods}}
+                    {{>method}}
+                {{/methods}}
+            </div>
+        {{/if}}
+
+        {{#if properties}}
+            <div id="properties" class="api-class-tabpanel">
+                <h2 class="off-left">Properties</h2>
+
+                {{#properties}}
+                    {{>props}}
+                {{/properties}}
+            </div>
+        {{/if}}
+
+        {{#if attrs}}
+            <div id="attrs" class="api-class-tabpanel">
+                <h2 class="off-left">Attributes</h2>
+
+                {{#attrs}}
+                    {{>attrs}}
+                {{/attrs}}
+            </div>
+        {{/if}}
+
+        {{#if events}}
+            <div id="events" class="api-class-tabpanel">
+                <h2 class="off-left">Events</h2>
+
+                {{#events}}
+                    {{>events}}
+                {{/events}}
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/events.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/events.handlebars
@@ -1,0 +1,137 @@
+<div id="event_{{name}}" class="events item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+    <h3 class="name"><code>{{name}}</code></h3>
+    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+
+    {{#if deprecated}}
+        <span class="flag deprecated"{{#if deprecationMessage}} title="{{deprecationMessage}}"{{/if}}>deprecated</span>
+    {{/if}}
+
+    {{#if access}}
+        <span class="flag {{access}}">{{access}}</span>
+    {{/if}}
+
+    {{#if final}}
+        <span class="flag final">final</span>
+    {{/if}}
+
+    {{#if static}}
+        <span class="flag static">static</span>
+    {{/if}}
+
+    <div class="meta">
+        {{#if overwritten_from}}
+            <p>Inherited from
+            <a href="{{crossLinkRaw overwritten_from/class}}#event_{{overwritten_from/name}}">
+                {{overwritten_from/class}}
+            </a>
+            {{#if foundAt}}
+            but overwritten in
+            {{/if}}
+        {{else}}
+            {{#if extended_from}}
+                <p>Inherited from
+                <a href="{{crossLinkRaw extended_from}}#event_{{name}}">{{extended_from}}</a>:
+            {{else}}
+                {{#providedBy}}
+                    <p>Provided by the <a href="../modules/{{.}}.html">{{.}}</a> module.</p>
+                {{/providedBy}}
+                <p>
+                {{#if foundAt}}
+                Defined in
+                {{/if}}
+            {{/if}}
+        {{/if}}
+        {{#if foundAt}}
+        <a href="{{foundAt}}">{{{file}}}:{{{line}}}</a>
+        {{/if}}
+        </p>
+
+        {{#if deprecationMessage}}
+            <p>Deprecated: {{deprecationMessage}}</p>
+        {{/if}}
+
+        {{#if since}}
+            <p>Available since {{since}}</p>
+        {{/if}}
+    </div>
+
+    <div class="description">
+        {{{eventDescription}}}
+    </div>
+
+    {{#if params}}
+        <div class="params">
+            <h4>Event Payload:</h4>
+
+            <ul class="params-list">
+            {{#params}}
+                <li class="param">
+                    {{#if optional}}
+                        <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                        <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                        <span class="flag optional" title="This parameter is optional.">optional</span>
+                    {{else}}
+                        <code class="param-name">{{name}}</code>
+                        <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                    {{/if}}
+
+                    {{#if multiple}}
+                        <span class="flag multiple" title="This parameter may occur one or more times.">Multiple</span>
+                    {{/if}}
+
+                    <div class="param-description">
+                        {{{description}}}
+                    </div>
+
+                    {{#if props}}
+                        <ul class="params-list">
+                            {{#props}}
+                            <li class="param">
+                                {{#if optional}}
+                                    <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                    <span class="flag optional" title="This parameter is optional.">optional</span>
+                                {{else}}
+                                    <code class="param-name">{{name}}</code>
+                                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                {{/if}}
+
+                                <div class="param-description">
+                                    {{{description}}}
+                                </div>
+
+                                {{#if props}}
+                                    <ul class="params-list">
+                                        {{#props}}
+                                        <li class="param">
+                                            <code class="param-name">{{name}}</code>
+                                            <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+
+                                            <div class="param-description">
+                                                {{{description}}}
+                                            </div>
+                                        </li>
+                                        {{/props}}
+                                    </ul>
+                                {{/if}}
+                            </li>
+                            {{/props}}
+                        </ul>
+                    {{/if}}
+                </li>
+            {{/params}}
+            </ul>
+        </div>
+    {{/if}}
+
+
+    {{#example}}
+        <div class="example">
+            <h4>Example:</h4>
+
+            <div class="example-content">
+                {{{.}}}
+            </div>
+        </div>
+    {{/example}}
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/index.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/index.handlebars
@@ -1,0 +1,7 @@
+<div class="apidocs">
+    <div id="docs-main" class="content">
+        <p>
+        Use the links to view API documentation.
+        </p>
+    </div>
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/method.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/method.handlebars
@@ -1,0 +1,184 @@
+<div id="method_{{name}}" class="method item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+	<h3>{{name}}
+    
+	    {{#if params}}
+	        <span class="paren">(</span>
+	        {{#params}}
+	            {{#if optional}}
+	                <cspan class="optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</span>
+	            {{else}}
+	                {{name}}
+	            {{/if}}
+	        {{/params}}
+			<span class="paren">)</span>
+	    {{else}}
+	        <span class="paren">()</span>
+	    {{/if}}
+	
+	    {{#if return}}
+	        <span class="returns-inline">
+	            <span class="type">{{#crossLink returnType}}{{/crossLink}}</span>
+	        </span>
+	    {{/if}}
+
+	    {{#if deprecated}}
+	        <span class="flag deprecated"{{#if deprecationMessage}} title="{{deprecationMessage}}"{{/if}}>deprecated</span>
+	    {{/if}}
+	
+	    {{#if access}}
+	        <span class="flag {{access}}">{{access}}</span>
+	    {{/if}}
+	
+	    {{#if final}}
+	        <span class="flag final">final</span>
+	    {{/if}}
+	
+	    {{#if static}}
+	        <span class="flag static">static</span>
+	    {{/if}}
+	
+	    {{#if chainable}}
+	        <span class="flag chainable">chainable</span>
+	    {{/if}}
+	
+	    {{#if async}}
+	        <span class="flag async">async</span>
+	    {{/if}}
+    </h3>
+
+    <div class="meta">
+        {{#if overwritten_from}}
+            <p>Inherited from
+            <a href="{{crossLinkRaw overwritten_from/class}}#method_{{overwritten_from/name}}">
+                {{overwritten_from/class}}
+            </a>
+            {{#if foundAt}}
+            but overwritten in
+            {{/if}}
+        {{else}}
+            {{#if extended_from}}
+                <p>Inherited from
+                <a href="{{crossLinkRaw extended_from}}#method_{{name}}">{{extended_from}}</a>:
+            {{else}}
+                {{#providedBy}}
+                    <p>Provided by the <a href="../modules/{{.}}.html">{{.}}</a> module.</p>
+                {{/providedBy}}
+                <p>
+            {{/if}}
+        {{/if}}
+        </p>
+
+
+        {{#if deprecationMessage}}
+            <p>Deprecated: {{deprecationMessage}}</p>
+        {{/if}}
+
+        {{#if since}}
+            <p>Available since {{since}}</p>
+        {{/if}}
+    </div>
+
+    <div class="description">
+        {{{methodDescription}}}
+    </div>
+
+    {{#if params}}
+        <div class="params">
+            <h4>Parameters:</h4>
+
+            <ul class="params-list">
+            {{#params}}
+                <li class="param">
+                    {{#if optional}}
+                        <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                        <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                        <span class="flag optional" title="This parameter is optional.">optional</span>
+                    {{else}}
+                        <code class="param-name">{{name}}</code>
+                        <span class="type">({{#crossLink type}}{{/crossLink}})</span>
+                    {{/if}}
+
+                    {{#if multiple}}
+                        <span class="flag multiple" title="This argument may occur one or more times.">multiple</span>
+                    {{/if}}
+
+                    <div class="param-description">
+                        {{{description}}}
+                    </div>
+
+                    {{#if props}}
+                        <ul class="params-list">
+                            {{#props}}
+                            <li class="param">
+                                {{#if optional}}
+                                    <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                    <span class="flag optional" title="This parameter is optional.">optional</span>
+                                {{else}}
+                                    <code class="param-name">{{name}}</code>
+                                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                {{/if}}
+
+                                <div class="param-description">
+                                    {{{description}}}
+                                </div>
+
+                                {{#if props}}
+                                    <ul class="params-list">
+                                        {{#props}}
+                                        <li class="param">
+                                            {{#if optional}}
+                                                <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                                <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                                <span class="flag optional" title="This parameter is optional.">optional</span>
+                                            {{else}}
+                                                <code class="param-name">{{name}}</code>
+                                                <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                            {{/if}}
+
+                                            <div class="param-description">
+                                                {{{description}}}
+                                            </div>
+                                        </li>
+                                        {{/props}}
+                                    </ul>
+                                {{/if}}
+                            </li>
+                            {{/props}}
+                        </ul>
+                    {{/if}}
+                </li>
+            {{/params}}
+            </ul>
+        </div>
+    {{/if}}
+
+    {{#return}}
+        <div class="returns">
+            <h4>Returns:</h4>
+
+            <div class="returns-description">
+                {{#if description}}
+                    {{#if type}}
+                        <span class="type">{{#crossLink type}}{{/crossLink}}</span>:
+                    {{/if}}
+                    {{{description}}}
+                {{else}}
+                    {{#if type}}
+                        <span class="type">{{#crossLink type}}{{/crossLink}}</span>:
+                    {{/if}}
+                {{/if}}
+            </div>
+        </div>
+    {{/return}}
+
+    {{#example}}
+        <div class="example">
+            <h4>Example:</h4>
+
+            <div class="example-content">
+                {{{.}}}
+            </div>
+        </div>
+    {{/example}}
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/module.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/module.handlebars
@@ -1,0 +1,92 @@
+<h1>{{name}} Module</h1>
+<div class="box clearfix meta">
+    {{#extra}}
+        {{#selleck}}
+            <a class="button link-docs" href="/yui/docs/{{name}}">User Guide &amp; Examples</a>
+        {{/selleck}}
+    {{/extra}}
+
+    {{#if requires}}
+        <div class="uses">
+            Requires
+            <ul class="inline commas">
+                {{#requires}}
+                    <li>{{#crossLinkModule .}}{{/crossLinkModule}}</li>
+                {{/requires}}
+            </ul>
+        </div>
+    {{/if}}
+
+    {{#if foundAt}}
+        <div class="foundat">
+            Defined in: <a href="{{foundAt}}">{{{file}}}:{{{line}}}</a>
+        </div>
+    {{/if}}
+
+    {{#if since}}
+        <p>Available since {{since}}</p>
+    {{/if}}
+</div>
+
+{{#if deprecated}}
+    <div class="box deprecated">
+        <p>
+        {{#if deprecationMessage}}
+            <strong>Deprecated:</strong> {{deprecationMessage}}
+        {{else}}
+            This module is deprecated.
+        {{/if}}
+        </p>
+    </div>
+{{/if}}
+
+<div class="box intro">
+    {{{moduleDescription}}}
+</div>
+
+{{#example}}
+    <div class="example">
+        <h4>Example:</h4>
+        <div class="example-content">
+            {{{.}}}
+        </div>
+    </div>
+{{/example}}
+
+<div class="yui3-g">
+    <div class="yui3-u-1-2">
+        {{#if moduleClasses}}
+            <p>This module provides the following classes:</p>
+
+            <ul class="module-classes">
+            {{#moduleClasses}}
+                <li class="module-class">
+                    <a href="{{../projectRoot}}classes/{{name}}.html">
+                        {{displayName}}
+                    </a>
+                </li>
+            {{/moduleClasses}}
+            </ul>
+        {{/if}}
+    </div>
+
+    <div class="yui3-u-1-2">
+        {{#if subModules}}
+            <p>This module is a rollup of the following modules:</p>
+
+            <ul class="module-submodules">
+            {{#subModules}}
+                <li class="module-submodule">
+                    <a href="{{../projectRoot}}modules/{{name}}.html">
+                        {{displayName}}
+                    </a>
+
+                    <div class="module-submodule-description">
+                        {{{description}}}
+                    </div>
+                </li>
+            {{/subModules}}
+            </ul>
+        {{/if}}
+    </div>
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/options.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/options.handlebars
@@ -1,0 +1,1 @@
+<!-- override default theme -->

--- a/build-res/yuidoc-theme-mindtouch/partials/props.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/props.handlebars
@@ -1,0 +1,120 @@
+<div id="property_{{name}}" class="property item{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}">
+    <h3>{{name}}
+	    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+	
+	    {{#if deprecated}}
+	        <span class="flag deprecated"{{#if deprecationMessage}} title="{{deprecationMessage}}"{{/if}}>deprecated</span>
+	    {{/if}}
+	
+	    {{#if access}}
+	        <span class="flag {{access}}">{{access}}</span>
+	    {{/if}}
+	
+	    {{#if final}}
+	        <span class="flag final">final</span>
+	    {{/if}}
+	
+	    {{#if static}}
+	        <span class="flag static">static</span>
+	    {{/if}}
+	</h3>
+
+    <div class="meta">
+        {{#if overwritten_from}}
+            <p>Inherited from
+            <a href="{{crossLinkRaw overwritten_from/class}}#property_{{overwritten_from/name}}">
+                {{overwritten_from/class}}
+            </a>
+            {{#if foundAt}}
+            but overwritten in
+            {{/if}}
+        {{else}}
+            {{#if extended_from}}
+                <p>Inherited from
+                <a href="{{crossLinkRaw extended_from}}#property_{{name}}">{{extended_from}}</a>:
+            {{else}}
+                {{#providedBy}}
+                    <p>Provided by the <a href="../modules/{{.}}.html">{{.}}</a> module.</p>
+                {{/providedBy}}
+                <p>
+                {{#if foundAt}}
+                Defined in
+                {{/if}}
+            {{/if}}
+        {{/if}}
+        {{#if foundAt}}
+        <a href="{{foundAt}}">{{{file}}}:{{{line}}}</a>
+        {{/if}}
+        </p>
+
+        {{#if deprecationMessage}}
+            <p>Deprecated: {{deprecationMessage}}</p>
+        {{/if}}
+
+        {{#if since}}
+            <p>Available since {{since}}</p>
+        {{/if}}
+    </div>
+
+    <div class="description">
+        {{{propertyDescription}}}
+    </div>
+
+    {{#if default}}
+        <p><strong>Default:</strong> {{default}}</p>
+    {{/if}}
+
+    {{#example}}
+        <div class="example">
+            <h4>Example:</h4>
+
+            <div class="example-content">
+                {{{.}}}
+            </div>
+        </div>
+    {{/example}}
+
+    {{#if subprops}}
+        <h4>Sub-properties:</h4>
+
+        <ul class="params-list">
+            {{#subprops}}
+            <li class="param">
+                {{#if optional}}
+                    <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                    <span class="flag optional" title="This property is optional.">optional</span>
+                {{else}}
+                    <code class="param-name">{{name}}</code>
+                    <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                {{/if}}
+
+                <div class="param-description">
+                    {{{description}}}
+                </div>
+
+                {{#if subprops}}
+                    <ul class="params-list">
+                        {{#subprops}}
+                        <li class="param">
+                            {{#if optional}}
+                                <code class="param-name optional">[{{name}}{{#if optdefault}}={{optdefault}}{{/if}}]</code>
+                                <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                                <span class="flag optional" title="This property is optional.">optional</span>
+                            {{else}}
+                                <code class="param-name">{{name}}</code>
+                                <span class="type">{{#crossLink type}}{{/crossLink}}</span>
+                            {{/if}}
+
+                            <div class="param-description">
+                                {{{description}}}
+                            </div>
+                        </li>
+                        {{/subprops}}
+                    </ul>
+                {{/if}}
+            </li>
+            {{/subprops}}
+        </ul>
+    {{/if}}
+</div>

--- a/build-res/yuidoc-theme-mindtouch/partials/sidebar.handlebars
+++ b/build-res/yuidoc-theme-mindtouch/partials/sidebar.handlebars
@@ -1,0 +1,13 @@
+<div id="api-list">
+    <h2 class="off-left">APIs</h2>
+    <div id="api-tabview" class="tabview">
+        <div id="api-tabview-panel">
+            <ul id="api-classes" class="apis classes">
+            {{#classes}}
+                <li><a href="{{../projectRoot}}classes/{{name}}.html">{{displayName}}</a></li>
+            {{/classes}}
+            </ul>
+        </div>
+    </div>
+</div>
+

--- a/build.properties
+++ b/build.properties
@@ -6,6 +6,8 @@ ivy.artifact.group=pentaho
 package.id=common-ui
 bin.dir=bin
 
+yuidoc.json=config/yuidoc-vizapi.json
+
 gwt-module.path=org.pentaho.gwt.widgets.themes.Themes
 js.build.optimizer=none
 

--- a/config/yuidoc-vizapi.json
+++ b/config/yuidoc-vizapi.json
@@ -1,0 +1,13 @@
+{
+    "name": "VizAPI JS Documentation",
+    "description": "Pentaho JavaScript Visualization API",
+    "version": "5.3",
+    "url": "localhost",
+    "options": {
+    	"linkNatives": "true",
+    	"attributesEmit": "true",
+      "paths":    ["package-res/resources/web/vizapi/"],
+      "exclude":  "package-res/resources/web/vizapi/ccc",
+      "outdir":   "doc-js/vizapi/"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "karma-requirejs": "~0.2.0",
     "karma-jasmine": "~0.1.3",
     "karma": "~0.10.4",
-    "requirejs": "~2.1.0"
+    "requirejs": "~2.1.0",
+    "yuidocjs": "~0.6.0"
   }
 }


### PR DESCRIPTION
* Adapted subfloor-js.xml (from the Analyzer project) to handle multiple YUIDoc configurations.
* Added the mindtouch YUIDoc template to the build-res directory
* Ant target "doc-js-mindtouch" uses the Mindtouch YUIDoc template
* Ant target "doc-js" uses the default template or whatever is specified in the config document.
* Updated package.json to use the latest YUIDoc version

@pminutillo please review.