### PR TITLE
[BACKLOG-2545] - DataTable - Tidy-up, Document, Unit-Test

### DIFF
--- a/config/require-config.js
+++ b/config/require-config.js
@@ -1,12 +1,12 @@
 // Find and inject tests using require
-var tests = Object.keys(window.__karma__.files).filter(function (file) {
+var tests = Object.keys(window.__karma__.files).filter(function(file) {
     return (/package\-res.*Spec\.js$/).test(file);
 });
 
 requireCfg['deps'] = tests;
 
 
-requireCfg['baseUrl'] = 'base/build-res/module-scripts/';
+requireCfg['baseUrl'] = '/base/build-res/module-scripts/';
 
 requireCfg['paths']['test/karma/unit/angular-directives'] = "../../package-res/resources/web/test/karma/unit/angular-directives";
 

--- a/config/yuidoc-vizapi.json
+++ b/config/yuidoc-vizapi.json
@@ -4,8 +4,9 @@
     "version": "5.3",
     "url": "localhost",
     "options": {
-    	"linkNatives": "true",
-    	"attributesEmit": "true",
+      "lint": false,
+      "linkNatives": "true",
+      "attributesEmit": "true",
       "paths":    ["package-res/resources/web/vizapi/"],
       "exclude":  "package-res/resources/web/vizapi/ccc",
       "outdir":   "doc-js/vizapi/"

--- a/package-res/resources/web/dataapi/controller.js
+++ b/package-res/resources/web/dataapi/controller.js
@@ -145,9 +145,9 @@ pentaho.pda.app.prototype.getSources = function(callback, options) {
 		} else {
 			return _sources;
 		}
-		
+
 	}
-	
+
 }
 
 pentaho.pda.app.prototype.addSource = function(source) {
@@ -161,11 +161,11 @@ pentaho.pda.app.prototype.sortData = function( results, columnIdx, direction ) {
         return;
     }
     // create a new data set
-    var sorted = { 
+    var sorted = {
         "metadata" : results.metadata,
         "resultset" : []
     };
-    
+
     // TODO support multi-level sort
     try {
         // TODO find a better way to do this without using globals
@@ -175,7 +175,7 @@ pentaho.pda.app.prototype.sortData = function( results, columnIdx, direction ) {
     } catch (e) {
         alert(e.message);
     }
-    return sorted;    
+    return sorted;
 
 }
 
@@ -190,7 +190,7 @@ pentaho.pda.app.prototype.compareRows = function( row1, row2 ) {
         return ( row1[pentaho.pda.app.prototype.sortedColumnIdx] > row2[pentaho.pda.app.prototype.sortedColumnIdx] ) ? 1 : -1;
     } else {
         return ( row1[pentaho.pda.app.prototype.sortedColumnIdx] < row2[pentaho.pda.app.prototype.sortedColumnIdx] ) ? 1 : -1;
-    } 
+    }
 }
 
 pentaho.pda.Handler = function(sandbox) {
@@ -226,7 +226,7 @@ pentaho.pda.model.prototype.getNodeText = function( node, tag ) {
         }
         return null;
 } //getNodeText
-    
+
 pentaho.pda.model.prototype.getNodeTextOfChild = function( node, tag1, tag2 ) {
         for( var idx=0; idx<node.childNodes.length; idx++ ) {
             if(node.childNodes[idx].nodeName == tag1) {
@@ -256,7 +256,7 @@ pentaho.pda.model.prototype.getCapabilityValue = function( capability ) {
 
 pentaho.pda.model.prototype.addCapability = function( capability, value ) {
         if( typeof value == 'undefined' ) {
-          value = true;  
+          value = true;
         }
         this.capabilities[capability] = value;
     }
@@ -314,13 +314,13 @@ pentaho.pda.model.prototype.getQueryElementsByFieldType = function( fieldType ) 
         fieldTypes.push( fieldType );
         return this.getColumnsByFieldTypes(fieldTypes, false);
     }
-	
+
 pentaho.pda.model.prototype.getColumnsByFieldType = function( fieldType ) {
         var fieldTypes = new Array();
         fieldTypes.push( fieldType );
         return this.getColumnsByFieldTypes(fieldTypes, true);
     }
-    
+
 pentaho.pda.model.prototype.getColumnsByFieldTypes = function( fieldTypes, allElements ) {
         var cols = this.getAllColumns();
         var columns = new Array();
@@ -335,20 +335,20 @@ pentaho.pda.model.prototype.getColumnsByFieldTypes = function( fieldTypes, allEl
             }
         }
         return columns;
-    }    
-    
+    }
+
 pentaho.pda.model.prototype.getQueryElementsByDataType = function( dataType ) {
         var dataTypes = new Array();
         dataTypes.push( dataType );
         return this.getColumnsByDataTypes(dataTypes, false);
     }
-        
+
 pentaho.pda.model.prototype.getColumnsByDataType = function( dataType ) {
         var dataTypes = new Array();
         dataTypes.push( dataType );
         return this.getColumnsByDataTypes(dataTypes, true);
     }
-    
+
 pentaho.pda.model.prototype.getColumnsByDataTypes = function( dataTypes, allElements ) {
         var cols = this.getAllColumns();
         var columns = new Array();
@@ -363,8 +363,8 @@ pentaho.pda.model.prototype.getColumnsByDataTypes = function( dataTypes, allElem
             }
         }
         return columns;
-    }    
-    
+    }
+
 pentaho.pda.model.prototype.getColumnById = function( id ) {
         var cols = this.getAllColumns();
         for( var colNo=0; colNo<cols.length; colNo++ ) {
@@ -374,11 +374,11 @@ pentaho.pda.model.prototype.getColumnById = function( id ) {
         }
         return null;
     }
-    
+
 pentaho.pda.model.prototype.sortColumnsByName = function( columns ) {
         return columns.sort( function( c1, c2 ) { return ( c1.name == c2.name ) ? 0 : ( c1.name > c2.name ) ? 1 : -1 } )
-    }    
-    
+    }
+
 pentaho.pda.model.prototype.createListOptions = function (columnList ) {
         var options = new Array();
         for( var idx=0; idx<columnList.length; idx++ ) {
@@ -387,7 +387,7 @@ pentaho.pda.model.prototype.createListOptions = function (columnList ) {
         }
         return options;
     }
-        
+
 pentaho.pda.model.prototype.populateListFromResults = function( valuesList, results, textColumnNumber, valueColumnNumber ) {
         var hasValues = false;
         if( ''+valueColumnNumber != 'undefined' ) {
@@ -406,8 +406,7 @@ pentaho.pda.model.prototype.populateListFromResults = function( valuesList, resu
                 }
                 valuesList.options[valuesList.options.length] = option;
             }
-        } 
-        else if( results.jsonTable ) { // DataTable format
+        } else if(results.getJsonTable) { // DataTable format
             for( var idx=0; idx<results.getNumberOfRows(); idx++ ) {
                 var option;
                 if( hasValues ) {
@@ -419,8 +418,8 @@ pentaho.pda.model.prototype.populateListFromResults = function( valuesList, resu
             }
         }
     }
-        
-        
+
+
 pentaho.pda.dataelement = function() {
 	this.dataType = pentaho.pda.Column.DATA_TYPES.UNKNOWN;
 this.elementType = pentaho.pda.Column.ELEMENT_TYPES.UNKNOWN;
@@ -569,7 +568,7 @@ pentaho.pda.Column.JAVA_SQL_TYPE_TO_TYPE[ pentaho.pda.Column.JAVA_SQL_TYPES.DATE
 pentaho.pda.Column.JAVA_SQL_TYPE_TO_TYPE[ pentaho.pda.Column.JAVA_SQL_TYPES.BOOLEAN ] = pentaho.pda.Column.DATA_TYPES.BOOLEAN;
 
 pentaho.pda.Column.COMPARATOR = new Object();
-pentaho.pda.Column.COMPARATOR.STRING = [ 
+pentaho.pda.Column.COMPARATOR.STRING = [
 	[pentaho.common.Messages.getString( "EXACTLY_MATCHES" ), pentaho.pda.Column.CONDITION_TYPES.EQUAL],
 	[pentaho.common.Messages.getString( "CONTAINS" ), pentaho.pda.Column.CONDITION_TYPES.CONTAINS],
 	[pentaho.common.Messages.getString( "ENDS_WITH" ), pentaho.pda.Column.CONDITION_TYPES.ENDSWITH],
@@ -591,7 +590,7 @@ pentaho.pda.Column.COMPARATOR.BOOLEAN = [
 //  ["<>", ],
   [pentaho.common.Messages.getString( "IS_NULL" ), pentaho.pda.Column.CONDITION_TYPES.IS_NULL],
   [pentaho.common.Messages.getString( "IS_NOT_NULL" ), pentaho.pda.Column.CONDITION_TYPES.NOT_NULL]];
-pentaho.pda.Column.COMPARATOR.DATE = [ 
+pentaho.pda.Column.COMPARATOR.DATE = [
 	[pentaho.common.Messages.getString( "ON" ), pentaho.pda.Column.CONDITION_TYPES.EQUAL],
 //	[pentaho.common.Messages.getString( "NOT_ON" ),
 	[pentaho.common.Messages.getString( "ON_OR_AFTER" ), pentaho.pda.Column.CONDITION_TYPES.MORE_THAN_OR_EQUAL],
@@ -605,7 +604,7 @@ pentaho.pda.Column.COMPARATOR.DATE = [
 pentaho.pda.Column.SINGLE_COMPARATORS = {};
 pentaho.pda.Column.SINGLE_COMPARATORS[pentaho.pda.Column.CONDITION_TYPES.IS_NULL] = {};
 pentaho.pda.Column.SINGLE_COMPARATORS[pentaho.pda.Column.CONDITION_TYPES.NOT_NULL] = {};
-  
+
 pentaho.pda.Column.COMPARATOR_MAP = new Object();
 pentaho.pda.Column.COMPARATOR_MAP[ pentaho.pda.Column.DATA_TYPES.NUMERIC ] = pentaho.pda.Column.COMPARATOR.NUMERIC;
 pentaho.pda.Column.COMPARATOR_MAP[ pentaho.pda.Column.DATA_TYPES.STRING ] = pentaho.pda.Column.COMPARATOR.STRING;

--- a/package-res/resources/web/test/karma/unit/vizapi/DataTableSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/DataTableSpec.js
@@ -1,0 +1,1293 @@
+define([
+  "common-ui/vizapi/DataTable"
+], function() {
+
+  var DataTable = pentaho.DataTable;
+
+  function getDatasetCDA1() {
+    return {
+      metadata: [
+        {colName: "country", colType: "STRING",  colLabel: "Country"},
+        {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+      ],
+      resultset: [
+        ["Portugal", 12000],
+        ["Ireland",   6000]
+      ]
+    };
+  }
+
+  function getDatasetDT1() {
+    return {
+      cols: [
+        {id: "country", type: "string", label: "Country"},
+        {id: "sales",   type: "number", label: "Sales"  },
+      ],
+      rows: [
+        {c: [ {v: "Portugal"}, {v: 12000}] },
+        {c: [ {v: "Ireland" }, {v:  6000}] }
+      ]
+    };
+  }
+
+  function getDatasetDT1Normalized() {
+    return {
+      cols: [
+        {id: "country", type: "string", label: "Country"},
+        {id: "sales",   type: "number", label: "Sales"  },
+      ],
+      rows: [
+        {c: [ {v: "Portugal", f: null}, {v: 12000, f: null}] },
+        {c: [ {v: "Ireland",  f: null}, {v:  6000, f: null}] }
+      ]
+    };
+  }
+
+  describe("DataTable -", function() {
+    it("should be a function", function() {
+      expect(typeof DataTable).toBe("function");
+    });
+
+    describe("#new() -", function() {
+
+      describe("with no arguments -", function() {
+
+        it("should return an instance of DataTable", function() {
+          var dataTable = new DataTable();
+          expect(dataTable instanceof DataTable).toBe(true);
+        });
+
+        it("should return a data table with 0 columns", function() {
+          var dataTable = new DataTable();
+          expect(dataTable.getNumberOfColumns()).toBe(0);
+        });
+
+        it("should return a data table with 0 rows", function() {
+          var dataTable = new DataTable();
+          expect(dataTable.getNumberOfRows()).toBe(0);
+        });
+      });
+
+      describe("with one argument, a plain JavaScript object in DataTable format -", function() {
+        var jsTable;
+
+        beforeEach(function() { jsTable = getDatasetDT1(); });
+
+        it("should return an instance of DataTable", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable instanceof DataTable).toBe(true);
+        });
+
+        it("should return a data table with 2 columns", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable.getNumberOfColumns()).toBe(2);
+        });
+
+        it("should return a data table with 2 rows", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable.getNumberOfRows()).toBe(2);
+        });
+
+        it("should return a data table whose internal _jsonTable is the specified object", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable._jsonTable).toBe(jsTable);
+        });
+      });
+
+      describe("with one argument, a plain JavaScript object in CDA format -", function() {
+        var jsTable;
+
+        beforeEach(function() { jsTable = getDatasetCDA1(); });
+
+        it("should return an instance of DataTable", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable instanceof DataTable).toBe(true);
+        });
+
+        it("should return a data table whose internal _jsonTable is not the specified object", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable._jsonTable instanceof Object).toBe(true);
+          expect(dataTable._jsonTable).not.toBe(jsTable);
+        });
+
+        it("should return a data table with 2 columns", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable.getNumberOfColumns()).toBe(2);
+        });
+
+        it("should return a data table with 2 rows", function() {
+          var dataTable = new DataTable(jsTable);
+          expect(dataTable.getNumberOfRows()).toBe(2);
+        });
+      });
+
+      // Exercizes toJSON, really.
+      describe("with one argument, another DataTable -", function() {
+        var sourceDataTable;
+
+        beforeEach(function() { sourceDataTable = new DataTable(getDatasetDT1Normalized()); });
+
+        it("should return a different instance of DataTable", function() {
+          var dataTable = new DataTable(sourceDataTable);
+          expect(dataTable instanceof DataTable).toBe(true);
+          expect(dataTable).not.toBe(sourceDataTable);
+        });
+
+        it("should return a data table whose internal _jsonTable is not that of the source data table", function() {
+          var dataTable = new DataTable(sourceDataTable);
+          expect(dataTable._jsonTable).not.toBe(sourceDataTable._jsonTable);
+        });
+
+        it("should return a data table having the same data as the source data table", function() {
+          var dataTable = new DataTable(sourceDataTable);
+          expect(dataTable._jsonTable).toEqual(sourceDataTable._jsonTable);
+        });
+      });
+    });
+
+    describe("table -", function() {
+      describe("#convertCdaToDataTable() -", function() {
+        var jsTable;
+
+        beforeEach(function() {
+          jsTable = DataTable.convertCdaToDataTable(getDatasetCDA1());
+        });
+
+        it("should return an Object", function() {
+          expect(jsTable instanceof Object).toBe(true);
+        });
+
+        it("should return a data table with the expected metadata and data", function() {
+          expect(jsTable).toEqual(getDatasetDT1Normalized());
+        });
+      });
+
+      // This is actually implemented in the abstract base class AbstractDataTable
+      describe("#toJSON() -", function() {
+        var dataTable;
+
+        beforeEach(function() {
+          dataTable = new DataTable(getDatasetDT1());
+        });
+
+        it("should return a plain JavaScript Object", function() {
+          var jsTable = dataTable.toJSON();
+          expect(jsTable instanceof Object).toBe(true);
+        });
+
+        it("should return an object with the same metadata and data", function() {
+          var jsTable = dataTable.toJSON();
+          expect(jsTable).toEqual(getDatasetDT1Normalized());
+        });
+
+        it("should return an object having distinct col, row and cell objects from those of the source data table", function() {
+          var jsTable = dataTable.toJSON();
+
+          expect(jsTable.cols[0]).not.toBe(dataTable._jsonTable.cols[0]);
+          expect(jsTable.cols[1]).not.toBe(dataTable._jsonTable.cols[1]);
+
+          expect(jsTable.rows[0]).not.toBe(dataTable._jsonTable.rows[0]);
+          expect(jsTable.rows[0].c[0]).not.toBe(dataTable._jsonTable.rows[0].c[0]);
+          expect(jsTable.rows[0].c[1]).not.toBe(dataTable._jsonTable.rows[0].c[1]);
+
+          expect(jsTable.rows[1]).not.toBe(dataTable._jsonTable.rows[1]);
+          expect(jsTable.rows[1].c[0]).not.toBe(dataTable._jsonTable.rows[1].c[0]);
+          expect(jsTable.rows[1].c[1]).not.toBe(dataTable._jsonTable.rows[1].c[1]);
+        });
+      });
+
+      describe("#getJsonTable() -", function() {
+        it("should return the internal plain JavaScript object in DataTable format", function() {
+          var dataTable = new DataTable(getDatasetDT1());
+          expect(dataTable._jsonTable).toBe(dataTable.getJsonTable());
+        });
+      });
+    });
+
+    describe("columns -", function() {
+
+      describe("#getNumberOfColumns() -", function() {
+        it("should return 0 when there are no columns", function() {
+          var dataTable = new DataTable();
+          expect(dataTable.getNumberOfColumns()).toBe(0);
+        });
+
+        it("should return 3 when there are 3 columns", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string"},
+              {id: "B", type: "number"},
+              {id: "C", type: "boolean"}
+            ],
+            rows: []
+          });
+          expect(dataTable.getNumberOfColumns()).toBe(3);
+        });
+      });
+
+      describe("#getColumnType() -", function() {
+        it("should return the column type of the given column index", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string"},
+              {id: "B", type: "number"},
+              {id: "C", type: "boolean"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnType(0)).toBe("string");
+          expect(dataTable.getColumnType(1)).toBe("number");
+          expect(dataTable.getColumnType(2)).toBe("boolean");
+        });
+
+        it("should return the column type as lower case", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "STRING"},
+              {id: "B", type: "NUMBER"},
+              {id: "C", type: "BOOLEAN"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnType(0)).toBe("string");
+          expect(dataTable.getColumnType(1)).toBe("number");
+          expect(dataTable.getColumnType(2)).toBe("boolean");
+        });
+
+        it("should return unknown column types", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "GUGU"},
+              {id: "B", type: "DADA"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnType(0)).toBe("gugu");
+          expect(dataTable.getColumnType(1)).toBe("dada");
+        });
+
+        it("should return the column type 'string' as default", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: null},
+              {id: "B", type: undefined},
+              {id: "C", type: ""},
+              {id: "D"},
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnType(0)).toBe("string");
+          expect(dataTable.getColumnType(1)).toBe("string");
+          expect(dataTable.getColumnType(2)).toBe("string");
+          expect(dataTable.getColumnType(3)).toBe("string");
+        });
+      });
+
+      describe("#getColumnId() -", function() {
+        it("should return the column id of the given column index", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A" },
+              {id: "Bc"},
+              {id: "dE"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnId(0)).toBe("A");
+          expect(dataTable.getColumnId(1)).toBe("Bc");
+          expect(dataTable.getColumnId(2)).toBe("dE");
+        });
+      });
+
+      describe("#getColumnLabel() -", function() {
+        it("should return the column label of the given column index", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {label: "ABC"},
+              {label: "DEF"},
+              {label: "GHI"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnLabel(0)).toBe("ABC");
+          expect(dataTable.getColumnLabel(1)).toBe("DEF");
+          expect(dataTable.getColumnLabel(2)).toBe("GHI");
+        });
+      });
+
+      describe("#getColumnProperty() -", function() {
+        it("should return the value of the specified column property", function() {
+          var foo = {},
+              bar = {},
+              dataTable = new DataTable({
+            cols: [
+              {foo: foo},
+              {bar: bar}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnProperty(0, "foo")).toBe(foo);
+          expect(dataTable.getColumnProperty(1, "bar")).toBe(bar);
+        });
+
+        it("should return `undefined` for a column property which is not defined", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {}
+            ]
+          });
+
+          expect(dataTable.getColumnProperty(0, "foo")).toBeUndefined();
+        });
+      });
+
+      describe("#setColumnProperty() -", function() {
+        it("should set the value of the specified column property", function() {
+          var foo = {},
+              bar = {},
+              dataTable = new DataTable({
+            cols: [
+              {},
+              {}
+            ],
+            rows: []
+          });
+
+          dataTable.setColumnProperty(0, "foo", foo);
+          dataTable.setColumnProperty(1, "bar", bar);
+
+          expect(dataTable.getColumnProperty(0, "foo")).toBe(foo);
+          expect(dataTable.getColumnProperty(1, "bar")).toBe(bar);
+        });
+      });
+
+      describe("#getColumnRange() -", function() {
+        it("should return a range object with both min and max `undefined` when there is no data", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+            ],
+            resultset: []
+          });
+
+          expect(dataTable.getColumnRange(1)).toEqual({min: undefined, max: undefined});
+        });
+
+        it("should return a range object with both min and max `undefined` " +
+           "when all data of the specified column is `null`, `undefined` or `NaN`", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+            ],
+            resultset: [
+              ["Portugal", null],
+              ["Ireland",  undefined],
+              ["France",   NaN]
+            ]
+          });
+
+          expect(dataTable.getColumnRange(1)).toEqual({min: undefined, max: undefined});
+        });
+
+        it("should return a range object with an equal defined value " +
+           "when only one row of the specified column is not `null`, `undefined` or `NaN`", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+            ],
+            resultset: [
+              ["Portugal", null],
+              ["Ireland",  undefined],
+              ["Italy",    100],
+              ["France",   NaN]
+            ]
+          });
+
+          expect(dataTable.getColumnRange(1)).toEqual({min: 100, max: 100});
+        });
+
+        it("should return a range object with the min and max values of the specified column", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  },
+              {colName: "qty",     colType: "NUMERIC", colLabel: "Qty"    }
+            ],
+            resultset: [
+              ["Portugal", 100,  -1],
+              ["Ireland",  200,   6],
+              ["Italy",    100,   3],
+              ["France",   1000, -3]
+            ]
+          });
+
+          expect(dataTable.getColumnRange(0)).toEqual({min: "France", max: "Portugal"});
+          expect(dataTable.getColumnRange(1)).toEqual({min: 100, max: 1000});
+          expect(dataTable.getColumnRange(2)).toEqual({min: -3, max: 6});
+        });
+      });
+
+      describe("#getDistinctValues() -", function() {
+
+        it("should return an empty array when there is no data", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+            ],
+            resultset: []
+          });
+
+          expect(dataTable.getDistinctValues(1)).toEqual([]);
+        });
+
+        it("should return an array containing all values present in the specified column", function() {
+
+          var values = [12000, 6000, 24000],
+              dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Italy",    12000]
+                ]
+              });
+
+          var valuesMap = {};
+          dataTable
+            .getDistinctValues(1)
+            .forEach(function(v) { valuesMap[v] = 1; });
+
+          values.forEach(function(v) {
+              expect(valuesMap[v]).toBe(1);
+          });
+        });
+
+        it("should return an array containing only values present in the specified column", function() {
+
+          var values = [12000, 6000, 24000],
+              dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Italy",    12000]
+                ]
+              });
+
+          dataTable
+            .getDistinctValues(1)
+            .forEach(function(v) {
+              expect(values.indexOf(v) >= 0).toBe(true);
+            });
+        });
+
+        it("should return an array containing only the distinct values present in the specified column", function() {
+
+          var values = [12000, 6000, 24000],
+              dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Italy",    12000]
+                ]
+              }),
+              valuesMap = {};
+
+          dataTable
+            .getDistinctValues(1)
+            .forEach(function(v) {
+              if(values.indexOf(v) >= 0) {
+                expect(valuesMap[v]).not.toBe(1);
+                valuesMap[v] = 1;
+              }
+            });
+        });
+
+        it("should return an array containing values in the order of occurrence in the specified column", function() {
+          var values = [12000, 6000, 24000],
+              dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Italy",    12000]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(1);
+
+          for(var i = 0; i < distinctValues.length - 1; i++) {
+            expect(values.indexOf(distinctValues[i    ])
+                   <=
+                   values.indexOf(distinctValues[i + 1]))
+              .toBe(true);
+          }
+        });
+
+        it("should return an array containing a single `null` value when the specified column contains `null` or `undefined` values", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   undefined],
+                  ["France",    null],
+                  ["Italy",     2000],
+                  ["Greece",    null]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(1);
+
+          expect(distinctValues.filter(function(v) { return v === null; }).length).toBe(1);
+        });
+
+        it("should return an array containing a single `NaN` value when the specified column contains `NaN` values", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",     NaN],
+                  ["Italy",      NaN]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(1);
+
+          expect(distinctValues.filter(function(v) { return isNaN(v); }).length).toBe(1);
+        });
+
+        it("should support string columns", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Portugal", 12000]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(0);
+
+          expect(distinctValues).toEqual(["Portugal", "Ireland", "France"]);
+        });
+
+        it("should support boolean columns", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "string",  colLabel: "Country"},
+                  {colName: "euro",    colType: "boolean", colLabel: "Euro"   }
+                ],
+                resultset: [
+                  ["Portugal", true],
+                  ["Ireland",  true],
+                  ["France",   true],
+                  ["UK",       false]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(1);
+
+          expect(distinctValues).toEqual([true, false]);
+        });
+
+        it("should return an array containing distinct `null` and `\"null\"` values, when the specified column contains both", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  [null,        6000],
+                  ["null",       500],
+                  ["Italy",    12000]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctValues(0);
+
+          expect(distinctValues).toEqual(["Portugal", null, "null", "Italy"]);
+        });
+      });
+
+      describe("#getDistinctFormattedValues() -", function() {
+
+        it("should return an empty array when there is no data", function() {
+
+          var dataTable = new DataTable({
+            metadata: [
+              {colName: "country", colType: "STRING",  colLabel: "Country"},
+              {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+            ],
+            resultset: []
+          });
+
+          expect(dataTable.getDistinctFormattedValues(1)).toEqual([]);
+        });
+
+        it("should return an array containing all formatted values present in the specified column", function() {
+
+          var values = ["1.2", "0.6", "2.4"],
+              dataTable = new DataTable({
+                cols: [
+                  {id: "country", type: "STRING", label: "Country"},
+                  {id: "sales",   type: "NUMBER", label: "Sales"  }
+                ],
+                rows: [
+                  {c: ["Portugal", {v: 12000, f: "1.2"}]},
+                  {c: ["Ireland",  {v:  6000, f: "0.6"}]},
+                  {c: ["France",   {v: 24000, f: "2.4"}]},
+                  {c: ["Italy",    {v: 11000, f: "1.2"}]}
+                ]
+              });
+
+          var valuesMap = {};
+          dataTable
+            .getDistinctFormattedValues(1)
+            .forEach(function(v) { valuesMap[v] = 1; });
+
+          values.forEach(function(v) {
+              expect(valuesMap[v]).toBe(1);
+          });
+        });
+
+        it("should return an array containing only formatted values present in the specified column", function() {
+
+          var values = ["1.2", "0.6", "2.4"],
+              dataTable = new DataTable({
+                cols: [
+                  {id: "country", type: "STRING", label: "Country"},
+                  {id: "sales",   type: "NUMBER", label: "Sales"  }
+                ],
+                rows: [
+                  {c: ["Portugal", {v: 12000, f: "1.2"}]},
+                  {c: ["Ireland",  {v:  6000, f: "0.6"}]},
+                  {c: ["France",   {v: 24000, f: "2.4"}]},
+                  {c: ["Italy",    {v: 11000, f: "1.2"}]}
+                ]
+              });
+
+          dataTable
+            .getDistinctFormattedValues(1)
+            .forEach(function(v) {
+              expect(values.indexOf(v) >= 0).toBe(true);
+            });
+        });
+
+        it("should return an array containing only the distinct formatted values present in the specified column", function() {
+
+          var values = ["1.2", "0.6", "2.4"],
+              dataTable = new DataTable({
+                cols: [
+                  {id: "country", type: "STRING", label: "Country"},
+                  {id: "sales",   type: "NUMBER", label: "Sales"  }
+                ],
+                rows: [
+                  {c: ["Portugal", {v: 12000, f: "1.2"}]},
+                  {c: ["Ireland",  {v:  6000, f: "0.6"}]},
+                  {c: ["France",   {v: 24000, f: "2.4"}]},
+                  {c: ["Italy",    {v: 11000, f: "1.2"}]}
+                ]
+              }),
+              valuesMap = {};
+
+          dataTable
+            .getDistinctFormattedValues(1)
+            .forEach(function(v) {
+              if(values.indexOf(v) >= 0) {
+                expect(valuesMap[v]).not.toBe(1);
+                valuesMap[v] = 1;
+              }
+            });
+        });
+
+        it("should return an array containing formatted values in the order of occurrence in the specified column", function() {
+          var values = ["1.2", "0.6", "2.4"],
+              dataTable = new DataTable({
+                cols: [
+                  {id: "country", type: "STRING", label: "Country"},
+                  {id: "sales",   type: "NUMBER", label: "Sales"  }
+                ],
+                rows: [
+                  {c: ["Portugal", {v: 12000, f: "1.2"}]},
+                  {c: ["Ireland",  {v:  6000, f: "0.6"}]},
+                  {c: ["France",   {v: 24000, f: "2.4"}]},
+                  {c: ["Italy",    {v: 11000, f: "1.2"}]}
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(1);
+
+          for(var i = 0; i < distinctValues.length - 1; i++) {
+            expect(values.indexOf(distinctValues[i    ])
+                   <=
+                   values.indexOf(distinctValues[i + 1]))
+              .toBe(true);
+          }
+        });
+
+        it("should return an array containing a single `null` value when the specified column contains `null` or `undefined` values", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   undefined],
+                  ["France",    null],
+                  ["Italy",     2000],
+                  ["Greece",    null]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(1);
+
+          expect(distinctValues.filter(function(v) { return v === null; }).length).toBe(1);
+        });
+
+        it("should return an array containing a single `NaN` value when the specified column contains `NaN` values", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",     NaN],
+                  ["Italy",      NaN]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(1);
+
+          expect(distinctValues.filter(function(v) { return isNaN(v); }).length).toBe(1);
+        });
+
+        it("should support string columns", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  ["Ireland",   6000],
+                  ["France",   24000],
+                  ["Portugal", 12000]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(0);
+
+          expect(distinctValues).toEqual(["Portugal", "Ireland", "France"]);
+        });
+
+        it("should support boolean columns", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "string",  colLabel: "Country"},
+                  {colName: "euro",    colType: "boolean", colLabel: "Euro"   }
+                ],
+                resultset: [
+                  ["Portugal", true],
+                  ["Ireland",  true],
+                  ["France",   true],
+                  ["UK",       false]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(1);
+
+          expect(distinctValues).toEqual(["true", "false"]);
+        });
+
+        it("should return an array containing distinct `null` and `\"null\"` values, when the specified column contains both", function() {
+          var dataTable = new DataTable({
+                metadata: [
+                  {colName: "country", colType: "STRING",  colLabel: "Country"},
+                  {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+                ],
+                resultset: [
+                  ["Portugal", 12000],
+                  [null,        6000],
+                  ["null",       500],
+                  ["Italy",    12000]
+                ]
+              }),
+              distinctValues = dataTable.getDistinctFormattedValues(0);
+
+          expect(distinctValues).toEqual(["Portugal", null, "null", "Italy"]);
+        });
+      });
+
+      describe("#addColumn()", function() {
+        it("should add another column to the table", function() {
+          var dataTable = new DataTable();
+          dataTable.addColumn({id: "A", type: "string", label: "A"});
+          expect(dataTable.getNumberOfColumns()).toBe(1);
+
+          dataTable.addColumn({id: "B", type: "string", label: "B"});
+          expect(dataTable.getNumberOfColumns()).toBe(2);
+        });
+
+        it("should add another column to the table as the last column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string"},
+              {id: "B", type: "number"},
+              {id: "C", type: "boolean"}
+            ],
+            rows: []
+          });
+
+          dataTable.addColumn({id: "D", type: "number", label: "D"});
+
+          expect(dataTable.getColumnId(3)).toBe("D");
+        });
+
+        it("should return the index of the added column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string"},
+              {id: "B", type: "number"},
+              {id: "C", type: "boolean"}
+            ],
+            rows: []
+          });
+
+          var index = dataTable.addColumn({id: "D", type: "number", label: "D"});
+
+          expect(index).toBe(3);
+        });
+
+        it("should respect all the specified known column attributes", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string" },
+              {id: "B", type: "number" },
+              {id: "C", type: "boolean"}
+            ],
+            rows: []
+          });
+
+          var index = dataTable.addColumn({id: "D", type: "number", label: "d"});
+          expect(dataTable.getColumnId(index)).toBe("D");
+          expect(dataTable.getColumnType(index)).toBe("number");
+          expect(dataTable.getColumnLabel(index)).toBe("d");
+        });
+      });
+    });
+
+    describe("cells -", function() {
+      describe("#getValue()", function() {
+        var dataTable = new DataTable({
+          cols: [
+            {id: "country", type: "string",  label: "Country"},
+            {id: "sales",   type: "number",  label: "Sales"  },
+            {id: "euro",    type: "boolean", label: "Euro"  }
+          ],
+          rows: [
+            {c: ["Ireland",  1]}, // 0
+            {c: ["Ireland",  2]}, // 1
+
+            {c: ["Portugal", null]}, // 2
+            {c: ["Portugal", undefined]}, // 3
+            {c: ["Portugal", NaN ]}, // 4
+
+            {c: ["Portugal", null, true ]}, // 5
+            {c: ["Portugal", null, false]}, // 6
+
+            {c: ["Ireland",  {v:  null, f: "NULL"}]}, // 7
+            {c: ["Ireland",  {v:  undefined, f: "UNDEF"}]}, // 8
+            {c: ["Ireland",  {v:  NaN, f: "NAN"}]}, // 9
+
+            {c: ["France",   {v: {foo: 'bar'}, f:  "foo-bar"}]} // 10
+          ]
+        });
+
+        it("should return the numeric value of the specified row and column", function() {
+          expect(dataTable.getValue(0, 1)).toBe(1);
+          expect(dataTable.getValue(1, 1)).toBe(2);
+        });
+
+        it("should return the string value of the specified row and column", function() {
+          expect(dataTable.getValue(0, 0)).toBe("Ireland");
+          expect(dataTable.getValue(2, 0)).toBe("Portugal");
+        });
+
+        it("should return the boolean value of the specified row and column", function() {
+          expect(dataTable.getValue(5, 2)).toBe(true );
+          expect(dataTable.getValue(6, 2)).toBe(false);
+        });
+
+        it("should return `null` if the value of the specified row and column is nully", function() {
+          expect(dataTable.getValue(2, 1)).toBe(null);
+          expect(dataTable.getValue(3, 1)).toBe(null);
+        });
+
+        it("should return `NaN` if the value of the specified row and column is `NaN`", function() {
+          expect(dataTable.getValue(4, 1)).toBeNaN();
+        });
+
+        it("should return a `null` value in the 'v' property of the specified row and column is nully", function() {
+          expect(dataTable.getValue(7, 1)).toBeNull();
+          expect(dataTable.getValue(8, 1)).toBeNull();
+        });
+
+        it("should return a `NaN` value in the 'v' property of the specified row and column is `NaN`", function() {
+          expect(dataTable.getValue(9, 1)).toBeNaN();
+        });
+
+        it("should return an object value in 'v' property of the specified row and columns pass-through ", function() {
+          var v = dataTable.getValue(10, 1);
+          expect(v instanceof Object).toBe(true);
+          expect(v.foo).toBe("bar");
+        });
+      });
+
+      describe("#getFormattedValue()", function() {
+        var dataTable = new DataTable({
+          cols: [
+            {id: "country", type: "string",  label: "Country"},
+            {id: "sales",   type: "number",  label: "Sales"  },
+            {id: "euro",    type: "boolean", label: "Euro"   }
+          ],
+          rows: [
+            {c: ["Ireland",  {v: 1, f: "1.0"}]},
+            {c: ["Ireland",  {v: 2, f: null}]},
+            {c: ["Ireland",  {v: 3, f: undefined}]},
+            {c: ["Ireland",  {v: 4}]}, // 3
+
+            {c: ["Ireland",  5]}, // 4
+
+            {c: ["Portugal", null]},      // 5
+            {c: ["Portugal", undefined]}, // 6
+            {c: ["Portugal", NaN ]},      // 7
+
+            {c: ["Portugal", null, true ]}, // 8
+            {c: ["Portugal", null, false]}, // 9
+            {c: [{v: "PT", f: "Portugal"}, null]}  // 10
+          ]
+        });
+
+        it("should return the value of the 'f' cell property", function() {
+          expect(dataTable.getFormattedValue(0, 1)).toBe("1.0");
+        });
+
+        it("should return the string value of the 'v' cell property if the 'f' property is nully or missing", function() {
+          expect(dataTable.getFormattedValue(1, 1)).toBe("2");
+          expect(dataTable.getFormattedValue(2, 1)).toBe("3");
+          expect(dataTable.getFormattedValue(3, 1)).toBe("4");
+        });
+
+        it("should return the string value of a direct value (no cell object)", function() {
+          expect(dataTable.getFormattedValue(4, 1)).toBe("5");
+          expect(dataTable.getFormattedValue(4, 0)).toBe("Ireland");
+          expect(dataTable.getFormattedValue(10, 0)).toBe("Portugal");
+          expect(dataTable.getFormattedValue(7, 1)).toBe("NaN");
+          expect(dataTable.getFormattedValue(8, 2)).toBe("true");
+          expect(dataTable.getFormattedValue(9, 2)).toBe("false");
+        });
+
+        it("should return the `null` value if a direct value is nully", function() {
+          expect(dataTable.getFormattedValue(5, 1)).toBe(null);
+          expect(dataTable.getFormattedValue(6, 1)).toBe(null);
+        });
+      });
+
+      describe("#getLabel()", function() {
+        var dataTable = new DataTable({
+          cols: [
+            {id: "country", type: "string",  label: "Country"},
+            {id: "sales",   type: "number",  label: "Sales"  },
+            {id: "euro",    type: "boolean", label: "Euro"   }
+          ],
+          rows: [
+            {c: ["Ireland",  {v: 1, f: "1.0"}]},
+            {c: ["Ireland",  {v: 2, f: null}]},
+            {c: ["Ireland",  {v: 3, f: undefined}]},
+            {c: ["Ireland",  {v: 4}]}, // 3
+
+            {c: ["Ireland",  5]}, // 4
+
+            {c: ["Portugal", null]},      // 5
+            {c: ["Portugal", undefined]}, // 6
+            {c: ["Portugal", NaN ]},      // 7
+
+            {c: ["Portugal", null, true ]}, // 8
+            {c: ["Portugal", null, false]}, // 9
+            {c: [{v: "PT", f: "Portugal"}, null]}  // 10
+          ]
+        });
+
+        it("should return the value of the 'f' cell property", function() {
+          expect(dataTable.getLabel(0,  1)).toBe("1.0");
+          expect(dataTable.getLabel(10, 0)).toBe("Portugal");
+        });
+
+        it("should return `null` if the 'f' property is nully or missing", function() {
+          expect(dataTable.getLabel(1, 1)).toBe(null);
+          expect(dataTable.getLabel(2, 1)).toBe(null);
+          expect(dataTable.getLabel(3, 1)).toBe(null);
+        });
+
+        it("should return `null` for a direct value (no cell object)", function() {
+          expect(dataTable.getLabel(4, 1)).toBe(null);
+          expect(dataTable.getLabel(4, 0)).toBe(null);
+          expect(dataTable.getLabel(7, 1)).toBe(null);
+          expect(dataTable.getLabel(8, 2)).toBe(null);
+          expect(dataTable.getLabel(9, 2)).toBe(null);
+        });
+
+        it("should return the `null` value if a direct value is nully", function() {
+          expect(dataTable.getLabel(5, 1)).toBe(null);
+          expect(dataTable.getLabel(6, 1)).toBe(null);
+        });
+      });
+
+      describe("#getCell()", function() {
+        var dataTable = new DataTable({
+          cols: [
+            {id: "country", type: "string",  label: "Country"},
+            {id: "sales",   type: "number",  label: "Sales"  },
+            {id: "euro",    type: "boolean", label: "Euro"   }
+          ],
+          rows: [
+            {c: ["Ireland",  {v: 1, f: "1.0"}]},
+
+            {c: ["Ireland",  {v: null, f: null }]}, // 1
+            {c: ["Ireland",  {v: null, f: undefined}]},
+            {c: ["Ireland",  {v: undefined, f: null}]},
+            {c: ["Ireland",  {v: undefined, f: undefined}]},
+
+            {c: ["Ireland",  {v: null,      f: "1"}]}, // 5
+            {c: ["Ireland",  {v: undefined, f: "1"}]},
+            {c: ["Ireland",  {v: 1,         f: null}]},
+            {c: ["Ireland",  {v: 1,         f: undefined}]},
+
+            {c: ["Ireland",  5]}, // 9
+
+            {c: ["Portugal", null]},        // 10
+            {c: ["Portugal", undefined]},   // 11
+
+            {c: ["Portugal", NaN]},         // 12
+            {c: ["Portugal", null, true]},  // 13
+            {c: ["Portugal", null, false]}, // 14
+            {c: ["Portugal", 0]},           // 15
+
+            {c: ["Ireland",  {v: 1, f: 1}]} // 16
+          ]
+        });
+
+        it("should return a shallow copy of the internal cell object", function() {
+          var cell0 = dataTable._jsonTable.rows[0].c[1];
+          var cell1 = dataTable.getCell(0, 1);
+          expect(cell0).not.toBe(cell1);
+          expect(cell1.v).toBe(cell0.v);
+          expect(cell1.f).toBe(cell0.f);
+        });
+
+        it("should return a cell 'f' property that is the string value of the source 'f' property", function() {
+          expect(dataTable.getCell(16, 1).f).toBe("1");
+        });
+
+        it("should return `null` when both 'v' or 'f' have a nully value", function() {
+          expect(dataTable.getCell(1, 1)).toBe(null);
+          expect(dataTable.getCell(2, 1)).toBe(null);
+          expect(dataTable.getCell(3, 1)).toBe(null);
+          expect(dataTable.getCell(4, 1)).toBe(null);
+        });
+
+        it("should return a cell object when either 'v' or 'f' do not have a nully value", function() {
+          expect(dataTable.getCell(5, 1) instanceof Object).toBe(true);
+          expect(dataTable.getCell(6, 1) instanceof Object).toBe(true);
+          expect(dataTable.getCell(7, 1) instanceof Object).toBe(true);
+          expect(dataTable.getCell(8, 1) instanceof Object).toBe(true);
+        });
+
+        it("should create and return a cell object for direct values, with a `null` 'f' property", function() {
+          function expectCell(i, j) {
+            var cell = dataTable.getCell(i, j);
+            expect(cell instanceof Object).toBe(true);
+            expect(cell.f).toBe(null);
+            return expect(cell.v);
+          }
+
+
+          expectCell(9,  1).toBe(5);
+          expectCell(12, 1).toBeNaN();
+          expectCell(13, 2).toBe(true);
+          expectCell(14, 2).toBe(false);
+          expectCell(15, 1).toBe(0);
+        });
+
+        it("should return `null` for direct nully values", function() {
+          expect(dataTable.getCell(10, 1)).toBe(null);
+          expect(dataTable.getCell(11, 1)).toBe(null);
+        });
+      });
+    });
+
+    describe("rows -", function() {
+      describe("#getNumberOfRows() -", function() {
+        it("should return 0 when there are no rows", function() {
+          var dataTable = new DataTable();
+          expect(dataTable.getNumberOfRows()).toBe(0);
+        });
+
+        it("should return 3 when there are 3 rows", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "A", type: "string"}
+            ],
+            rows: [
+              {c: ["1"]},
+              {c: ["2"]},
+              {c: ["3"]}
+            ]
+          });
+          expect(dataTable.getNumberOfRows()).toBe(3);
+        });
+      });
+
+      describe("#getFilteredRows() -", function() {
+        it("should return an empty array when there are 0 rows", function() {
+          expect(new DataTable().getFilteredRows([])).toEqual([]);
+        });
+
+        it("should return all rows indexes of there are 0 filters", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "country", type: "string",  label: "Country"},
+              {id: "sales",   type: "number",  label: "Sales"  }
+            ],
+            rows: [
+              {c: ["Ireland",  1]},
+              {c: ["Portugal", 2]},
+              {c: ["Italy",    3]}
+            ]
+          });
+
+          expect(dataTable.getFilteredRows([])).toEqual([0, 1, 2]);
+        });
+
+        it("should filter rows having a given value on the given column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "country", type: "string",  label: "Country"},
+              {id: "sales",   type: "number",  label: "Sales"  }
+            ],
+            rows: [
+              {c: ["Ireland",  1]},
+              {c: ["Portugal", {v: null, f: 2}]},
+              {c: ["Ireland",  {v: 2}]},
+              {c: ["Portugal", 2]},
+              {c: [2,          NaN]}
+            ]
+          });
+
+          expect(dataTable.getFilteredRows([{column: 0, value: "Portugal"}])).toEqual([1, 3]);
+
+          expect(dataTable.getFilteredRows([{column: 1, value: 2}])).toEqual([2, 3]);
+        });
+
+        it("should filter rows having a value on a column _and_ another value on another column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "country", type: "string",  label: "Country"},
+              {id: "sales",   type: "number",  label: "Sales"  }
+            ],
+            rows: [
+              {c: ["Portugal",  1]},
+              {c: ["Portugal", {v: null, f: 2}]},
+              {c: ["Ireland",  {v: 2}]},
+              {c: ["Portugal", 2]},
+              {c: [2,          NaN]}
+            ]
+          });
+
+          expect(dataTable.getFilteredRows([
+            {column: 0, value: "Portugal"},
+            {column: 1, value: 2}
+          ])).toEqual([3]);
+        });
+
+        it("should filter rows having a `null` (or `undefined`) value on a column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "country", type: "string",  label: "Country"},
+              {id: "sales",   type: "number",  label: "Sales"  }
+            ],
+            rows: [
+              {c: ["Portugal", null]},
+              {c: ["Portugal", {v: null}]},
+              {c: ["Ireland",  {v: 2}]},
+              {c: ["Portugal", undefined]},
+              {c: [2,          {v: undefined}]}
+            ]
+          });
+
+          expect(dataTable.getFilteredRows([
+            {column: 1, value: null}
+          ])).toEqual([0, 1, 3, 4]);
+        });
+
+        it("should filter rows having an `NaN` value on a column", function() {
+          var dataTable = new DataTable({
+            cols: [
+              {id: "country", type: "string",  label: "Country"},
+              {id: "sales",   type: "number",  label: "Sales"  }
+            ],
+            rows: [
+              {c: ["Portugal", 1]},
+              {c: ["Portugal", 2]},
+              {c: ["Ireland",  {v: 2}]},
+              {c: ["Portugal", null]},
+              {c: [2,          NaN]}
+            ]
+          });
+
+          expect(dataTable.getFilteredRows([
+            {column: 1, value: NaN}
+          ])).toEqual([4]);
+        });
+
+      });
+    });
+  });
+});

--- a/package-res/resources/web/test/karma/unit/vizapi/DataTableSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/DataTableSpec.js
@@ -1,3 +1,19 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 define([
   "common-ui/vizapi/DataTable"
 ], function() {
@@ -275,7 +291,7 @@ define([
               {id: "A", type: null},
               {id: "B", type: undefined},
               {id: "C", type: ""},
-              {id: "D"},
+              {id: "D"}
             ],
             rows: []
           });

--- a/package-res/resources/web/test/karma/unit/vizapi/DataViewSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/DataViewSpec.js
@@ -1,3 +1,19 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 define([
   "common-ui/vizapi/DataTable"
 ], function() {
@@ -18,7 +34,7 @@ define([
         {c: [ {v: "Portugal"}, {v: 12000, f: "1.2"},  true] },
         {c: [ {v: "Ireland" }, {v:  6000, f: "0.6"}, false] },
         {c: [ {v: "Italy"   }, {v: 10000, f: "1.0"},  true] },
-        {c: [ {v: "France"  }, {v: 24000, f: "2.4"},  true] },
+        {c: [ {v: "France"  }, {v: 24000, f: "2.4"},  true] }
       ]
     };
   }

--- a/package-res/resources/web/test/karma/unit/vizapi/DataViewSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/DataViewSpec.js
@@ -1,0 +1,515 @@
+define([
+  "common-ui/vizapi/DataTable"
+], function() {
+
+  var DataTable = pentaho.DataTable,
+      DataView  = pentaho.DataView,
+      fooValue = {},
+      barValue = {};
+
+  function getDatasetDT1() {
+    return {
+      cols: [
+        {id: "country", type: "string",  label: "Country", foo: fooValue},
+        {id: "sales",   type: "number",  label: "Sales",   bar: barValue},
+        {id: "euro",    type: "boolean", label: "Euro"   }
+      ],
+      rows: [
+        {c: [ {v: "Portugal"}, {v: 12000, f: "1.2"},  true] },
+        {c: [ {v: "Ireland" }, {v:  6000, f: "0.6"}, false] },
+        {c: [ {v: "Italy"   }, {v: 10000, f: "1.0"},  true] },
+        {c: [ {v: "France"  }, {v: 24000, f: "2.4"},  true] },
+      ]
+    };
+  }
+
+  describe("DataView -", function() {
+
+    var dataTable;
+    beforeEach(function() { dataTable = new DataTable(getDatasetDT1()); });
+
+    it("should be a function", function() {
+      expect(typeof DataView).toBe("function");
+    });
+
+    describe("#new() -", function() {
+
+      describe("with no arguments -", function() {
+
+        it("should throw", function() {
+          expect(function() {
+            new DataView();
+          }).toThrow();
+        });
+
+      });
+
+      describe("with one argument, a plain JavaScript object in DataTable format -", function() {
+
+        it("should return an instance of DataView", function() {
+          var dataView = new DataView(dataTable);
+          expect(dataView instanceof DataView).toBe(true);
+        });
+
+        it("should return a data view with all source columns", function() {
+          var dataView = new DataView(dataTable);
+          expect(dataView.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+        });
+
+        it("should return a data view with all source rows", function() {
+          var dataView = new DataView(dataTable);
+          expect(dataView.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+        });
+
+        it("should return a data view whose source is the specified data table", function() {
+          var dataView = new DataView(dataTable);
+          expect(dataView._source).toBe(dataTable);
+        });
+      });
+    });
+
+    describe("table -", function() {
+      describe("#getSourceTable() -", function() {
+        it("should return the view's source table", function() {
+          var dataView = new DataView(dataTable);
+          expect(dataView.getSourceTable()).toBe(dataTable);
+        });
+      });
+
+      describe("#toDataTable() -", function() {
+        it("should return a DataTable", function() {
+          var dataView = new DataView(dataTable);
+
+          expect(dataView.toDataTable() instanceof DataTable).toBe(true);
+        });
+
+        it("should not return the source data table", function() {
+          var dataView = new DataView(dataTable);
+
+          expect(dataView.toDataTable()).not.toBe(dataTable);
+        });
+
+        it("should return a data table having the same data", function() {
+          var dataView = new DataView(dataTable);
+          var dataTable2 = dataView.toDataTable();
+
+          expect(dataTable2.toJSON()).toEqual(dataTable.toJSON());
+        });
+
+        it("should return a data table having only the view's visible columns", function() {
+          var dataView = new DataView(dataTable);
+          dataView.setColumns([0, 1]);
+
+          var dataTable2 = dataView.toDataTable();
+
+          expect(dataTable2.getNumberOfColumns()).toBe(2);
+          expect(dataTable2.getColumnId(0)).toBe('country');
+          expect(dataTable2.getColumnId(1)).toBe('sales');
+
+          expect(dataTable2.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+        });
+
+        it("should return a data table having only the view's visible rows", function() {
+          var dataView = new DataView(dataTable);
+          dataView.setRows([0, 1]);
+
+          var dataTable2 = dataView.toDataTable();
+
+          expect(dataTable2.getNumberOfRows()).toBe(2);
+          expect(dataTable2.getValue(0, 0)).toBe("Portugal");
+          expect(dataTable2.getValue(1, 0)).toBe("Ireland");
+
+          expect(dataTable2.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+        });
+      });
+    });
+
+    describe("columns -", function() {
+      var dataView;
+
+      beforeEach(function() {
+        dataView = new DataView(dataTable);
+        dataView.setColumns([2, 0, 1]);
+      });
+
+      describe("#getNumberOfColumns() -", function() {
+        it("should return 0 when there are no columns", function() {
+          var dataView2 = new DataView(new DataTable());
+          expect(dataView2.getNumberOfColumns()).toBe(0);
+        });
+
+        it("should return source column count when columns have not been set", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+        });
+
+        it("should return 2 when there are 2 visible columns", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([2, 1]);
+          expect(dataView2.getNumberOfColumns()).toBe(2);
+        });
+
+        it("should return 3 when there are 3 visible columns", function() {
+          expect(dataView.getNumberOfColumns()).toBe(3);
+        });
+      });
+
+      describe("#getTableColumnIndex()", function() {
+        it("should return the specified index when setColumns was not called", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.getTableColumnIndex(1)).toBe(1);
+        });
+
+        it("should return the mapped index when setColumns was called", function() {
+          expect(dataView.getTableColumnIndex(0)).toBe(2);
+          expect(dataView.getTableColumnIndex(1)).toBe(0);
+          expect(dataView.getTableColumnIndex(2)).toBe(1);
+        });
+      });
+
+      describe("#setColumns()", function() {
+        it("should set all columns visible when called with a nully value", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([]);
+          expect(dataView2.getNumberOfColumns()).toBe(0);
+
+          dataView2.setColumns();
+          expect(dataView2.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+
+          dataView2.setColumns([]);
+          dataView2.setColumns(null);
+          expect(dataView2.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+
+          dataView2.setColumns([]);
+          dataView2.setColumns(undefined);
+          expect(dataView2.getNumberOfColumns()).toBe(dataTable.getNumberOfColumns());
+        });
+
+        it("should set only the specified columns visible", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([0, 1]);
+          expect(dataView2.getNumberOfColumns()).toBe(2);
+          expect(dataView2.getColumnId(0)).toBe("country");
+          expect(dataView2.getColumnId(1)).toBe("sales"  );
+
+          dataView2.setColumns([1, 2, 1]);
+          expect(dataView2.getNumberOfColumns()).toBe(3);
+          expect(dataView2.getColumnId(0)).toBe("sales"  );
+          expect(dataView2.getColumnId(1)).toBe("euro");
+          expect(dataView2.getColumnId(2)).toBe("sales"  );
+        });
+
+        it("should return `this`", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.setColumns([0, 1])).toBe(dataView2);
+        });
+      });
+
+      describe("#hideColumns()", function() {
+        it("should return `this`", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.hideColumns([0, 1])).toBe(dataView2);
+        });
+
+        it("should make sure the specified source column indexes are hidden", function() {
+          dataView.hideColumns([0, 2]);
+          expect(dataView.getNumberOfColumns()).toBe(1);
+          expect(dataView.getColumnId(0)).toBe("sales");
+        });
+
+        it("should not throw if a specified column is already visible", function() {
+          dataView.setColumns([0, 2]);
+          dataView.hideColumns([1, 0]);
+          expect(dataView.getNumberOfColumns()).toBe(1);
+          expect(dataView.getColumnId(0)).toBe("euro");
+        });
+      });
+
+      describe("#getViewColumns()", function() {
+        it("should get all source column indexes, before setColumns is called", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.getViewColumns()).toEqual([0, 1, 2]);
+        });
+
+        it("should get the source column indexes currently visible", function() {
+          expect(dataView.getViewColumns()).toEqual([2, 0, 1]);
+
+          dataView.setColumns([1, 2]);
+          expect(dataView.getViewColumns()).toEqual([1, 2]);
+
+          dataView.setColumns([2, 2]);
+          expect(dataView.getViewColumns()).toEqual([2, 2]);
+        });
+      });
+
+      describe("#getColumnType() -", function() {
+        it("should return the column type of the given column index", function() {
+          expect(dataView.getColumnType(0)).toBe("boolean");
+          expect(dataView.getColumnType(1)).toBe("string");
+          expect(dataView.getColumnType(2)).toBe("number");
+        });
+      });
+
+      describe("#getColumnId() -", function() {
+        it("should return the column id of the given column index", function() {
+          expect(dataView.getColumnId(0)).toBe("euro");
+          expect(dataView.getColumnId(1)).toBe("country");
+          expect(dataView.getColumnId(2)).toBe("sales");
+        });
+      });
+
+      describe("#getColumnLabel() -", function() {
+        it("should return the column label of the given column index", function() {
+          expect(dataView.getColumnLabel(0)).toBe("Euro");
+          expect(dataView.getColumnLabel(1)).toBe("Country");
+          expect(dataView.getColumnLabel(2)).toBe("Sales");
+        });
+      });
+
+      describe("#getColumnProperty() -", function() {
+        it("should return the value of the specified column property", function() {
+          expect(dataView.getColumnProperty(1, "foo")).toBe(fooValue);
+          expect(dataView.getColumnProperty(2, "bar")).toBe(barValue);
+        });
+
+        it("should return `undefined` for a column property which is not defined", function() {
+          expect(dataView.getColumnProperty(0, "foo")).toBeUndefined();
+        });
+      });
+
+      describe("#setColumnProperty() -", function() {
+        it("should set the value of the specified column property", function() {
+          var guru = {};
+          dataView.setColumnProperty(0, "guru", guru);
+
+          expect(dataView.getColumnProperty(0, "guru")).toBe(guru);
+          expect(dataTable.getColumnProperty(2, "guru")).toBe(guru);
+        });
+      });
+
+      describe("#getColumnRange() -", function() {
+        it("should return a range object with both min and max `undefined` when there is no data", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([]);
+
+          expect(dataView2.getColumnRange(1)).toEqual({min: undefined, max: undefined});
+        });
+
+        it("should return a range object with the min and max values of the specified column", function() {
+
+          expect(dataView.getColumnRange(0)).toEqual({min: false, max: true});
+          expect(dataView.getColumnRange(1)).toEqual({min: "France", max: "Portugal"});
+          expect(dataView.getColumnRange(2)).toEqual({min: 6000, max: 24000});
+        });
+      });
+
+      describe("#getDistinctValues() -", function() {
+
+        it("should return an empty array when there is no data", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([]);
+
+          expect(dataView2.getDistinctValues(1)).toEqual([]);
+        });
+
+        it("should return an array containing the distinct values of the specified column", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([2, 0, 1]);
+          dataView2.setRows([2, 1, 3, 0]);
+
+          expect(dataView2.getDistinctValues(0)).toEqual([true, false]);
+          expect(dataView2.getDistinctValues(1)).toEqual(["Italy", "Ireland", "France", "Portugal"]);
+          expect(dataView2.getDistinctValues(2)).toEqual([10000, 6000, 24000, 12000]);
+        });
+      });
+
+      describe("#getDistinctFormattedValues() -", function() {
+
+        it("should return an empty array when there is no data", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([]);
+
+          expect(dataView2.getDistinctFormattedValues(1)).toEqual([]);
+        });
+
+        it("should return an array containing the distinct formatted values of the specified column", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([2, 0, 1]);
+          dataView2.setRows([2, 1, 3, 0]);
+
+          expect(dataView2.getDistinctFormattedValues(0)).toEqual(["true", "false"]);
+          expect(dataView2.getDistinctFormattedValues(1)).toEqual(["Italy", "Ireland", "France", "Portugal"]);
+          expect(dataView2.getDistinctFormattedValues(2)).toEqual(["1.0", "0.6", "2.4", "1.2"]);
+        });
+      });
+
+      describe("#addColumn()", function() {
+        it("should add another column to the root table as last column", function() {
+          var count = dataTable.getNumberOfColumns();
+          dataView.addColumn({id: "A", type: "string", label: "A"});
+
+          expect(dataTable.getNumberOfColumns()).toBe(count + 1);
+          expect(dataTable.getColumnId(count)).toBe("A");
+        });
+
+        it("should make the new column visible in the view", function() {
+          var count = dataTable.getNumberOfColumns();
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([0, 1]);
+          dataView2.addColumn({id: "A", type: "string", label: "A"});
+
+          expect(dataTable.getColumnId(count)).toBe("A");
+
+          expect(dataView2.getNumberOfColumns()).toBe(3);
+          expect(dataView2.getColumnId(2)).toBe("A");
+        });
+
+        it("should return the index of the added view column", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setColumns([0, 1]);
+          var index = dataView2.addColumn({id: "A", type: "string", label: "A"});
+          expect(index).toBe(2);
+        });
+      });
+    });
+
+    describe("rows -", function() {
+      describe("#getNumberOfRows() -", function() {
+        it("should return 0 when there are no rows", function() {
+          var dataView2 = new DataView(new DataTable());
+          expect(dataView2.getNumberOfRows()).toBe(0);
+        });
+
+        it("should return source row count when rows have not been set", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+        });
+
+        it("should return 2 when there are 2 visible rows", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([1, 2]);
+          expect(dataView2.getNumberOfRows()).toBe(2);
+        });
+
+        it("should return 3 when there are 3 visible rows", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([1, 2, 0]);
+          expect(dataView2.getNumberOfRows()).toBe(3);
+        });
+      });
+
+      describe("#getTableRowIndex()", function() {
+        it("should return the specified index when setRows was not called", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.getTableRowIndex(1)).toBe(1);
+          expect(dataView2.getTableRowIndex(0)).toBe(0);
+        });
+
+        it("should return the mapped index when setRows was called", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([0, 2, 1]);
+          expect(dataView2.getTableRowIndex(0)).toBe(0);
+          expect(dataView2.getTableRowIndex(1)).toBe(2);
+          expect(dataView2.getTableRowIndex(2)).toBe(1);
+        });
+      });
+
+      describe("#setRows()", function() {
+        it("should set all rows visible when called with a nully value", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([]);
+          expect(dataView2.getNumberOfRows()).toBe(0);
+
+          dataView2.setRows();
+          expect(dataView2.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+
+          dataView2.setRows([]);
+          dataView2.setRows(null);
+          expect(dataView2.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+
+          dataView2.setRows([]);
+          dataView2.setRows(undefined);
+          expect(dataView2.getNumberOfRows()).toBe(dataTable.getNumberOfRows());
+        });
+
+        it("should set only the specified rows visible", function() {
+          var dataView2 = new DataView(dataTable);
+          dataView2.setRows([1, 0]);
+          expect(dataView2.getNumberOfRows()).toBe(2);
+          expect(dataView2.getValue(0, 0)).toBe("Ireland");
+          expect(dataView2.getValue(1, 0)).toBe("Portugal");
+
+          dataView2.setRows([1, 2, 1]);
+          expect(dataView2.getNumberOfRows()).toBe(3);
+          expect(dataView2.getValue(0, 0)).toBe("Ireland");
+          expect(dataView2.getValue(1, 0)).toBe("Italy");
+          expect(dataView2.getValue(2, 0)).toBe("Ireland");
+        });
+
+        it("should return `this`", function() {
+          var dataView2 = new DataView(dataTable);
+          expect(dataView2.setRows([0, 1])).toBe(dataView2);
+        });
+      });
+
+      describe("#getViewRows()", function() {
+        var dataView;
+
+        beforeEach(function() {
+          dataView = new DataView(dataTable);
+        });
+
+        it("should return null before setColumns is called", function() {
+          expect(dataView.getViewRows()).toBe(null);
+        });
+
+        it("should get the source column indexes currently visible", function() {
+          dataView.setRows([1, 2]);
+          expect(dataView.getViewRows()).toEqual([1, 2]);
+
+          dataView.setRows([2, 2]);
+          expect(dataView.getViewRows()).toEqual([2, 2]);
+        });
+      });
+    });
+
+    describe("cells -", function() {
+      var dataView;
+
+      beforeEach(function() {
+        dataView = new DataView(dataTable);
+        dataView.setColumns([2, 0, 1]);
+        dataView.setRows([3, 0, 1]);
+      });
+
+      describe("#getValue()", function() {
+        it("should return the value of the specified row and column", function() {
+          expect(dataView.getValue(0, 1)).toBe("France");
+          expect(dataView.getValue(2, 0)).toBe(false);
+        });
+      });
+
+      describe("#getFormattedValue()", function() {
+        it("should return the formatted value of the specified row and column", function() {
+          expect(dataView.getFormattedValue(0, 2)).toBe("2.4");
+          expect(dataView.getFormattedValue(1, 0)).toBe("true");
+        });
+      });
+
+      describe("#getLabel()", function() {
+        it("should return the label of the specified row and column", function() {
+          expect(dataView.getLabel(0, 2)).toBe("2.4");
+          expect(dataView.getLabel(1, 0)).toBe(null);
+        });
+      });
+
+      describe("#getCell()", function() {
+        it("should return the cell of the specified row and column", function() {
+          expect(dataView.getCell(0, 2)).toEqual({v: 24000, f: "2.4"});
+          expect(dataView.getCell(1, 0)).toEqual({v: true,  f:  null});
+        });
+      });
+
+    });
+  });
+});

--- a/package-res/resources/web/test/query-sample.html
+++ b/package-res/resources/web/test/query-sample.html
@@ -35,7 +35,7 @@
         <script language="javascript" src="../dataapi/models-cda.js" type="text/javascript"></script>
         <script language="javascript" src="../dataapi/models-svc.js" type="text/javascript"></script>
         <script language="javascript" src="../vizapi/DataTable.js" type="text/javascript"></script>
-          
+
         <script language="javascript" >
 
         pentaho.common.Messages.addUrlBundle('dataapi',CONTEXT_PATH+'i18n?plugin=common-ui&name=resources/web/dataapi/nls/messages');
@@ -75,7 +75,7 @@ function loadPage() {
     while( dataTable.rows.length > 0 ) {
         dataTable.deleteRow(0);
     }
-    
+
     var row = document.getElementById('param-template-row');
     paramHtmlTemplate = row.innerHTML;
     document.getElementById('data-select-table').deleteRow(9);
@@ -104,7 +104,7 @@ function loadPage() {
 		source: {}
 	};
 	var moduleArray = [da_mql,da_olap,da_svc];
-	pentaho.myapp.app.init(moduleArray);	
+	pentaho.myapp.app.init(moduleArray);
     pentaho.myapp.app.moduleData['da-mql'].instance.METADATA_SERVICE_URL = CONTEXT_PATH + 'content/ws-run/metadataService';
 
     try {
@@ -112,7 +112,7 @@ function loadPage() {
     } catch(e) {
         alert(e.message);
     }
-    
+
     filterDialog = dijit.byId('filterDialog');
     filterDialog.setLocalizationLookupFunction(pentaho.common.Messages.getString);
     filterDialog.setSearchListLimit(200);
@@ -130,13 +130,13 @@ function loadModels() {
     // load the list of datasource models
 	pentaho.myapp.app.getSources(
 		//function to be called for each source as it is added
-		function(source) {	
+		function(source) {
 			//console.log(source);
 			var list = document.getElementById('model-list');
             opt = new Option( source.name, source.id );
 			list.options[list.length] = opt;
 		}
-	);    
+	);
     if( document.getElementById('model-list').options.length > 0 ) {
         document.getElementById('model-list').selectedIndex=0;
     }
@@ -155,7 +155,7 @@ try {
     // get the model
     pentaho.myapp.source = pentaho.myapp.app.getSources(null, {filter: {property:'id', value:document.getElementById('model-list').options[idx].value}});
   	pentaho.myapp.source.discoverModelDetail();
-    model = pentaho.myapp.source; 
+    model = pentaho.myapp.source;
 
     document.getElementById('use-across-location-1').disabled = !model.hasCapability(pentaho.pda.CAPABILITIES.HAS_ACROSS_AXIS);
     document.getElementById('use-across-location-1').checked = false;
@@ -168,18 +168,18 @@ try {
     list1.options.length = 0;
     list2.options.length = 0;
     list3.options.length = 0;
-    
+
     // populate the lists of fields
-    var types = new Array( pentaho.pda.Column.ELEMENT_TYPES.LEVEL, 
-        pentaho.pda.Column.ELEMENT_TYPES.DIMENSION, 
-        pentaho.pda.Column.ELEMENT_TYPES.ATTRIBUTE, 
-        pentaho.pda.Column.ELEMENT_TYPES.KEY, 
+    var types = new Array( pentaho.pda.Column.ELEMENT_TYPES.LEVEL,
+        pentaho.pda.Column.ELEMENT_TYPES.DIMENSION,
+        pentaho.pda.Column.ELEMENT_TYPES.ATTRIBUTE,
+        pentaho.pda.Column.ELEMENT_TYPES.KEY,
         pentaho.pda.Column.ELEMENT_TYPES.UNKNOWN );
-        
+
     var columns = model.getColumnsByFieldTypes( types );
     columns = model.sortColumnsByName( columns );
     var options = model.createListOptions( columns );
-    
+
     list1.options[0] = new Option('');
     list2.options[0] = new Option('');
     for( var idx=0; idx<options.length; idx++ ) {
@@ -195,12 +195,12 @@ try {
     columns = model.getColumnsByFieldTypes( types );
     columns = model.sortColumnsByName( columns );
     options = model.createListOptions( columns );
-    
+
     for( var idx=0; idx<options.length; idx++ ) {
         list3.options[list3.options.length] = options[idx];
     }
     list3.size = Math.min( columns.length, 10 );
-    
+
     // enabled all of the controls now that a model has been selected
     document.getElementById('Column1Select').disabled = false;
     document.getElementById('Column1ValuesSelect').disabled = false;
@@ -220,7 +220,7 @@ try {
     } catch (e) {
         alert( e.message );
     }
-    
+
 }
 
 function changeColumn( selectId, valuesId ) {
@@ -236,7 +236,7 @@ function changeColumn( selectId, valuesId ) {
     var column = model.getColumnById( columnId );
     // get the values for the column
     var results = model.getAllValuesForColumn( column );
-    if( results['className'] != 'pentaho.DataTable' ) {
+    if( !(results instanceof pentaho.DataTable) ) {
         results = new pentaho.DataTable(results);
     }
     valuesList.options[0] = new Option('<ALL>');
@@ -258,14 +258,14 @@ function selectionsChanged() {
         var list = document.getElementById('Column1ValuesSelect' );
         handleSelection( column, list, query, document.getElementById('use-across-location-1').checked );
     }
-    
+
     // add item 2
     var column = model.getColumnById( document.getElementById('Column2Select').value );
     if( column ) {
         var list = document.getElementById('Column2ValuesSelect' );
         handleSelection( column, list, query, document.getElementById('use-across-location-2').checked );
     }
-    
+
     // add measures
     var list = document.getElementById('MeasureSelect' );
     for( var idx=0; idx<list.options.length; idx++ ) {
@@ -273,14 +273,14 @@ function selectionsChanged() {
             query.addSelectionById( list.options[idx].value );
         }
     }
-    
+
     if( queryParameters && queryParameters.length ) {
         for( var idx=0; idx<queryParameters.length; idx++ ) {
-            query.addConditionById(queryParameters[idx].columnId, 
+            query.addConditionById(queryParameters[idx].columnId,
                 queryParameters[idx].operator,queryParameters[idx].value,queryParameters[idx].condition);
         }
     }
-    
+
 //    alert(query.getJson());
     query.prepare();
     document.getElementById('querytext').value = query.getQueryStr();
@@ -290,7 +290,7 @@ function selectionsChanged() {
         return;
     }
     results = model.submitQuery( query );
-    if( results['className'] != 'pentaho.DataTable' ) {
+    if( !(results instanceof pentaho.DataTable) ) {
         results = new pentaho.DataTable(results);
     }
     if( results == null ) {
@@ -304,7 +304,7 @@ function selectionsChanged() {
 
 function handleSelection( column, list, query, useAcross ) {
         var selection = null;
-        
+
         var location = (useAcross) ? pentaho.pda.AXIS_LOCATION_ACROSS : pentaho.pda.AXIS_LOCATION_DOWN;
         if( list.options[0].selected ) {
             // the 'ALL' option is selected, so we don't need individual selections
@@ -323,7 +323,7 @@ function handleSelection( column, list, query, useAcross ) {
                 var value = null;
                 if( selectedValues.length == 1 ) {
                     value = selectedValues[0];
-                } 
+                }
                 else if( selectedValues.length > 1 ) {
                     value = selectedValues;
                 }
@@ -350,7 +350,7 @@ function displayData( results ) {
         }
         var html = headerCellHtml.replace( /{contents}/, headerContent );
         html = html.replace( /{idx}/g, idx );
-        if( results.getColumnType(idx) == pentaho.pda.Column.DATA_TYPES.NUMERIC || 
+        if( results.getColumnType(idx) == pentaho.pda.Column.DATA_TYPES.NUMERIC ||
             results.getColumnType(idx) == pentaho.pda.Column.DATA_TYPES.BOOLEAN ) {
             html = html.replace( /text-align: left;/, 'text-align: right;' );
         }
@@ -364,10 +364,10 @@ function displayData( results ) {
         var rowHtml = '';
         for( var colNo=0; colNo<results.getNumberOfColumns();colNo++ ) {
             var html = dataCellHtml.replace( /{contents}/, results.getFormattedValue(rowNo, colNo) );
-            if( results.getColumnType(colNo) == pentaho.pda.Column.DATA_TYPES.NUMERIC || 
+            if( results.getColumnType(colNo) == pentaho.pda.Column.DATA_TYPES.NUMERIC ||
                 results.getColumnType(colNo) == pentaho.pda.Column.DATA_TYPES.BOOLEAN ) {
                 html = html.replace( /text-align: left;/, 'text-align: right;' );
-            }            
+            }
             rowHtml += html;
         }
         var newRow = dataTable.insertRow(dataTable.rows.length);
@@ -413,7 +413,7 @@ function createFilter () {
 
     filter.value = ["Testing"];
     dialog.configureFor(filter);
-    
+
     dialog.show();
 
 }
@@ -468,8 +468,8 @@ function updateParametersList() {
     for( var idx=0; idx<queryParameters.length; idx++ ) {
         var param = queryParameters[idx];
         var html = paramHtmlTemplate;
-        html = html.replace( /{idx}/g, ''+idx );   
-        html = html.replace( /{desc}/g, param.description );   
+        html = html.replace( /{idx}/g, ''+idx );
+        html = html.replace( /{desc}/g, param.description );
         var newRow = table.insertRow(9+idx);
         addTableCells( newRow, html );
 
@@ -511,7 +511,7 @@ function autoUpdateChanged() {
 function showQueryChanged() {
 
     var e = document.getElementById("querySection");
-    
+
     if( document.getElementById("show-query").checked ) {
         e.style.display = 'block';
     } else {
@@ -532,7 +532,7 @@ function submitPassThrough() {
         var sorted = pentaho.pda.app.prototype.sortData( results, 0, pentaho.pda.Column.SORT_TYPES.ASCENDING );
         displayData( sorted );
     }
-    
+
 }
 
 dojo.ready(loadPage);
@@ -548,7 +548,7 @@ dojo.ready(loadPage);
         </div>
 
         <div style="padding: 8px; background-color:white">
-        
+
             <h3>Data API - Queries</h3>
             This example shows you how to create and execute a query against a data source.
             <p/>
@@ -573,7 +573,7 @@ dojo.ready(loadPage);
                                     <td><select size="10" multiple="true" id="Column1ValuesSelect" onchange="selectionsChanged()" style="width:200px" disabled="true"></select></td>
                                 </tr>
                                 <tr>
-                                    <td>Item 2 
+                                    <td>Item 2
                                         <input id="use-across-location-2" type="checkbox" checked="false" onchange="selectionsChanged()"/>Across
                                     </td>
                                 </tr>
@@ -628,7 +628,7 @@ dojo.ready(loadPage);
             </table>
 
         </div>
-        
+
     </body>
-  
+
 </html>

--- a/package-res/resources/web/vizapi/DataTable.js
+++ b/package-res/resources/web/vizapi/DataTable.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -665,7 +665,7 @@ pentaho.DataTable.prototype.addColumn = function(colSpec) {
  *
  * @example
  * To filter on column 0 == 'France':
- * 
+ *
  *     var rows = dataTable.getFilteredRows({column: 0, value: 'France'});
  *     var view = new pentaho.DataView(dataTable);
  *     view.setRows(rows);

--- a/package-res/resources/web/vizapi/DataTable.js
+++ b/package-res/resources/web/vizapi/DataTable.js
@@ -15,1094 +15,1219 @@
 *
 */
 
-/*
-pentaho.DataTable
-pentaho.DataView
-
-Client-side non-visual data tables.
-
-author: James Dixon
-
-*/
-
 pentaho = typeof pentaho == "undefined" ? {} : pentaho;
 
-/****************************************************
-    pentaho.DataTable
-    A client-side table object. 
-****************************************************/
+/**
+ * Pentaho JavaScript Visualization Data APIs.
+ *
+ * This module defines interfaces and classes
+ * used by visualizations for data representation and manipulatation.
+ *
+ * @module common-ui.vizapi.data
+ * @main common-ui.vizapi.data
+ */
+
+/**
+ * An _AbstractDataTable_ represents a set of tabular data.
+ *
+ * @class AbstractDataTable
+ * @constructor
+ */
+ pentaho.AbstractDataTable = function AbstractDataTable() {};
+
+/**
+ * Gets a column object, given its index.
+ *
+ * @method _getColumn
+ * @param {Number} colIdx The column index (zero-based).
+ * @return {Object} The column object.
+ * @protected
+ */
+
+/**
+ * Gets a row object, given its index.
+ *
+ * @method _getRow
+ * @param {Number} rowIdx The row index (zero-based).
+ * @return {Object} The row object.
+ * @protected
+ */
+
+/**
+ * Gets a cell, given its row and column index.
+ *
+ * @method _getCell
+ * @param {Number} rowIdx The cell's row index (zero-based).
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Null|Object} The cell.
+ * @protected
+ */
+
+/**
+ * Gets the number of columns.
+ *
+ * @method getNumberOfColumns
+ * @return {Number} The number of columns.
+ */
+
+/**
+ * Gets the number of rows.
+ *
+ * @method getNumberOfRows
+ * @return {Number} The number of rows.
+ */
+
+// NOTE: Not publicizing the add method yet, as it is not unit-tested,
+// and would need many other methods to be complete:
+// addRow, addRows, setCell, setValue, setFormattedValue, ...
+// Used internally for the createTrend method.
 
 /*
-    Constructor.
-    jsonTable:      A CDA JSON table object or a Google DataTable JSON object
-*/
-pentaho.DataTable = function( jsonTable ) {
-    this.jsonTable = jsonTable;
-    this.className = "pentaho.DataTable";
-    if( jsonTable.metadata ) {
-        // convert from CDA to DataTable
-        this.jsonTable = pentaho.DataTable.convertCdaToDataTable(jsonTable);
-    }
-}
+ * Appends a new column to the table, given its specification.
+ *
+ * For data views,
+ * this method adds a column to the nearest `DataTable`
+ * and makes the column visible in the intervening views.
+ *
+ * In all existing rows, the value of the new column will be set to `null`.
+ *
+ * @method addColumn
+ * @param {Object} colSpec The column specification.
+ * @param {String} colSpec.id The id of the column.
+ * @param {String} [colSpec.type="string"]  The data type of the column's values.
+ * @param {String} [colSpec.label] The label of the column.
+ * @return {Number} The index of the new column.
+ */
 
-/*
-    convertCdaToDataTable
-    Converts a CDA JSON table object to a Google DataTable JSON table object
-    
-    Input format
-    {
-        metadata: [
-            { colName: 'col1', colType: 'STRING', colLabel: 'Column 1' },
-            { colName: 'col2', colType: 'NUMERIC', colLabel: 'Column 2' }
-        ],
-        resultset: [
-            [ 'Row1', 123 ],
-            [ 'Row2', 456 ]
-        ]
-    }
-    
-    Output format
-    {
-        cols: [
-            { id: 'col1', type: 'string', label: 'Column 1' },
-            { id: 'col2', type: 'number', label: 'Column 2' },
-        ],
-        rows: [
-            { c: [ {v: 'Row 1' }, {v: 123} ] },
-            { c: [ {v: 'Row 2' }, {v: 456} ] }
-        ]
-    }
-    
-    cdaTable:   a CDA JSON table
-    returns:    a Google DataTable JSON table object
-*/
-pentaho.DataTable.convertCdaToDataTable = function( cdaTable ) {
+// TODO: metadata/properties on column/cell/row/table should be stored in a metadata bag, property "p".
+// However, any change must be performed in tandem with Analyzer server-side placement of
+// the "dataReq", "geoRole column property (See GoogleVisualizationRender.renderDataTable).
+// Deferred to when we touch server-side, during DataTable extensions work.
 
-    var cols = [];
-    var rows = [];
-    
-    // create the columns objects
-    for(var columnIdx=0; columnIdx<cdaTable.metadata.length; columnIdx++) {
-        // create a column object
-        col = {
-            id: cdaTable.metadata[columnIdx].colName,
-            type: cdaTable.metadata[columnIdx].colType.toLowerCase(),
-            label: cdaTable.metadata[columnIdx].colLabel
-        }
-        if(!col.label) {
-            col.label = col.id;
-        }
-        if(col.type == 'numeric') {
-            // convert 'numeric' to 'number' to be compatible with Google Charts
-            col.type = 'number';
-        }
-        // add the column to the cols array
-        cols.push(col);
-    }
-    
-    // now add the rows
-    var cdaData = cdaTable.resultset;
-    for(var rowIdx=0; rowIdx<cdaData.length; rowIdx++) {
-        // create a cells array
-        var cells = [];
-        var cdaRow = cdaData[rowIdx];
-        for( columnIdx=0; columnIdx<cdaRow.length; columnIdx++ ) {
-            // add a value to the cells array
-            cells.push({
-                v: cdaRow[columnIdx]
-            });
-        }
-        var row = {
-            c: cells
-        };
-        // add the row to the rows array
-        rows.push(row);
-    }
-    
-    // returns the finished object
-    return {
-        cols: cols,
-        rows: rows
-    };
+// ----
+// COLS
 
-}
+/**
+ * Gets the data type of the values of a column, given its index.
+ *
+ * DataType values are always delivered in lower case
+ * (whatever the initially provided casing).
+ *
+ * The recognized data type values are:
+ * * `"string"` — values are such that `typeof value === "string"`
+ * * `"number"` — values are such that `typeof value === "number"`
+ * * `"boolean"` — values are such that `typeof value === "boolean"`
+ *
+ * @method getColumnType
+ * @param {Number} colIdx The column index (zero-based).
+ * @return {String} The data type of the column's values.
+ */
+pentaho.AbstractDataTable.prototype.getColumnType = function(colIdx) {
+  var type = this._getColumn(colIdx).type;
+  return type ? type.toLowerCase() : "string";
+};
 
-/*
-    Add Java classnames in select places so that this data table can be
-    deserialized from JSON into Java objects
-*/
-pentaho.DataTable.prototype.makePostable = function() {
-    this.jsonTable["class"] = "org.pentaho.dataservice.DataTable";
-    for( var idx=0; idx<this.getNumberOfColumns(); idx++ ) {
-        this.jsonTable.cols[idx]["class"] = "org.pentaho.dataservice.Column";
-    } 
-    for( var idx=0; idx<this.getNumberOfRows(); idx++ ) {
-        var cells = this.jsonTable.rows[idx].c;
-        if( cells ) {
-            for( cellNo=0; cellNo<cells.length; cellNo++ ) {
-                if( cells[cellNo] ) {
-                    cells[cellNo]["class"] = "org.pentaho.dataservice.Cell";
-                }
-            }
-        }
+/**
+ * Gets the id of the data property stored in a column, given its index.
+ *
+ * @method getColumnId
+ * @param {Number} colIdx The column index (zero-based).
+ * @return {String} The column's data property id.
+ */
+pentaho.AbstractDataTable.prototype.getColumnId = function(colIdx) {
+  return this._getColumn(colIdx).id;
+};
+
+/**
+ * Gets the label of the data property stored in a column, given its index.
+ *
+ * @method getColumnLabel
+ * @param {Number} colIdx The column index (zero-based).
+ * @return {String} The column's data property label.
+ */
+pentaho.AbstractDataTable.prototype.getColumnLabel = function(colIdx) {
+  return this._getColumn(colIdx).label;
+};
+
+/**
+ * Gets the value of a column property.
+ *
+ * @method getColumnProperty
+ * @param {Number} colIdx The column index (zero-based).
+ * @param {String} name  The name of the property.
+ * @return {any} The property value.
+ */
+pentaho.AbstractDataTable.prototype.getColumnProperty = function(colIdx, name) {
+  return this._getColumn(colIdx)[name];
+};
+
+/**
+ * Sets the value of a column property.
+ *
+ * @method setColumnProperty
+ * @param {Number} colIdx The column index (zero-based).
+ * @param {String} name  The name of the property.
+ * @param {any}    value The value of the property.
+ * @chainable
+ */
+pentaho.AbstractDataTable.prototype.setColumnProperty = function(colIdx, name, value) {
+  this._getColumn(colIdx)[name] = value;
+  return this;
+};
+
+// TODO: Cache results when no key function is specified.
+
+/**
+ * Gets the value range of a column, given its index.
+ *
+ * When there is no data, or all data is `null`, `undefined` or `NaN`,
+ * the returned range object will have both of its properties, `min` and `max`,
+ * with the value `undefined`.
+ *
+ * This method can be applied meaningfully to columns having a `"number"` or `"string"` data type
+ * (or whose specified `options.key` function evaluates to such types of values).
+ * When the data type is `"string"`, the comparison is lexicographical.
+ *
+ * @example
+ *     {min: 123, max: 456}
+ *
+ * @method getColumnRange
+ * @param {Number} colIdx The column index (zero-based).
+ * @param {Object} [options] A keyword arguments object.
+ * @param {Function} [options.key] A function that derives values from the actual column values.
+ * @return {Object} A non-null range object.
+ */
+pentaho.AbstractDataTable.prototype.getColumnRange = function(colIdx, options) {
+  var set = false,
+      key = options && options.key,
+      i = 0,
+      R = this.getNumberOfRows(),
+      min, max; // = undefined
+
+  while(i < R) {
+    var value = this.getValue(i++, colIdx);
+    if(value != null && !isNaN(value)) {
+      if(key) {
+        value = key(value);
+        if(value == null || isNaN(value)) continue;
+      }
+
+      if(!set) {
+        min = max = value;
+        set = true;
+      } else {
+        if(value < min) min = value;
+        if(value > max) max = value;
+      }
     }
-}
+  }
 
-/*
-    Returns the underlying JSON table
-*/
-pentaho.DataTable.prototype.getJsonTable = function() {
-    return this.jsonTable;
-}
- 
-/*
-    getNumberOfColumns
-    returns     The number of columns in the table
-*/
+  return {min: min, max: max};
+};
+
+/**
+ * Gets an array of the distinct values of a column, given its index.
+ *
+ * Values are obtained by calling
+ * {{#crossLink "AbstractDataTable/getValue:method"}}{{/crossLink}} on each cell.
+ *
+ * The distinct values are returned in order of first occurrence (not sorted).
+ *
+ * The values `null` and `NaN` are treated just like other values and
+ * can thus be returned.
+ *
+ * @method getDistinctValues
+ * @param {Number} colIdx The column index (zero-based).
+ * @return {Array} A non-null array with the distinct values.
+ */
+pentaho.AbstractDataTable.prototype.getDistinctValues = function(colIdx) {
+  return this._getDistinctValuesCore(colIdx, /*formatted:*/false);
+};
+
+/**
+ * Gets an array of the distinct _formatted_ values of a column, given its index.
+ *
+ * Formatted values are obtained by calling
+ * {{#crossLink "AbstractDataTable/getFormattedValue:method"}}{{/crossLink}} on each cell.
+ *
+ * The distinct formatted values are returned in order of first occurrence (not sorted).
+ *
+ * The value `null` is treated just like other values and can thus be returned.
+ *
+ * @method getDistinctFormattedValues
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Array} A non-null array with the distinct formatted values.
+ */
+pentaho.AbstractDataTable.prototype.getDistinctFormattedValues = function(colIdx) {
+  return this._getDistinctValuesCore(colIdx, /*formatted:*/true);
+};
+
+pentaho.AbstractDataTable.prototype._getDistinctValuesCore = function(colIdx, formatted) {
+  var values = [],
+      keyMap = {},
+      i = 0,
+      R = this.getNumberOfRows(),
+      getValue = formatted ? this.getValue : this.getFormattedValue,
+      value, key;
+
+  while(i < R) {
+    value = getValue.call(this, i++, colIdx);
+    key   = (typeof value) + ":" + value;
+    if(keyMap[key] !== 1) {
+      keyMap[key] = 1;
+      values.push(value);
+    }
+  }
+
+  return values;
+};
+
+// =====
+// CELLS
+
+/**
+ * Gets the value of a cell, given its row and column index.
+ *
+ * When a cell is missing or has a `null`or `undefined` value,
+ * then `null` is returned.
+ *
+ * @method getValue
+ * @param {Number} rowIdx The cell's row index (zero-based).
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Null|Boolean|Number|String} The cell's value.
+ */
+pentaho.AbstractDataTable.prototype.getValue = function(rowIdx, colIdx) {
+  var cell = this._getCell(rowIdx, colIdx),
+      v;
+
+  return cell         ==  null      ? null :
+         (typeof cell !== "object") ? cell :
+         (v = cell.v) !=  null      ? v    :
+         null;
+};
+
+/**
+ * Gets a _copy_ of a cell, given its row and column index.
+ *
+ * The value `null` is returned when:
+ * 1. a cell is missing, or
+ * 2. a cell has both a _nully_ value and formatted value properties
+ *    (where _nully_ means `null`or `undefined`).
+ *
+ * @method getCell
+ * @param {Number} rowIdx The cell's row index (zero-based).
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Null|Object} A copy of the cell or `null`.
+ */
+pentaho.AbstractDataTable.prototype.getCell = function(rowIdx, colIdx) {
+  var cell = this._getCell(rowIdx, colIdx);
+  if(cell == null) return null;
+  if(typeof cell !== "object") return {v: cell, f: null};
+
+  var v = cell.v, f = cell.f;
+  if(v == null && f == null) return null;
+  return {
+    v: v == null ? null : v,
+    f: f == null ? null : String(f)
+  };
+};
+
+/**
+ * Gets the formatted value of a cell, given its row and column index.
+ *
+ * If the cell has a specified formatted value,
+ * then the string representation of that value is returned.
+ *
+ * Otherwise, if the cell has a specified value,
+ * then the string representation of that value is returned.
+ *
+ * **Note**: When both the cell's formatted value and value are `null`or `undefined`,
+ * then `null` is returned.
+ *
+ * Contrast this method with {{#crossLink "AbstractDataTable/getLabel:method"}}{{/crossLink}},
+ * that only returns a formatted value when one has been explicitly defined in the cell's `f` property.
+ *
+ * @method getFormattedValue
+ * @param {Number} rowIdx The cell's row index (zero-based).
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Null|String} The cell's formatted value.
+ */
+pentaho.AbstractDataTable.prototype.getFormattedValue = function(rowIdx, colIdx) {
+  var cell = this._getCell(rowIdx, colIdx),
+      f;
+
+  return cell == null ? null :
+         (((f = cell.f) != null) || ((f = cell.v) != null))  ? String(f) :
+         (typeof cell === 'object') ? null :
+         String(cell);
+};
+
+/**
+ * Gets the formatted value _property_ of a cell, given its row and column index.
+ *
+ * This method returns the string representation of the value of the cell's `f` property,
+ * when the value is defined, or `null`, otherwise.
+ *
+ * Contrast this method with {{#crossLink "AbstractDataTable/getFormattedValue:method"}}{{/crossLink}},
+ * that returns a best-effort formatted value in all cases,
+ * except for `null` or `undefined` values.
+ *
+ * @method getLabel
+ * @param {Number} rowIdx The cell's row index (zero-based).
+ * @param {Number} colIdx The cell's column index (zero-based).
+ * @return {Null|String} The specified formatted value or `null`.
+ * @since 3.0
+ */
+pentaho.AbstractDataTable.prototype.getLabel = function(rowIdx, colIdx) {
+  var cell = this._getCell(rowIdx, colIdx),
+      f;
+
+  return cell != null && (f = cell.f) != null ? String(f) : null;
+};
+
+// -----
+// TABLE
+
+/**
+ * Gets a table plain-object, in DataTable format.
+ *
+ * See also: {{#crossLink "DataView/toDataTable:method"}}{{/crossLink}}.
+ *
+ * @method toJSON
+ * @return {Object} A table plain-object.
+ * @since 3.0
+ */
+pentaho.AbstractDataTable.prototype.toJSON = function() {
+  var C = this.getNumberOfColumns(),
+      cols = new Array(C),
+      j = -1;
+
+  while(++j < C) {
+    // Copy, to preserve any metadata.
+    var srcCol = this._getColumn(j),
+        col    = cols[j] = {};
+    for(var p in srcCol)
+      if(srcCol.hasOwnProperty(p))
+        col[p] = srcCol[p];
+  }
+
+  var R = this.getNumberOfRows(),
+      rows = new Array(R),
+      i = -1,
+      cells;
+
+  while(++i < R) {
+    cells = new Array((j = C));
+
+    while(j--) cells[j] = this.getCell(i, j);
+
+    rows[i] = {c: cells};
+  }
+
+  return {cols: cols, rows: rows};
+};
+
+// ---------------
+
+/**
+ * A {{#crossLink "DataTable"}}{{/crossLink}} is a
+ * type of table that directly stores tabular data.
+ *
+ * A `DataTable` can be constructed empty, or from either:
+ * * a {{#crossLink "AbstractDataTable"}}{{/crossLink}} object,
+ *   in which case its data is copied, or
+ * * a plain JavaScript object having one of the supported data formats:
+ *   _DataTable_ or _CDA_.
+ *
+ * @example
+ * To create a `DataTable` from a plain JavaScript object in _DataTable_ format:
+ *
+ *     var dataTable = new DataTable({
+ *       cols: [
+ *         {id: "col1", type: "string", label: "Column 1"},
+ *         {id: "col2", type: "number", label: "Column 2"},
+ *       ],
+ *       rows: [
+ *         {c: [ {v: "row1", f: "Row 1"}, 123] },
+ *         {c: [ {v: "row2", f: "Row 1"}, {v: 456}] }
+ *       ]
+ *     });
+ *
+ * @example
+ * To create a `DataTable` from a plain JavaScript object in _CDA_ format:
+ *
+ *     var dataTable = new DataTable({
+ *       metadata: [
+ *         {colName: "col1", colType: "STRING",  colLabel: "Column 1"},
+ *         {colName: "col2", colType: "NUMERIC", colLabel: "Column 2"}
+ *       ],
+ *       resultset: [
+ *         ["Row1", 123],
+ *         ["Row2", 456]
+ *       ]
+ *     });
+ *
+ * @example
+ * To create a `DataTable` with a copy of the data
+ * in a `DataTable` or `DataView` object,
+ * use the copy constructor variant:
+ *
+ *     var dataTable = new DataTable(dataTableOrView);
+ *
+ * @class DataTable
+ * @extends AbstractDataTable
+ * @constructor
+ * @param {Object|AbstractDataTable} [table]
+ *    An instance of {{#crossLink "AbstractDataTable"}}{{/crossLink}} or
+ *    a plain JavaScript object in a supported data format.
+ */
+pentaho.DataTable = function DataTable(table) {
+  this._jsonTable =
+    !table ? {cols: [], rows: []} :
+    table instanceof pentaho.AbstractDataTable ? table.toJSON() :
+    table.metadata ? pentaho.DataTable.convertCdaToDataTable(table) :
+    table;
+};
+
+pentaho.DataTable.prototype = new pentaho.AbstractDataTable();
+pentaho.DataTable.prototype.constructor = pentaho.DataTable;
+
+// ====
+// Abstract class implementation
+
+pentaho.DataTable.prototype._getColumn = function(colIdx) {
+  return this._jsonTable.cols[colIdx];
+};
+
+pentaho.DataTable.prototype._getRow = function(rowIdx) {
+  return this._jsonTable.rows[rowIdx];
+};
+
+pentaho.DataTable.prototype._getCell = function(rowIdx, colIdx) {
+  return this._jsonTable.rows[rowIdx].c[colIdx];
+};
+
 pentaho.DataTable.prototype.getNumberOfColumns = function() {
-    return this.jsonTable.cols.length;
-}
+  return this._jsonTable.cols.length;
+};
 
-/*
-    getNumberOfRows
-    returns     The number of rows in the table
-*/
 pentaho.DataTable.prototype.getNumberOfRows = function() {
-    return this.jsonTable.rows.length;
-}
+  return this._jsonTable.rows.length;
+};
 
-/*
-    getColumnType
-    columnIdx   The column number (zero based)
-    returns     The type of the specified column (number, string, date, boolean
-*/
-pentaho.DataTable.prototype.getColumnType = function(columnIdx) {
-    return this.jsonTable.cols[columnIdx].type;
-}
+// =====
+// TABLE
 
-/*
-    getColumnId
-    columnIdx   The column number (zero based)
-    returns     The id of the specified column
-*/
-pentaho.DataTable.prototype.getColumnId = function(columnIdx) {
-    return this.jsonTable.cols[columnIdx].id;
-}
+/**
+ * Converts a table in plain JavaScript object, in _CDA_ format, to _DataTable_ format.
+ *
+ * @example
+ * If the _CDA_ table object is:
+ *
+ *     {
+ *        metadata: [
+ *          {colName: "country", colType: "STRING",  colLabel: "Country"},
+ *          {colName: "sales",   colType: "NUMERIC", colLabel: "Sales"  }
+ *        ],
+ *        resultset: [
+ *          ["Portugal", 12000],
+ *          ["Ireland",   6000]
+ *        ]
+ *     }
+ *
+ * the resulting table object in _DataTable_ format is:
+ *
+ *     {
+ *       cols: [
+ *         {id: "country", type: "string", label: "Country"},
+ *         {id: "sales",   type: "number", label: "Sales"  },
+ *       ],
+ *       rows: [
+ *         {c: [ {v: "Portugal"}, {v: 12000}] },
+ *         {c: [ {v: "Ireland" }, {v:  6000}] }
+ *       ]
+ *     }
+ *
+ * @method convertCdaToDataTable
+ * @static
+ * @param {Object} cdaTable A table object in _CDA_ format.
+ * @return {Object} A table object in _DataTable_ format.
+ */
+pentaho.DataTable.convertCdaToDataTable = function(cdaTable) {
+  var cdaCols = cdaTable.metadata,
+      cdaRows = cdaTable.resultset,
+      C = cdaCols.length,
+      R = cdaRows.length,
+      cols = new Array(C),
+      rows = new Array(R),
+      j;
 
-/*
-    getColumnLabel
-    columnIdx   The column number (zero based)
-    returns     The label of the specified column
-*/
-pentaho.DataTable.prototype.getColumnLabel = function(columnIdx) {
-    return this.jsonTable.cols[columnIdx].label;
-}
+  // TODO: Move this constant object out to closure space upon AMD conversion!
+  // CDA lowercase -> DT
+  var colTypeMap = {
+    'numeric': 'number',
+    'integer': 'number'
+  };
 
-/*
-    getValue
-    columnIdx   The column number (zero based)
-    rowIdx      The row number (zero based)
-    returns     The value of the specified cell
-*/
-pentaho.DataTable.prototype.getValue = function(rowIdx,columnIdx) {
-    if(!this.jsonTable.rows[rowIdx].c[columnIdx]){
-        return null;
+  // Columns
+  j = -1;
+  while(++j < C) {
+    var cdaCol  = cdaCols[j],
+        colType = String(cdaCol.colType || 'string').toLowerCase();
+
+    if(colTypeMap.hasOwnProperty(colType))
+      colType = colTypeMap[colType];
+
+    cols[j] = {
+      id:    cdaCol.colName,
+      type:  colType,
+      label: cdaCol.colLabel || cdaCol.colName
+    };
+  }
+
+  // Rows
+  var i = -1;
+  while(++i < R) {
+    var cdaRow = cdaData[i], cells = new Array(C);
+
+    // Copy cells
+    j = C;
+    while(j--) {
+      var v = cdaRow[j];
+      cells[j] = v == null ? null : // direct null
+                 (typeof v === 'object') && ('v' in v) ? v : // direct cell
+                 {v: v, f: undefined}; // value to cell
     }
-    if( this.jsonTable.rows[rowIdx].c[columnIdx].v !== undefined ) {
-        // we have a value field so return it
-        return this.jsonTable.rows[rowIdx].c[columnIdx].v;
-    } else {
-        return this.jsonTable.rows[rowIdx].c[columnIdx];
-    }
-}
 
-/*
-    Returns the cell object
-*/
-pentaho.DataTable.prototype._getCell = function(rowIdx,columnIdx) {
-    if(!this.jsonTable.rows[rowIdx].c[columnIdx]){
-        return null;
-    }
-    return this.jsonTable.rows[rowIdx].c[columnIdx];
-}
+    rows[i] = {c: cells};
+  }
 
+  return {cols: cols, rows: rows};
+};
 
-/*
-    getFormattedValue
-    columnIdx   The column number (zero based)
-    rowIdx      The row number (zero based)
-    returns     The formatted value of the specified cell
-*/
-pentaho.DataTable.prototype.getFormattedValue = function(rowIdx,columnIdx) {
-    if( !this.jsonTable.rows[rowIdx].c[columnIdx] ) {
-        return null;
-    }
-    else if( this.jsonTable.rows[rowIdx].c[columnIdx].f !== undefined ) {
-        // we have a formatted value so return it
-        return this.jsonTable.rows[rowIdx].c[columnIdx].f;
-    } 
-    else if( this.jsonTable.rows[rowIdx].c[columnIdx].v !== undefined ) {
-        // we have a value field so return it
-        return this.jsonTable.rows[rowIdx].c[columnIdx].v;
-    } 
-    else if( this.jsonTable.rows[rowIdx].c[columnIdx].v == null ) {
-        // we have a null value field so return it
-        return null;
-    } 
-    else {
-        return this.jsonTable.rows[rowIdx].c[columnIdx];
-    }
-}
+/**
+ * Gets the underlying plain object in DataTable format,
+ * that contains the current data in the data table.
+ *
+ * Do **NOT** modify the returned data structure.
+ *
+ * This method is deprecated.
+ * You can use {{#crossLink "AbstractDataTable/toJSON:method"}}{{/crossLink}}
+ * to get a copy of the contained data,
+ * or use the methods that access each table component directly.
+ *
+ * @method getJsonTable
+ * @return {Object} The JSON-like data object.
+ * @deprecated Use method "toJSON" instead.
+ */
+pentaho.DataTable.prototype.getJsonTable = function() {
+  return this._jsonTable;
+};
 
-/*
-    getColumnRange
-    Returns a range object describing the minimum and maximum values from the specified column
-    columnIdx   The column number (zero based)
-    options      A keyword arguments object.
-    options.key  A function that extracts the values from the column data.
-    returns      A range object - { min: 123, max: 456 }.
-                 When there is no data, or all data is null or NaN, the returned
-                 range object will have both its properties, 'min' and 'max', 
-                 with the value undefined.
-*/
-pentaho.DataTable.prototype.getColumnRange = function(columnIdx, options) {
+// ====
+// COLS
+pentaho.DataTable.prototype.addColumn = function(colSpec) {
+  var j = this._jsonTable.cols.push({
+     id:    colSpec.id,
+     type:  colSpec.type,
+     label: colSpec.label,
+  }) - 1;
 
-    var min;
-    var max;
-    var set = false;
-    var key = options && options.key;
-    
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        // get the value from this row
-        var value = this.getValue( rowNo, columnIdx );
-        if(value != null) {
-            if(key){
-                value = key(value);
-            }
-            
-            if(!set) {
-                min = value;
-                max = value;
-                set = true;
-            } else {
-                if( value < min ) {
-                    min = value;
-                }
-                if( value > max ) {
-                    max = value;
-                }
-            }
-        }
-    }
-    
-    // return the range 
-    var range = {
-        min: min,
-        max: max
-    }
-    return range;
+  // Set all rows to null
+  var rows = this._jsonTable.rows,
+      R = rows.length;
+  if(R) {
+    var i = -1;
+    while(++i < R) rows[i].c[j] = null;
+  }
 
-}
+  return j;
+};
 
-/*
-    getDistinctValues
-    Returns an array of the distinct values from the specified column
-    columnIdx   The column number (zero based)
-    Returns     An array of the distinct values from the specified column
-*/
-pentaho.DataTable.prototype.getDistinctValues = function(columnIdx) {
-    var values = [];
-    var valueMap = {};
-    var isNumber = this.getColumnType(columnIdx) == 'number';
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        var value = isNumber ? this.getValue( rowNo, columnIdx ) : this.getFormattedValue( rowNo, columnIdx );
-        if( !valueMap[value] ) {
-            valueMap[value] = true;
-            values.push(value);
-        }
-    }
-    return values;
-}
+// ====
+// ROWS
 
-/*
-    getDistinctFormattedValues
-    Returns an array of the distinct formatted values from the specified column
-    columnIdx   The column number (zero based)
-    Returns     an array of the distinct formatted values from the specified column
-*/
-pentaho.DataTable.prototype.getDistinctFormattedValues = function(columnIdx) {
-    var values = [];
-    var valueMap = {};
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        var value = this.getFormattedValue( rowNo, columnIdx );
-        if( !valueMap[value] ) {
-            valueMap[value] = true;
-            values.push(value);
-        }
-    }
-    return values;
-}
-
-/*
-    getFilteredRows
-    Filters the rows of the table using the specified filter(s). Returns an array of the row numbers
-    that met the filter criteria. The result can be passed to DataView.setRows to get a filtered table
-    
-    To filter on column 0 == 'France'
-    var rows = dataTable.getFilteredRows({ column: 0, value: 'France' })
-    var view = new pentaho.DataView( dataTable );
-    view.setRows(rows)
-    
-    To combine France and Germany
-    var rows = dataTable.getFilteredRows({ column: 0, combine: [{values:['France','Germany']}] })
-    var view = new pentaho.DataView( dataTable );
-    view.setRows(rows)
-    
-    Returns     an array of row nummbers of the rows that met the filter requirements
+/**
+ * Filters the rows of the table using the specified filters.
+ * Returns an array of the row indexes that meet the filter criteria.
+ *
+ * The result can be passed to
+ * {{#crossLink "DataView/setRows:method"}}{{/crossLink}}
+ * to obtain a filtered table.
+ *
+ * When no value filters are specified, all rows will be included in the output.
+ *
+ * @example
+ * To filter on column 0 == 'France':
+ *     var rows = dataTable.getFilteredRows({column: 0, value: 'France'});
+ *     var view = new pentaho.DataView(dataTable);
+ *     view.setRows(rows);
+ *
+ * @method getFilteredRows
+ * @param {Array} filters The filters array.
+ * @return {Array} An array of row indexes of the rows that meet the filter requirements.
 */
 pentaho.DataTable.prototype.getFilteredRows = function(filters) {
-    var rows = [];
-    var comboMap = {};
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) { // check each row
-        for( var filterNo=0; filterNo<filters.length; filterNo++ ) { // check each filter
-            if( filters[filterNo].value ) {
-                // this is a 'filter by value'
-                if( this.getValue( rowNo, filters[filterNo].column ) == filters[filterNo].value ) {
-                    // this row passes the filter requirements, add the row number to the rows array
-                    rows.push( rowNo );
-                }
-            }
-            if( filters[filterNo].combinations ) {
-                // this is a 'local combination of rows'
-                var value = this.getValue( rowNo, filters[filterNo].column );
-                var combinations = filters[filterNo].combinations;
-                var combined = false;
-                for( combinationNo=0; combinationNo<combinations.length; combinationNo++ ) {
-                    // check the values
-                    for( valueNo=0; valueNo<combinations[combinationNo].values.length; valueNo++ ) {
-                        if( value == combinations[combinationNo].values[valueNo] ) {
-                            // found something to combine
-                            if( comboMap[combinationNo] ) {
-                                comboMap[combinationNo][1].push( rowNo );
-                            } else {
-                                // this is a new one
-                                var row = ['combine',[]];
-                                row[1].push( rowNo );
-                                rows.push( row );
-                                comboMap[combinationNo] = row;
-                            }
-                            combined = true;
-                        }
-                    }
-                }
-                if( !combined ) {
-                    rows.push( rowNo );
-                }
-            }
-        }
+  var rows = [],
+      R = this.getNumberOfRows();
+
+  // Any data?
+  if(R) {
+    // Process filters
+    var valuePredicate = this._buildFilteredRowsPredicate(filters),
+        i = -1;
+
+    // Filter
+    while(++i < R)
+      if(!valuePredicate || valuePredicate.call(this, i))
+        rows.push(i);
+  }
+
+  return rows;
+};
+
+// TODO: Convert this to internal function upon the AMD conversion.
+
+// Conjunction of all value filters, if any.
+pentaho.DataTable.prototype._buildFilteredRowsPredicate = function(valueFilters) {
+  var F = valueFilters.length;
+
+  // (rowIdx: number) -> boolean
+  if(F) return function(rowIdx) {
+    for(var f = 0; f < F; f++) {
+      var filter = valueFilters[f],
+          v = filter.value;
+      if(v !== undefined && this.getValue(rowIdx, filter.column) !== v) return false;
     }
-    return rows;
-}
+    return true;
+  };
+};
 
-/*
-    setColumnProperty
-    Sets a column property
+/**
+ * A **data view** is an object that
+ * provides a way to access a subset of a source table.
+ *
+ * A data view can selectively show rows and/or columns from the source table
+ * through use of the
+ * {{#crossLink "DataView/setRows:method"}}{{/crossLink}}
+ * and {{#crossLink "DataView/setColumns:method"}}{{/crossLink}} methods,
+ * respectively.
+ * Columns can also be hidden by using the
+ * {{#crossLink "DataView/hideColumns:method"}}{{/crossLink}},
+ * a variant that preserves already hidden columns.
+ *
+ * @class DataView
+ * @extends AbstractDataTable
+ * @constructor
+ * @param {AbstractDataTable} table The source table.
+ */
+pentaho.DataView = function DataView(table) {
+  this._source = table;
 
-    columnIndex The index of the column to set the property on
-    name        The name of the property
-    value       The value of the property
-*/
-pentaho.DataTable.prototype.setColumnProperty = function(columnIndex, name, value) {
-    if( columnIndex >= 0 && columnIndex < this.jsonTable.cols.length) {
-        this.jsonTable.cols[columnIndex][name] = value;
-    }
-}
+  this._rows    = null;
+  this._columns = this._getSourceColumns();
+};
 
-/*
-    getColumnProperty
-    Returns a column property
+pentaho.DataView.prototype = new pentaho.AbstractDataTable();
+pentaho.DataView.prototype.constructor = pentaho.DataView;
 
-    columnIndex The index of the column to set the property on
-    name        The name of the property
+// ====
+// Implement abstract class
 
-    Return      The value of the property
-*/
-pentaho.DataTable.prototype.getColumnProperty = function(columnIndex, name) {
-    if( columnIndex >= 0 && columnIndex < this.jsonTable.cols.length) {
-        return this.jsonTable.cols[columnIndex][name];
-    }
-    return null;
-}
+pentaho.DataView.prototype._getColumn = function(colIdx) {
+  return this._source._getColumn(this.getTableColumnIndex(colIdx));
+};
 
-/****************************************************
-    pentaho.DataView
-    A client-side data view object.
-    Provides a way to access a subset of a DataTable.
-    You can reduce the rows and/or columns of the
-    underlying DataTable
-****************************************************/
+pentaho.DataView.prototype._getRow = function(rowIdx) {
+  return this._source._getRow(this.getTableRowIndex(rowIdx));
+};
 
-/*
-    Constructor
-    dataTable:  A DataTable object to base this view on
-*/
-pentaho.DataView = function( dataTable ) {
-    this.dataTable = dataTable;
-    this.rows = null;
-    this.columns = null;
-    this.className = "pentaho.DataView";
-}
+pentaho.DataView.prototype._getCell = function(rowIdx, colIdx) {
+  return this._source._getCell(this.getTableRowIndex(rowIdx), this.getTableColumnIndex(colIdx));
+};
 
-/*
-    setRows
-    Sets the row numbers of the rows to have in the view.
-    The row numbers do not have to match the order of the
-    underlying table.
-    If this function is not called this DataView will include
-    all the rows of the underlying DataTable.
-    All of the row numbers must be within the range of valid
-    row numbers for the DataTable.
-    
-    rows    An array of row numbers
-*/
-pentaho.DataView.prototype.setRows = function(rows) {
-    this.rows = rows;
-}
-
-/*
-    setColumns
-    Sets the column numbers to have in the view.
-    The column numbers do not have to match the order of the
-    columns in the underlying table.
-    If this function is not called this DataView will include
-    all the columns of the underlying DataTable.
-    All of the columns numbers must be within the range of valid
-    columns numbers for the DataTable.
-    
-    columns    An array of columns numbers
-*/
-pentaho.DataView.prototype.setColumns = function(columns) {
-    this.columns = columns;
-}
-
-/*
-    getColumnRange
-    Returns a range object describing the minimum and maximum values from the specified column
-    columnIdx   The column number (zero based)
-    options      A keyword arguments object.
-    options.key  A function that extracts the values from the column data.
-    returns      A range object - { min: 123, max: 456 }.
-                 When there is no data, or all data is null or NaN, the returned
-                 range object will have both its properties, 'min' and 'max', 
-                 with the value undefined.
-*/
-pentaho.DataView.prototype.getColumnRange = function(columnIdx, options) {
-
-    var min;
-    var max;
-    var set = false;
-    var key = options && options.key;
-    
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        var value = this.getValue( rowNo, columnIdx );
-        if(value != null) {
-            if(key){
-                value = key(value);
-            }
-            
-            if(!set) {
-                min = value;
-                max = value;
-                set = true;
-            } else {
-                if( value < min ) {
-                    min = value;
-                }
-                if( value > max ) {
-                    max = value;
-                }
-            }
-        }
-    }
-    var range = {
-        min: min,
-        max: max
-    }
-    return range;
-
-}
-
-/*
-    getDistinctValues
-    Returns an array of the distinct values from the specified column
-    columnIdx   The column number (zero based)
-    Returns     An array of the distinct values from the specified column
-*/
-pentaho.DataView.prototype.getDistinctValues = function(columnIdx) {
-    var values = [];
-    var valueMap = {};
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        var value = this.getValue( rowNo, columnIdx );
-        if( !valueMap[value] ) {
-            valueMap[value] = true;
-            values.push(value);
-        }
-    }
-    return values;
-}
-
-/*
-    getDistinctFormattedValues
-    Returns an array of the distinct formatted values from the specified column
-    columnIdx   The column number (zero based)
-    Returns     an array of the distinct formatted values from the specified column
-*/
-pentaho.DataView.prototype.getDistinctFormattedValues = function(columnIdx) {
-    var values = [];
-    var valueMap = {};
-    for( var rowNo=0; rowNo<this.getNumberOfRows(); rowNo++ ) {
-        var value = this.getFormattedValue( rowNo, columnIdx );
-        if( !valueMap[value] ) {
-            valueMap[value] = true;
-            values.push(value);
-        }
-    }
-    return values;
-}
-
-/*
-    hideColumns
-    Removes columns from the view.
-    The list of column numbers to hide must be in ascending order so the indexes don't shift as we delete.
-    
-    columns     An array of column numbers to hide
-*/
-pentaho.DataView.prototype.hideColumns = function(columns) {
-    tmpCols = [];
-    for( var columnIdx=0; columnIdx < this.getNumberOfColumns(); columnIdx++ ) {
-        tmpCols.push( columnIdx );
-    }
-    for( var idx=columns.length-1; idx> -1; idx-- ) {
-        tmpCols.splice(columns[idx],1)
-    }
-    this.columns = tmpCols;
-}
-
-/*
-    getNumberOfRows
-    returns     The number of rows in the table
-*/
-pentaho.DataView.prototype.getNumberOfRows = function() {
-    return this.rows == null ? this.dataTable.getNumberOfRows() : this.rows.length;
-}
-
-/*
-    getNumberOfColumns
-    returns     The number of columns in the table
-*/
 pentaho.DataView.prototype.getNumberOfColumns = function() {
-    return this.columns == null ? this.dataTable.getNumberOfColumns() : this.columns.length;
-}
+  return this._columns.length;
+};
+
+pentaho.DataView.prototype.getNumberOfRows = function() {
+  return this._rows ? this._rows.length : this._source.getNumberOfRows();
+};
+
+// ====
+// COLS
 
 /*
-    getColumnId
-    columnIdx   The column number (zero based)
-    returns     The id of the specified column
-*/
-pentaho.DataView.prototype.getColumnId = function(columnIdx) {
-    return this.columns == null ? this.dataTable.getColumnId(columnIdx) : this.dataTable.getColumnId(this.columns[columnIdx]);
-}
+ * Gets an array with all source column indexes.
+ *
+ * @method _getSourceColumns
+ * @return {Array} An array of source column indexes.
+ */
+pentaho.DataView.prototype._getSourceColumns = function() {
+  var C = this._source.getNumberOfColumns(),
+      cols = new Array(C),
+      j;
+
+  for(j = 0; j < C; j++) cols[j] = j;
+
+  return cols;
+};
+
+/**
+ * Gets the source column index corresponding to a given view column index.
+ *
+ * @method getTableColumnIndex
+ * @param {Number} colIdx The view column index.
+ * @return {Number} The source column index.
+ * @since 3.0
+ */
+pentaho.DataView.prototype.getTableColumnIndex = function(colIdx) {
+  return this._columns[colIdx];
+};
+
+/**
+ * Sets the indexes of the visible source columns.
+ *
+ * The column indexes do not have to match the order of columns in the source table.
+ * However, these must be within the range of valid source column indexes.
+ *
+ * If this method is not called or is called with a `null` or `undefined` value in the `columns` argument,
+ * all of the source columns are made visible.
+ *
+ * @method setColumns
+ * @param {Array} [columns] An array of source column indexes.
+ * @chainable
+ */
+pentaho.DataView.prototype.setColumns = function(columns) {
+  this._columns = columns ? columns.slice() : this._getSourceColumns();
+  return this;
+};
+
+/**
+ * Gets the indexes of the visible source columns.
+ *
+ * Do **NOT** modify the returned array directly.
+ *
+ * @method getViewColumns
+ * @return {Array} The array of source column indexes.
+ * @since 3.0
+ */
+pentaho.DataView.prototype.getViewColumns = function() {
+  return this._columns;
+};
+
+/**
+ * Hides columns, given their **source** indexes.
+ *
+ * It is allowed to specify a column that is already hidden.
+ *
+ * @method hideColumns
+ * @param columns An array of source column indexes to hide.
+ * @chainable
+ */
+pentaho.DataView.prototype.hideColumns = function(columns) {
+  var cols = this._columns;
+  if(cols.length) {
+    var hideColsMap = {},
+        j;
+
+    // Index the indexes of the specified columns to be hidden.
+    j = columns.length;
+    while(j--)  hideColsMap[j] = 1;
+
+    // Remove those indexes from the current visible columns.
+    j = cols.length;
+    while(j--)
+      if(hideColsMap[columns[j]] === 1)
+        cols.splice(j, 1);
+  }
+
+  return this;
+};
+
+pentaho.DataView.prototype.addColumn = function(colSpec) {
+  var colIdx = this._source.addColumn(colSpec);
+  return this._columns.push(colIdx) - 1;
+};
+
+// ====
+// ROWS
+
+/**
+ * Gets the source row index corresponding to a given view row index.
+ *
+ * @method getTableRowIndex
+ * @param {Number} rowIdx The view row index.
+ * @return {Number} The source row index.
+ * @since 3.0
+ */
+pentaho.DataView.prototype.getTableRowIndex = function(rowIdx) {
+  return this._rows ? this._rows[rowIdx] : rowIdx;
+};
+
+/**
+ * Sets the indexes of the source rows to show in the view.
+ *
+ * The row indexes do not have to match the order of rows in the source table.
+ *
+ * If this method is not called, or is called with a `null` value,
+ * all of the source rows are included.
+ *
+ * The row indexes must be within the range of valid row indexes of the source table.
+ *
+ * @method setRows
+ * @param {Array} [rows=null] An array of source row indexes.
+ * @chainable
+ */
+pentaho.DataView.prototype.setRows = function(rows) {
+  this._rows = rows || null;
+  return this;
+};
+
+/**
+ * Gets the indexes of the visible source rows.
+ *
+ * Do **NOT** modify the returned array directly.
+ *
+ * @method getViewRows
+ * @return {Array|Null} The array of source row indexes or `null`, if one has not been set.
+ * @since 3.0
+ */
+pentaho.DataView.prototype.getViewRows = function() {
+  return this._rows;
+};
+
+// -----
+// TABLE
 
 /*
-    getColumnLabel
-    columnIdx   The column number (zero based)
-    returns     The label of the specified column
-*/
-pentaho.DataView.prototype.getColumnLabel = function(columnIdx) {
-    return this.columns == null ? this.dataTable.getColumnLabel(columnIdx) : this.dataTable.getColumnLabel(this.columns[columnIdx]);
-}
+ * Gets the view's source table.
+ *
+ * @method getSourceTable
+ * @return {AbstractDataTable} The source table.
+ * @since 3.0
+ */
+pentaho.DataView.prototype.getSourceTable = function() {
+  return this._source;
+};
 
-/*
-    getColumnType
-    columnIdx   The column number (zero based)
-    returns     The type of the specified column (number, string, date, boolean
-*/
-pentaho.DataView.prototype.getColumnType = function(columnIdx) {
-    return this.columns == null ? this.dataTable.getColumnType(columnIdx) : this.dataTable.getColumnType(this.columns[columnIdx]);
-}
-
-/*
-    getValue
-    columnIdx   The column number (zero based)
-    rowIdx      The row number (zero based)
-    returns     The value of the specified cell
-*/
-pentaho.DataView.prototype.getValue = function(rowNo, colNo) {
-    var rowIdx = this.rows == null ? rowNo : this.rows[rowNo];
-    var colIdx = this.columns == null ? colNo : this.columns[colNo];
-    if( rowIdx.length && rowIdx[0] == 'combine' ) {
-        // this is a combined row
-
-        var type = this.getColumnType(colNo);
-        var value 
-        for( var idx=0; idx<rowIdx[1].length; idx++ ) {
-            if( idx == 0 ) {
-                value = this.dataTable.getValue(rowIdx[1][idx], colIdx);
-            }
-            else if( type == 'string' ) {
-                value += ' + '+this.dataTable.getValue(rowIdx[1][idx], colIdx);
-            }
-            else if( type == 'number' ) {
-                value += this.dataTable.getValue(rowIdx[1][idx], colIdx);
-            }
-        }
-        return value;
-    }
-    return this.dataTable.getValue(rowIdx, colIdx);
-}
-
-pentaho.DataView.prototype._getCell = function(rowNo, colNo) {
-    var rowIdx = this.rows == null ? rowNo : this.rows[rowNo];
-    var colIdx = this.columns == null ? colNo : this.columns[colNo];
-    return this.dataTable._getCell(rowIdx, colIdx);
-}
-
-/*
-    getFormattedValue
-    columnIdx   The column number (zero based)
-    rowIdx      The row number (zero based)
-    returns     The formatted value of the specified cell
-*/
-pentaho.DataView.prototype.getFormattedValue = function(rowNo, colNo) {
-    var rowIdx = this.rows == null ? rowNo : this.rows[rowNo];
-    var colIdx = this.columns == null ? colNo : this.columns[colNo];
-    if( rowIdx.length && rowIdx[0] == 'combine' ) {
-        // this is a combined row
-
-        var type = this.getColumnType(colNo);
-        var value 
-        for( var idx=0; idx<rowIdx[1].length; idx++ ) {
-            if( idx == 0 ) {
-                value = this.dataTable.getFormattedValue(rowIdx[1][idx], colIdx);
-            }
-            else if( type == 'string' ) {
-                value += ' + '+this.dataTable.getFormattedValue(rowIdx[1][idx], colIdx);
-            }
-            else if( type == 'number' ) {
-                value += this.dataTable.getFormattedValue(rowIdx[1][idx], colIdx);
-            }
-        }
-        return value;
-    }
-    return this.dataTable.getFormattedValue(rowIdx, colIdx);
-}
-
-/*
-    toDataTable
-    Converts this view into a DataTable that has its own copy of the
-    underlying data.
-    The column metadata and the rows are copied into the new object.
-    
-    Returns:    A DataTable
+/**
+ * Gets a {{#crossLink "DataTable"}}{{/crossLink}} loaded with the
+ * data view's visible rows and columns.
+ *
+ * This is a convenience method for abbreviating:
+ *
+ *      var dataTable = new pentaho.DataTable(thisDataView.toJSON());
+ *
+ * @method toDataTable
+ * @return {DataTable} A data table.
 */
 pentaho.DataView.prototype.toDataTable = function() {
-
-    var cols = [];
-    for( var colIdx=0; colIdx<this.getNumberOfColumns(); colIdx++ ) {
-        col = {
-            type: this.getColumnType(colIdx),
-            id:  this.getColumnId(colIdx),
-            label: this.getColumnLabel(colIdx)
-        }
-        cols.push(col);
-    }
-    
-    var rows = [];
-    for( var rowIdx=0; rowIdx<this.getNumberOfRows(); rowIdx++ ) {
-        cells = [];
-        for( var colIdx=0; colIdx<this.getNumberOfColumns(); colIdx++ ) {
-            var cell = this._getCell(rowIdx, colIdx);
-            cells.push(cell);
-        }
-        row = {
-            c: cells
-        };
-        rows.push( row );
-    }
-    
-    var json = { cols: cols, rows: rows };
-    
-    var table = new pentaho.DataTable(json);
-    return table;
-
-}
-
-/*
-    setColumnProperty
-    Sets a column property
-
-    columnIndex The index of the column to set the property on
-    name        The name of the property
-    value       The value of the property
-*/
-pentaho.DataView.prototype.setColumnProperty = function(columnIndex, name, value) {
-    this.dataTable.setColumnProperty(columnIndex, name, value);
-}
-
-/*
-    getColumnProperty
-    Returns a column property
-
-    columnIndex The index of the column to set the property on
-    name        The name of the property
-
-    Return      The value of the property
-*/
-pentaho.DataView.prototype.getColumnProperty = function(columnIndex, name) {
-    return this.dataTable.getColumnProperty(columnIndex, name);
+  return new pentaho.DataTable(this.toJSON());
 };
 
 /* TRENDS */
 
-(function(){
+(function() {
 
-    function argRequired(name){
-        return new Error("Argument '" + name + "' is required.");
+    function argRequired(name) {
+      return new Error("Argument '" + name + "' is required.");
     }
-    
-    function argInvalid(name, text){
-        return new Error("Argument '" + name + "' is invalid." + (text ? (" " + text) : ""));
+
+    function argInvalid(name, text) {
+      return new Error("Argument '" + name + "' is invalid." + (text ? (" " + text) : ""));
     }
-    
-    /* createTrend
-     * Computes a trend of a given type and adds the 
-     * result to a new column in the data table.
-     *  
-     * trendArgs Keyword arguments
-     * trendArgs.type  The type of trend to create; possible values: 'linear'
-     * trendArgs.x     The index of the "x" value column; can be a numeric or string column
-     * trendArgs.y     The index of the "y" value column; must be of a column of type 'number'
-     * trendArgs.name  The name of the new trend column; defaults to the type of trend plus the suffix "Trend"
-     * trendArgs.label The label of the new trend column; defaults to the trend name, if specified, or the default label of the trend type.
-     * 
+
+    // NOTE: This needs unit-testing before being documented publicly.
+
+    /*
+     * Computes a trend of a given type and adds the
+     * result to a new column in the table.
+     *
+     * For data views,
+     * this method creates the trend in the _root_ `DataTable`,
+     * and makes the created trend column visible in the intervening views.
+     *
+     * @method createTrend
+     * @for AbstractDataTable
+     * @param {Object} trendArgs A keyword arguments object.
+     * @param {String} trendArgs.type  The type of trend to create; possible values: 'linear'.
+     * @param {Number} trendArgs.x     The index of the "x" value column; can be a numeric or string column.
+     * @param {Number} trendArgs.y     The index of the "y" value column; must be of a column of type 'number'.
+     * @param {String} trendArgs.name  The name of the new trend column; defaults to the type of trend plus the suffix "Trend".
+     * @param {String} trendArgs.label The label of the new trend column; defaults to the trend name, when specified, or to the default label of the trend type.
+     * @return {Number} The index of the added trend column.
      */
-    pentaho.DataView.prototype.createTrend = 
-    pentaho.DataTable.prototype.createTrend = function(trendArgs){
-        
-        // Validate arguments
-        
-        if(!(trendArgs instanceof Object)){
-            throw argRequired('trendArgs');
-        }
-        
-        // ----
-        
-        var trendType = trendArgs.type;
-        if(!trendType){
-            throw argRequired('trendArgs.type');
-        }
-        
-        trendType = '' + trendType; // toString
-        
-        var trendInfo = pentaho.trends.get(trendType, /*assert*/ true);
-        
-        // -----
-        
-        var colCount = this.getNumberOfColumns();
-        
-        var xIndex = trendArgs.x;
-        if(xIndex == null){
-            throw argRequired('trendArgs.x');
-        }
-        
-        xIndex = +xIndex; // toNumber
-        if(isNaN(xIndex)){
-            throw argInvalid('trendArgs.x', "Not a number.");
-        }
-        
-        if(xIndex < 0 || xIndex >= colCount){
-            throw argInvalid('trendArgs.x', "Out of range.");
-        }
-        
-        // can be numeric or string
-        
-        // -----
-        
-        var yIndex = trendArgs.y;
-        if(yIndex == null){
-            throw argRequired('trendArgs.y');
-        }
-        
-        yIndex = +yIndex; // toNumber
-        if(isNaN(yIndex)){
-            throw argInvalid('trendArgs.y', "Not a number.");
-        }
-        
-        if(yIndex < 0 || yIndex >= colCount){
-            throw argInvalid('trendArgs.y', "Out of range.");
-        }
-        
-        if(this.getColumnType(yIndex) !== 'number'){
-            throw argInvalid('trendArgs.y', "Must be a numeric column.");
-        }
-        
-        // xIndex may be equal to yIndex...
-        
-        // ----
-        
-        var trendName  = trendArgs.name  ||
-                         (trendType + "Trend");
-        
-        var trendLabel = trendArgs.label ||
-                         (trendArgs.name ?  trendName : trendInfo.label);
-        
-        // ----
-        
-        var trendOptions = trendArgs.options || {};
-        
-        // ----
-        
-        // Create the trend column. 
-        //   Am I a DataView or a DataTable?
-        var table = (this.dataTable || this).jsonTable;
-        var trendIndex = table.cols.length; 
-        table.cols.push({
-            type:  'number',
-            id:    trendName,
-            label: trendLabel
-        });
-        
-        // ----
-        
-        var isXDiscrete = this.getColumnType(xIndex) !== 'number';
-        
-        var rowIndexesEnumtor = this.getRowIndexEnumerator();
-        
-        var me = this;
-        
-        var funX = isXDiscrete ? 
-            null : // means: "use *index* as X value"
-            function(i){
-                return me.getValue(i, xIndex);
-            };
-        
-        var funY = function(i){
-                return me.getValue(i, yIndex);
-            };
-        
-        var options = Object.create(trendOptions);
-        options.rows = rowIndexesEnumtor;
-        options.x = funX;
-        options.y = funY;
-        
-        var trendModel = trendInfo.model(options);
-        if(!trendModel){
-            // Not enough points to interpolate...
-            // Fill every row's trend column with null
-            dojo.forEach(table.rows, function(row){
-                row.c[trendIndex] = {v: null};
-            });
-            
-            return false;
-        }
-        
-        dojo.forEach(table.rows, function(row, i){
-            var trendX = funX ? funX(i) : i;
-            var trendY = trendX != null ?
-                trendModel.sample(trendX, funY(i), i) : 
-                null;
-            
-            row.c[trendIndex] = {v: trendY};
-        });
-        
-        return true;
+
+    pentaho.DataView.prototype.createTrend = function(trendArgs) {
+      var trendIndex = this._source.createTrend(trendArgs);
+      return this._columns.push(trendIndex) - 1;
+    };
+
+    pentaho.DataTable.prototype.createTrend = function(trendArgs) {
+      // Argument validation
+      // ===================
+
+      if(!(trendArgs instanceof Object)) throw argRequired('trendArgs');
+
+      // # TrendType
+
+      var trendType = trendArgs.type;
+      if(!trendType) throw argRequired('trendArgs.type');
+
+      trendType = '' + trendType; // toString
+
+      var trendInfo = pentaho.trends.get(trendType, /*assert*/ true);
+
+      // # x
+
+      var colCount = this.getNumberOfColumns();
+
+      var xIndex = trendArgs.x;
+      if(xIndex == null) throw argRequired('trendArgs.x');
+
+      xIndex = +xIndex; // toNumber
+      if(isNaN(xIndex)) throw argInvalid('trendArgs.x', "Not a number.");
+
+      if(xIndex < 0 || xIndex >= colCount) throw argInvalid('trendArgs.x', "Out of range.");
+
+      // can be numeric or string
+
+      // # y
+
+      var yIndex = trendArgs.y;
+      if(yIndex == null)
+        throw argRequired('trendArgs.y');
+
+      yIndex = +yIndex; // toNumber
+      if(isNaN(yIndex))
+        throw argInvalid('trendArgs.y', "Not a number.");
+
+      if(yIndex < 0 || yIndex >= colCount)
+        throw argInvalid('trendArgs.y', "Out of range.");
+
+      if(this.getColumnType(yIndex) !== 'number')
+        throw argInvalid('trendArgs.y', "Must be a numeric column.");
+
+      // xIndex may be equal to yIndex...
+
+      // # name and label
+
+      var trendName  = trendArgs.name  ||
+                       (trendType + "Trend");
+
+      var trendLabel = trendArgs.label ||
+                       (trendArgs.name ?  trendName : trendInfo.label);
+
+      // # custom options
+
+      var trendOptions = trendArgs.options || {};
+
+      // Create Trend Column
+      // ===================
+
+      // TODO: Use setCell method when available.
+
+      // Create the trend column.
+      // Am I a DataView or a DataTable?
+      var trendIndex = this.addColumn({
+        id:    trendName,
+        type:  'number',
+        label: trendLabel
+      });
+
+      var table = this._jsonTable;
+      var me = this;
+
+      // ----
+
+      var isXDiscrete = this.getColumnType(xIndex) !== 'number';
+
+      var rowIndexesEnumtor = this.getRowIndexEnumerator();
+
+      var getX = isXDiscrete ?
+          null : // means: "use *index* as X value"
+          function(i) { return me.getValue(i, xIndex); };
+
+      var getY = function(i) { return me.getValue(i, yIndex); };
+
+      var options = Object.create(trendOptions);
+      options.rows = rowIndexesEnumtor;
+      options.x = getX;
+      options.y = getY;
+
+      var trendModel = trendInfo.model(options);
+
+      // Not enough points to interpolate?
+      // Every row's trend column already has the value null.
+      if(!trendModel) return false;
+
+      dojo.forEach(table.rows, function(row, i){
+        var trendX = getX ? getX(i) : i,
+            trendY = trendX != null ? trendModel.sample(trendX, getY(i), i) : null;
+
+        row.c[trendIndex] = {v: trendY};
+      });
+
+      return true;
     };
 
     /* getRowIndexEnumerator
-     * 
-     * Obtains an enumerator for the row index of the data table. 
+     *
+     * Obtains an enumerator for the row index of the data table.
      */
-    pentaho.DataView.prototype.getRowIndexEnumerator = 
-    pentaho.DataTable.prototype.getRowIndexEnumerator = function(){
-        var index = -1;
-        var count = this.getNumberOfRows();
-        var enumtor = {
+    pentaho.AbstractDataTable.prototype.getRowIndexEnumerator = function() {
+      var index = -1,
+          count = this.getNumberOfRows(),
+          enumtor = {
             item: undefined,
-            next: function(){
-                if(index < count - 1){
+            next: function() {
+                if(index < count - 1) {
                     enumtor.item = ++index; // the row index
                     return true;
                 }
-                
-                if(enumtor.item) {
-                    enumtor.item = undefined; 
-                }
-                
+
+                if(enumtor.item) enumtor.item = undefined;
+
                 return false;
             }
-        };
-        
-        return enumtor;
+          };
+
+      return enumtor;
     };
-        
+
     /* trendType -> trendInfo */
     var _trends = {};
-    
+
     pentaho.trends = {};
-    
+
     /* define
      * Defines a trend type given its specification.
-     * 
+     *
      * type The type of trend to define.
      * spec The trend specification object.
      * spec.label A name for the type of trend; defaults to the capitalized trend type with the suffix "Trend".
      * spec.model A function that given a series of points computes a trend model.
-     * 
+     *
      */
     pentaho.trends.define = function(type, spec){
-        if(!type){
-            throw argRequired('type');
-        }
-        
-        type = '' + type; // to string
-        
-        if(!spec){
-            throw argRequired('spec');
-        }
-        
-        // ----
-        
-        var model = spec.model;
-        if(!model){
-            throw argRequired('spec.model');
-        }
-        
-        if(typeof model !== 'function'){
-            throw argInvalid('spec.model', "Not a function");
-        }
-        
-        // ----
-        
-        var label = spec.label;
-        if(!label){
-            label = type.chartAt(0).toUpperCase() + type.substr(1) + " Trend";
-        }
-        
-        var trendInfo = {
-           type:  type,
-           label: label,
-           model: model
-        };
-        
-        _trends[type] = trendInfo;
+      if(!type) throw argRequired('type');
+
+      type = '' + type; // to string
+
+      if(!spec) throw argRequired('spec');
+
+      // ----
+
+      var model = spec.model;
+      if(!model) throw argRequired('spec.model');
+      if(typeof model !== 'function') throw argInvalid('spec.model', "Not a function");
+
+      // ----
+
+      var label = spec.label;
+      if(!label) label = type.chartAt(0).toUpperCase() + type.substr(1) + " Trend";
+
+      _trends[type] = {
+        type:  type,
+        label: label,
+        model: model
+      };
     };
-    
+
     /* get
      * Obtains the trend info object of a given trend type.
-     * 
+     *
      * type The type of trend desired.
      * assert If an error should be thrown if the trend type is not defined.
      */
-    pentaho.trends.get = function(type, assert){
-        if(!type){
-            throw argRequired('type');
-        }
-        
-        var trendInfo = _trends.hasOwnProperty(type) ? _trends[type] : null;
-        if(!trendInfo && assert){
-            throw argInvalid('type', "There is no trend type named '" + type + "'.");
-        }
-        
-        return trendInfo;
+    pentaho.trends.get = function(type, assert) {
+      if(!type) throw argRequired('type');
+
+      var trendInfo = _trends.hasOwnProperty(type) ? _trends[type] : null;
+      if(!trendInfo && assert)
+        throw argInvalid('type', "There is no trend type named '" + type + "'.");
+
+      return trendInfo;
     };
-    
+
     /* types
      * Obtains an array with the names of all defined trend types.
      */
-    pentaho.trends.types = function(){
-        // TODO: replace with dojo or JavaScript's Object.keys implementation...
-        
-        var ret = [];
-        for(var p in _trends){
-            if(Object.prototype.hasOwnProperty.call(_trends, p)){
-                ret.push(p);
+    pentaho.trends.types = function() {
+      // TODO: replace with dojo or JavaScript's Object.keys implementation...
+
+      var ret = [];
+      for(var p in _trends)
+        if(Object.prototype.hasOwnProperty.call(_trends, p))
+          ret.push(p);
+
+      return ret;
+    };
+
+    // --------------------
+
+    function parseNum(value) {
+      return value != null ? (+value) : NaN;  // to Number works for dates as well
+    }
+
+    pentaho.trends.define('linear', {
+      label: 'Linear trend',
+      model: function(options) {
+        var rowsQuery = options.rows,
+            getX = options.x,
+            getY = options.y,
+            i = 0,
+            N = 0,
+            sumX  = 0,
+            sumY  = 0,
+            sumXY = 0,
+            sumXX = 0;
+
+        while(rowsQuery.next()) {
+          var row = rowsQuery.item,
+              // Ignore null && NaN values
+              x = getX ? parseNum(getX(row)) : i; // use the index itself for discrete stuff
+
+          if(!isNaN(x)) {
+            var y = parseNum(getY(row));
+            if(!isNaN(y)) {
+              N++;
+
+              sumX  += x;
+              sumY  += y;
+              sumXY += x * y;
+              sumXX += x * x;
             }
+          }
+
+          i++; // Discrete nulls must still increment the index
         }
 
-        return ret;
-    };
-    
-    // --------------------
-    
-    function parseNum(value){
-        return value != null ? (+value) : NaN;  // to Number works for dates as well
-    }
-  
-    pentaho.trends.define('linear', {
-        label: 'Linear trend',
-        model: function(options){
-            var rowsQuery = options.rows;
-            var funX = options.x;
-            var funY = options.y;
-            
-            var i = 0;
-            var N = 0;
-            var sumX  = 0;
-            var sumY  = 0;
-            var sumXY = 0;
-            var sumXX = 0;
-            
-            while(rowsQuery.next()){
-                var row = rowsQuery.item;
-                
-                // Ignore null && NaN values
-                var x = funX ? parseNum(funX(row)) : i; // use the index itself for discrete stuff
-                if(!isNaN(x)){
-                    var y = parseNum(funY(row));
-                    if(!isNaN(y)){
-                        N++;
-                        
-                        sumX  += x;
-                        sumY  += y;
-                        sumXY += x * y;
-                        sumXX += x * x;
-                    }
-                }
-                
-                i++; // Discrete nulls must still increment the index
-            }
-            
+        // y = alpha + beta * x
+        if(N >= 2) {
+          var avgX  = sumX  / N,
+              avgY  = sumY  / N,
+              avgXY = sumXY / N,
+              avgXX = sumXX / N,
+
+              // When N === 1 => den = 0
+              den = (avgXX - avgX * avgX),
+
+              beta = den && ((avgXY - (avgX * avgY)) / den),
+
+              alpha = avgY - beta * avgX;
+
+          return {
+            alpha: alpha,
+            beta:  beta,
+            reset: function() {},
+
             // y = alpha + beta * x
-            var alpha, beta;
-            if(N >= 2){
-                var avgX  = sumX  / N;
-                var avgY  = sumY  / N;
-                var avgXY = sumXY / N;
-                var avgXX = sumXX / N;
-            
-                // When N === 1 => den = 0
-                var den = (avgXX - avgX * avgX);
-                if(den === 0){
-                    beta = 0;
-                } else {
-                    beta = (avgXY - (avgX * avgY)) / den;
-                }
-                
-                alpha = avgY - beta * avgX;
-                
-                return {
-                    alpha: alpha,
-                    beta:  beta,
-                    
-                    reset: function(){},
-                    
-                    // y = alpha + beta * x
-                    sample: function(x){
-                        return alpha + beta * (+x);
-                    }
-                };
-            }
+            sample: function(x) { return alpha + beta * (+x); }
+          };
         }
+      }
     });
-    
+
 }());

--- a/package-res/resources/web/vizapi/VizController.js
+++ b/package-res/resources/web/vizapi/VizController.js
@@ -92,7 +92,7 @@ pentaho.palettes.push( {
  */
 pentaho.visualizations = pentaho.visualizations || [];
 
-pentaho.visualizations.getById = function(id){
+pentaho.visualizations.getById = function(id) {
   for(var i = 0; i < this.length ; i++){
     if(this[i].id == id){
       return this[i];
@@ -105,18 +105,16 @@ pentaho.visualizations.getById = function(id){
 var visualizations = pentaho.visualizations;
 
 /*
- pentaho.VizController
+    pentaho.VizController
  The visualization controller
  */
 pentaho.VizController = function(id) {
   this.id = id;
   this.domNode = null;
   this.isDragging = false;
-  this.combinations = [];
   this.selections = [];
   this.highlights = [];
   this.metrics = null;
-  this.origTable = null;
   this.dataTable = null;
   this.currentViz = null;
   this.currentAction = 'select';
@@ -153,14 +151,14 @@ pentaho.VizController.prototype.getState = function() {
   try {
     var state = {};
 
-    if( this.currentViz ) {
+    if(this.currentViz) {
       state.vizId = this.currentViz.id;
-      if( this.chart.getState ) {
+      if(this.chart.getState) {
         state.vizState = this.chart.getState();
       }
     }
     return state;
-  } catch (e) {
+  } catch(e) {
     this.lastError = e;
     return null;
   }
@@ -170,8 +168,8 @@ pentaho.VizController.prototype.getState = function() {
  setState
  Sets the state of the controller and the visualization
 
- state       A state object
- returns     true if there were no errors
+ state    A state object
+ returns  true if there were no errors
  */
 pentaho.VizController.prototype.setState = function(state) {
   try {
@@ -194,7 +192,7 @@ pentaho.VizController.prototype.setState = function(state) {
     dojo.safeMixin(this.currentViz, state);
 
     if( this.chart && this.chart.setState ) {
-      this.chart.setState( state.vizState );
+      this.chart.setState(state.vizState);
     }
     return true;
   } catch (e) {
@@ -210,16 +208,16 @@ pentaho.VizController.prototype.setState = function(state) {
  node    HTML DOM element
  returns     true if there were no errors
  */
-pentaho.VizController.prototype.setDomNode = function( node ) {
+pentaho.VizController.prototype.setDomNode = function(node) {
   try {
-    this.domNode = node;
+  this.domNode = node;
 
     // Empty out the node
     while(node.firstChild) {
       node.removeChild(node.firstChild);
     }
 
-    // Create an empty DIV for the visualization to render in
+  // Create an empty DIV for the visualization to render in
     var width = this.domNode.offsetWidth;
     var height = this.domNode.offsetHeight;
     this.visualPanelElement = document.createElement("DIV");
@@ -242,7 +240,7 @@ pentaho.VizController.prototype.setDomNode = function( node ) {
  */
 pentaho.VizController.prototype.setDataTable = function(table) {
   try {
-    this.origTable = table;
+    this.dataTable = table;
     this.setupTable();
     return true;
   } catch (e) {
@@ -258,7 +256,7 @@ Sets the color mappings for members in the current data table
 colors     Map of attributes/measures in the table to a map of member to color mappings
 */
 pentaho.VizController.prototype.setMemberPalette = function(colors) {
- this.memberPalette = colors;
+  this.memberPalette = colors;
 }
 
 /*
@@ -277,7 +275,7 @@ The structure of this argument is like the following:
     }
 */
 pentaho.VizController.prototype.setFormatInfo = function(formatInfo) {
- this.formatInfo = formatInfo;
+  this.formatInfo = formatInfo;
 }
 
 /*
@@ -299,7 +297,7 @@ pentaho.VizController.prototype.setTitle = function(title) {
  */
 pentaho.VizController.prototype.setVisualization = function(visualization, options) {
   try {
-    if( this.currentViz && this.currentViz['class'] != visualization['class'] ) {
+    if(this.currentViz && this.currentViz['class'] != visualization['class']) {
       // remove the old visualization
       this.setDomNode(this.domNode);
     }
@@ -307,7 +305,7 @@ pentaho.VizController.prototype.setVisualization = function(visualization, optio
     // dipslay the new visualization
     this.doVisualization(visualization, options);
     return true;
-  } catch (e) {
+  } catch(e) {
     this.lastError = e;
     return false;
   }
@@ -359,48 +357,48 @@ pentaho.VizController.prototype.doVisualization = function( visualization, userD
       controller: this,
       action: this.currentAction,
       selections: this.highlights
-    };
+};
 
     if( visualization.needsColorGradient ) {
       var gradMap = [ [255,0,0],[255,255,0],[0,0,255],[0,255,0] ];
-//            var idx = document.getElementById('colorGradient1Select').selectedIndex;
+    // var idx = document.getElementById('colorGradient1Select').selectedIndex;
       options.color1 = gradMap[0];
-//            idx = document.getElementById('colorGradient2Select').selectedIndex;
+    // idx = document.getElementById('colorGradient2Select').selectedIndex;
       options.color2 = gradMap[3];
-    }
+  }
 
 
     // see if we have additional properties to set
     var propMap = visualization.propMap;
-    if(propMap) {
-      for(var propNo=0; propNo<propMap.length; propNo++) {
-        var prop = propMap[propNo];
-        var propValue = null;
-        if( prop.source == 'columnlabel') {
-          propValue = currentView.getColumnLabel(prop.position);
+  if(propMap) {
+    for(var propNo=0; propNo<propMap.length; propNo++) {
+      var prop = propMap[propNo];
+      var propValue = null;
+      if(prop.source == 'columnlabel') {
+        propValue = currentView.getColumnLabel(prop.position);
         }
         if( prop.source == 'maxvalue') {
-          propValue = this.metrics[prop.position].range.max;
+        propValue = this.metrics[prop.position].range.max;
         }
         if( prop.source == 'minvalue') {
-          propValue = this.metrics[prop.position].range.min;
-        }
+        propValue = this.metrics[prop.position].range.min;
+      }
         var obj = options;
-        for( var nameNo=0; nameNo<prop.name.length; nameNo++) {
-          if(nameNo < prop.name.length-1) {
-            // make sure the parent parts exist
-            if( !obj[prop.name[nameNo]] ) {
-              obj[prop.name[nameNo]] = {};
-            }
+      for(var nameNo = 0; nameNo < prop.name.length; nameNo++) {
+        if(nameNo < prop.name.length - 1) {
+          // make sure the parent parts exist
+          if(!obj[prop.name[nameNo]]) {
+            obj[prop.name[nameNo]] = {};
+          }
             obj = obj[prop.name[nameNo]]
           }
           else {
-            // we are at the end
-            obj[prop.name[nameNo]] = propValue;
-          }
+          // we are at the end
+          obj[prop.name[nameNo]] = propValue;
         }
       }
     }
+  }
 
     if(visualization.args) {
       for(var x in visualization.args) {
@@ -438,7 +436,7 @@ pentaho.VizController.prototype.doVisualization = function( visualization, userD
       alert('No suitable dataset');
       document.getElementById('chart_div').innerHTML = '';
       return;
-    }
+  }
 
     try {
       this.chart.draw(currentView, options);
@@ -525,13 +523,13 @@ pentaho.VizController.prototype.processHighlights = function(args) {
         }
 
         if( rowItemsSame && colItemsSame && this.highlights[hNo].colId && this.highlights[hNo].colId == colId && this.highlights[hNo].type == 'column' && selectedItem.type == 'cell') {
-          // switch this
+              // switch this
           this.highlights[hNo].type = 'row';
-          highlight.id = selectedItem.rowId;
-          highlight.value = rowItem;
-          modified = true;
-          break;
-        }
+              highlight.id    = selectedItem.rowId;
+              highlight.value = rowItem;
+              modified = true;
+              break;
+            }
         else if( rowItemsSame && colItemsSame && this.highlights[hNo].colId && this.highlights[hNo].colId == colId && this.highlights[hNo].type == 'column') {
           // remove this
           this.highlights.splice( hNo, 1 );
@@ -539,10 +537,10 @@ pentaho.VizController.prototype.processHighlights = function(args) {
           break;
         }
         else if( rowItemsSame && colItemsSame ) {
-          // remove this
-          this.highlights.splice( hNo, 1 );
-          removed = true;
-          break;
+            // remove this
+            this.highlights.splice( hNo, 1 );
+            removed = true;
+            break;
         }
       }
     }
@@ -567,33 +565,7 @@ pentaho.VizController.prototype.processHighlights = function(args) {
     }
   }
 //    this.updateHighlights();
-}
-
-
-pentaho.VizController.prototype.createCombination = function() {
-
-  // assume the highlighted items are of the same type
-  var type, columnId, values = [];
-  for( var idx=0; idx<this.highlights.length; idx++ ) {
-    if( idx==0) {
-      type = this.highlights[idx].type;
-      values.push(this.highlights[idx].value);
-      columnId = this.highlights[idx].id;
-    }
-    else if(this.highlights[idx].id == columnId) {
-      values.push(this.highlights[idx].value);
-    }
-  }
-  this.combinations.push( {
-    values: values,
-    columnId: columnId
-  });
-  this.setupTable();
-  // now clear the selections
-  this.highlights = [];
-  this.updateVisualization();
-
-}
+};
 
 /*
  updateHighlights
@@ -601,7 +573,7 @@ pentaho.VizController.prototype.createCombination = function() {
  */
 pentaho.VizController.prototype.updateHighlights = function() {
 
-  if( this.chart.setHighlights ) {
+  if(this.chart.setHighlights) {
     this.chart.setHighlights(this.highlights);
   }
 
@@ -617,30 +589,18 @@ pentaho.VizController.prototype.clearSelections = function() {
 
 
 pentaho.VizController.prototype.setupTable = function( ) {
-
-  if(!this.origTable) {
-    return;
-  }
+  if(!this.dataTable) return;
 
   this.metrics = [];
-  this.dataTable = this.origTable;
-
-  // apply any local combinations
-  if( this.combinations && this.combinations.length > 0 ) {
-    var rows = this.origTable.getFilteredRows([{column: 0, combinations: this.combinations}]);
-    var view = new pentaho.DataView(table);
-    view.setRows( rows );
-    this.dataTable = view;
-  }
-
+  
   // get metrics across the entire dataset in case we need them
-  for( var colNo=0; colNo<this.dataTable.getNumberOfColumns(); colNo++) {
-    if( this.dataTable.getColumnType(colNo) == 'string' ) {
+  for(var colNo = 0; colNo < this.dataTable.getNumberOfColumns(); colNo++) {
+    if(this.dataTable.getColumnType(colNo) == 'string') {
       var values = this.dataTable.getDistinctValues(colNo);
-      var paletteMap = pentaho.VizController.createPaletteMap( values, this.palette );
+      var paletteMap = pentaho.VizController.createPaletteMap(values, this.palette);
       // TODO add longest sting length to the metrics
       this.metrics.push({
-        values: values,
+        values:     values,
         paletteMap: paletteMap
       });
     }
@@ -664,13 +624,13 @@ function sort( columnIdx, direction ) {
  createPaletteMap
  Static function to create a palette map
  */
-pentaho.VizController.createPaletteMap = function( items, palette ) {
+pentaho.VizController.createPaletteMap = function(items, palette) {
   var map = {};
-  for(var itemNo=0; itemNo<items.length && itemNo<palette.colors.length; itemNo++) {
+  for(var itemNo = 0; itemNo < items.length && itemNo < palette.colors.length; itemNo++) {
     map[items[itemNo]] = palette.colors[itemNo];
   }
   // are there more items than colors in the palette?
-  for(var itemNo=palette.colors.length; itemNo<items.length; itemNo++) {
+  for(var itemNo = palette.colors.length; itemNo < items.length; itemNo++) {
     map[items[itemNo]] = "#000000";
   }
 
@@ -752,16 +712,16 @@ pentaho.VizController.getRgbStepFromMultiColorHex = function(value, min, max, co
   return pentaho.VizController.getRrbColor(color[0], color[1], color[2]);
 }
 
-pentaho.VizController.convertToRGB = function(hex){
+pentaho.VizController.convertToRGB = function(hex) {
   if(hex.indexOf("#") == 0){
     hex = hex.substring(1);
   } else {
     hex = pentaho.VizController.CSS_Names[hex.toLowerCase()];
   }
   return [
-    parseInt(hex.substring(0,2),16),
-    parseInt(hex.substring(2,4),16),
-    parseInt(hex.substring(4,6),16)
+    parseInt(hex.substring(0, 2), 16),
+    parseInt(hex.substring(2, 4), 16),
+    parseInt(hex.substring(4, 6), 16)
   ];
 }
 

--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -37,6 +37,8 @@ function(def, pvc, pv){
         pentaho.visualizations.push(viz);
     }
 
+    // Null Members:  {v: "...[#null]", f: "Not Available"}
+    // Null Values:   come as a null cell or null cell value ("-" report setting only affects the pivot table view).
     var _nullMemberRe = /\[#null\]$/;
 
     defCCCVisualizations();
@@ -65,7 +67,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 reqs: def.array.appendMany(
                     createDataReq('VERTICAL_BAR', {options: false}),
-                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],                    
+                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],
                     createTrendsDataReqs({separator: true}),
                     [ createChartOptionsDataReq(true) ])
             }],
@@ -102,7 +104,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 reqs: def.array.appendMany(
                     createDataReq('HORIZONTAL_BAR', {options: false}),
-                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],                    
+                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],
                     [ createChartOptionsDataReq(true) ])
             }],
             menuOrdinal: 130,
@@ -186,7 +188,7 @@ function(def, pvc, pv){
                      createLineWidthDataReq()
                     ],
                     createTrendsDataReqs(),
-                    [ 
+                    [
                      createChartOptionsDataReq(true)
                     ]
                 )
@@ -311,7 +313,7 @@ function(def, pvc, pv){
                         createMeaDataReq('VERTICAL_BAR_LINE_NUMLINE'),
                         'id', 'measuresLine',
                         'required', false),
-                    
+
                     createColumnDataLabelsReq({value_anchor: 'VALUE_COLUMN_ANCHOR',   separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}),
                     createLabelsVisibleAnchorDataReq({labels_option: 'lineLabelsOption', value_anchor: 'VALUE_LINE_ANCHOR'}),
                     createMultiDataReq(),
@@ -405,7 +407,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 drillOrder: ['rows','columns'],
                 hyperlinkOrder: ['rows','columns'],
-                reqs : def.array.appendMany(                    
+                reqs : def.array.appendMany(
                     createDataReq("MULTIPLE_PIE", {multi: false, options: false}),
                     [
                         createLabelsVisiblePositionDataReq(),
@@ -559,7 +561,7 @@ function(def, pvc, pv){
                           caption: dropZoneLabel('SUNBURST_SIZE'),
                           required: false,
                           allowMultiple: false
-                      },                      
+                      },
                       createMultiDataReq()],
                       [createLabelsVisibleAnchorDataReq({ hideOptions : ['left', 'right', 'top', 'bottom'] })],
                       createSortDataReqs(true),
@@ -805,7 +807,7 @@ function(def, pvc, pv){
                     }
                 }
             }
-            
+
             return {
                     id: def.get(keyArgs, 'labels_option', 'labelsOption'),
                     dataType: 'string',
@@ -818,11 +820,11 @@ function(def, pvc, pv){
                     }
                 };
         }
-        
+
         function createColumnDataLabelsReq(keyArgs){
-          
+
             var anchors = def.get(keyArgs, 'anchors');
-          
+
             return {
                 id: 'labelsOption',
                 dataType: 'string',
@@ -846,11 +848,11 @@ function(def, pvc, pv){
                     group: 'options',
                     type:  'checkbox',
                     seperator: def.get(keyArgs, 'separator', true),
-                    caption: 'Labels' // TODO i18n pending....                
+                    caption: 'Labels' // TODO i18n pending....
                 }
             };
         }
-        
+
         function createChartOptionsDataReq(hasSeparator){
             return {
                 id: "optionsBtn",
@@ -1427,9 +1429,9 @@ function(def, pvc, pv){
                     visRoles = context.panel.visualRolesOf(cccDimName, /*includeChart*/true);
 
                 if(visRoles && visRoles.some(function(r) { return r.isPercent; })) {
-                    var group = context.scene.group, 
-                        dim   = (group || data).dimensions(cccDimName), 
-                        pct   = group 
+                    var group = context.scene.group,
+                        dim   = (group || data).dimensions(cccDimName),
+                        pct   = group
                             ? dim.percentOverParent({visible: true})
                             : dim.percent(atom.value);
 
@@ -2259,9 +2261,8 @@ function(def, pvc, pv){
             for(var tr = 0; tr < rowCount; tr++) {
                 var row = new Array(colCount);
 
-                for(tc = 0 ; tc < colCount ; tc++){
-                    row[tc] = this._getTableCell(tr, tc);
-                }
+                tc = -1;
+                while(++tc < colCount) row[tc] = this._dataTable.getCell(tr, tc);
 
                 table[tr] = row;
             }
@@ -2382,8 +2383,8 @@ function(def, pvc, pv){
                                         }
 
                                         // Copy map values to ColorMap
-                                        // All color maps are joined together and there will be no 
-                                        // value collisions because the key is prefixed with the name 
+                                        // All color maps are joined together and there will be no
+                                        // value collisions because the key is prefixed with the name
                                         // of the category
                                         for (var j in map) {
                                             colorMap[j] = map[j];
@@ -2391,11 +2392,11 @@ function(def, pvc, pv){
                                     }
                                 }
                             } else {
-                                colorMap = memberPalette[colorGems[C - 1].formula];    
+                                colorMap = memberPalette[colorGems[C - 1].formula];
                             }
                         } else {
                             // Use measures (M === 1)
-                            
+
                             /*
                              * "[Measures].[MeasuresLevel]": {
                              *    "[MEASURE:0]": "violet",
@@ -2449,11 +2450,11 @@ function(def, pvc, pv){
                                         var keys     = compKey.split("~"),
                                             level    = keys.length - 1,
                                             keyLevel = keys[level];
-                                        
+
                                         // Obtain color for most specific key from color map.
                                         // If color map has no color and it is the 1st level,
                                         //  then reserve a color from the default color scale.
-                                        // Otherwise, return undefined, 
+                                        // Otherwise, return undefined,
                                         //  meaning that a derived color should be used.
                                         return def.getOwn(colorMap, keyLevel) ||
                                             (level ? undefined : defaultScale(keyLevel));
@@ -2857,7 +2858,7 @@ function(def, pvc, pv){
             }
         },
 
-        _limitSelection: function(selections){
+        _limitSelection: function(selections) {
             // limit selection
             var filterSelectionMaxCount = this._vizOptions['filter.selection.max.count'] || 200;
             var selections2 = selections;
@@ -2871,10 +2872,10 @@ function(def, pvc, pv){
                 for(var i = 0 ; i < L ; i++){
                     var selection = selections[i];
                     var keep = true;
-                    if(deselectCount){
-                        if(this._previousSelectionKeys){
+                    if(deselectCount) {
+                        if(this._previousSelectionKeys) {
                             var key = this._getSelectionKey(selection);
-                            if(!this._previousSelectionKeys[key]){
+                            if(!this._previousSelectionKeys[key]) {
                                 keep = false;
                             }
                         } else if(i >= filterSelectionMaxCount) {
@@ -2882,12 +2883,12 @@ function(def, pvc, pv){
                         }
                     }
 
-                    if(keep){
+                    if(keep) {
                         selections2.push(selection);
                     } else {
                         var datums = selection.__cccDatums;
-                        if(datums){
-                            if(def.array.is(datums)){
+                        if(datums) {
+                            if(def.array.is(datums)) {
                                 def.array.append(deselectDatums, datums);
                             } else {
                                 deselectDatums.push(datums);
@@ -3019,11 +3020,11 @@ function(def, pvc, pv){
             }
 
             function addDatum(datum) {
-                if(!datum.isNull){
+                if(!datum.isNull) {
                     if(datum.isTrend){
-                        // Some trend datums, like those of the scatter plot,
-                        // don't have anything distinguishing between them,
-                        // so we need to explicitly add them to the output.
+                    // Some trend datums, like those of the scatter plot,
+                    // don't have anything distinguishing between them,
+                    // so we need to explicitly add them to the output.
                         outDatums.push(datum);
                     }
 
@@ -3107,28 +3108,6 @@ function(def, pvc, pv){
                 colLabel: colLabel,
                 colType:  colType
             });
-        },
-
-        _getTableCell: function(tr, tc) {
-            var cell = this._dataTable._getCell(tr, tc);
-            if(!cell){
-                return null;
-            }
-
-            var value = cell.v;
-            if(value == null || value === '-') {
-                return null;
-            }
-
-            return {
-                v: value,
-                f: cell.f
-            };
-        },
-
-        _getTableValue: function(tr, tc) {
-            var cell = this._getTableCell(tr, tc);
-            return cell ? cell.v : ceff.f;
         }
     });
 
@@ -3294,12 +3273,12 @@ function(def, pvc, pv){
 
             configureColumnLabelsAlignmentOptions.call(this);
         },
-        
+
         _readUserOptions: function(options, vizOptions) {
             this.base(options, vizOptions);
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.label_textStyle = vizOptions.labelColor;
-        }        
+        }
     });
 
     // -------------------
@@ -3427,7 +3406,7 @@ function(def, pvc, pv){
 
             options.plot2ValuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.plot2Label_textStyle = vizOptions.labelColor;
-            
+
             configureLabelsOptions.call(this);
         },
 
@@ -3447,7 +3426,7 @@ function(def, pvc, pv){
             this._configureAxisTitle('ortho2',"");
 
             this.options.plot2OrthoAxis = 2;
-            
+
             configureLineLabelsAlignmentOptions.call(this);
 
             // Plot2 uses same color scale
@@ -3487,7 +3466,7 @@ function(def, pvc, pv){
                 options.dotsVisible = true;
                 options.extensionPoints.dot_shape = shape;
             }
-            
+
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.label_textStyle = vizOptions.labelColor;
 
@@ -3608,7 +3587,7 @@ function(def, pvc, pv){
 
             configureLabelsAnchorOptions.call(this);
         },
-        
+
         _readUserOptions: function(options, vizOptions) {
             this.base(options, vizOptions);
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
@@ -3975,7 +3954,7 @@ function(def, pvc, pv){
             // configure value label
             if(this.options.valuesVisible){
                 this._configureValuesMask();
-            }            
+            }
         },
 
         _showLegend: function(){
@@ -4215,14 +4194,14 @@ function(def, pvc, pv){
                         var th = m.height * 0.85, // tight text bounding box
                             tb = pvLabel.textBaseline(),
                             // The effective height of text that must be covered.
-                            // one text margin, for the anchor, 
+                            // one text margin, for the anchor,
                             // half text margin for the anchor's opposite side.
                             // All on only one of the sides of the wedge.
                             thEf = 2 * (th + 3*tm/2);
 
                         // Minimum inner radius whose straight-arc has a length `thEf`
                         irmin = Math.max(
-                            irmin, 
+                            irmin,
                             thEf / (2 * Math.tan(a / 2)));
                     }
 
@@ -4240,7 +4219,7 @@ function(def, pvc, pv){
                     // Continue with normal processing for the main label.
                     return null;
                 };
-                
+
                 var me = this;
                 eps.label_add = function() {
                     return new pv.Label()
@@ -4250,8 +4229,8 @@ function(def, pvc, pv){
                         })
                         .text(function(scene) {
                             var pvMainLabel = this.proto;
-                            return !pvMainLabel.text() 
-                                ? "" 
+                            return !pvMainLabel.text()
+                                ? ""
                                 : me._formatSize(scene.vars.size, scene.firstAtoms.size.dimension);
                         })
                         .textBaseline("top");
@@ -4359,11 +4338,11 @@ function(def, pvc, pv){
                     // Normal relational part
                         category, // aggregated category
                         dtColParts.join('~'), // series label
-                        this._getTableValue(tr, tc),  // series value - may be null...is it ok?
+                        this._dataTable.getValue(tr, tc), // series value - may be null...is it ok?
 
                         // Marker - may be missing on the last measure pair
                         m + 1 < measuresCount ?
-                        this._getTableValue(tr, measureCols[markerColIndex]) :
+                        this._dataTable.getValue(tr, measureCols[markerColIndex]) :
                         vizOptions.bulletMarkers[0] // TODO: 7500
                     ];
 
@@ -4383,8 +4362,8 @@ function(def, pvc, pv){
 
     oldCccChart._aggregateRowAxisForTableRow = function(tr) {
         // Concat all of the string columns
-        var values = this._rowNormalDtColIndexes.map(function(tc){
-            return this._getTableValue(tr, tc);
+        var values = this._rowNormalDtColIndexes.map(function(tc) {
+            return this._dataTable.getValue(tr, tc);
         }, this);
 
         return values.join('~');
@@ -4514,13 +4493,13 @@ function(def, pvc, pv){
 
         // Set Values Visible
         if(this._vizOptions.labelsVisible) {
-            this.options.valuesVisible = this._vizOptions.labelsVisible;    
+            this.options.valuesVisible = this._vizOptions.labelsVisible;
         }
 
         if (this._vizOptions.labelsAnchor) {
-            this.options.valuesAnchor = this._vizOptions.labelsAnchor;    
+            this.options.valuesAnchor = this._vizOptions.labelsAnchor;
         }
-        
+
         if (this._vizOptions.labelsTextAlign) {
              if (!this.options.extensionPoints) {
                 this.options.extensionPoints = {};
@@ -4537,7 +4516,7 @@ function(def, pvc, pv){
 
         if(!this._vizOptions.labelsOption || this._vizOptions.labelsOption == 'none') {
             return this.options.valuesVisible = false;
-        } 
+        }
 
         return this.options.valuesVisible = true;
     }
@@ -4549,7 +4528,7 @@ function(def, pvc, pv){
         }
     }
 
-    
+
     function configureColumnLabelsAlignmentOptions() {
         if (configureLabelsVisibilityOptions.call(this)) {
             if (!this.options.extensionPoints) {
@@ -4559,7 +4538,7 @@ function(def, pvc, pv){
             var labelsOption = this._vizOptions.labelsOption;
 
             this.options.extensionPoints.label_textMargin = 7;
-            
+
             if(labelsOption == 'center') {
                 this.options.valuesAnchor = 'center';
             }
@@ -4588,7 +4567,7 @@ function(def, pvc, pv){
             }
         }
     }
-    
+
     function configureLineLabelsAlignmentOptions() {
         var lineLabelsOption = this._vizOptions.lineLabelsOption;
         if(lineLabelsOption && lineLabelsOption != 'none') {

--- a/package-res/resources/web/vizapi/ccc/sample/sampleVisualization.js
+++ b/package-res/resources/web/vizapi/ccc/sample/sampleVisualization.js
@@ -18,53 +18,50 @@
 require(["common-ui/vizapi/VizController"], function(){
 
   pentaho.visualizations.push({
-    id: 'sample_calc',                          // unique identifier
-    type: 'calc',                       // generic type id
-    source: 'Sample',                          // id of the source library
-    name: 'Sample Calculation',                     // visible name, this will come from a properties file eventually
-    'class': 'pentaho.sample.Calc',          // type of the Javascript object to instantiate
-    args: {                                 // arguments to provide to the Javascript object
-
-    },
+    id:      'sample_calc',         // unique identifier
+    type:    'calc',                // generic type id
+    source:  'Sample',              // id of the source library
+    name:    'Sample Calculation',  // visible name, this will come from a properties file eventually
+    'class': 'pentaho.sample.Calc', // type of the Javascript object to instantiate
+    args:    {},                    // arguments to provide to the Javascript object
     propMap: [],
-    dataReqs: [                             // dataReqs describes the data requirements of this visualization
+    dataReqs: [                     // dataReqs describes the data requirements of this visualization
       {
         name: 'Default',
-        reqs :
-            [
-              {
-                id: 'rows',             // id of the data element
-                dataType: 'string',         // data type - 'string', 'number', 'date', 'boolean', 'any' or a comma separated list
-                dataStructure: 'column',    // 'column' or 'row' - only 'column' supported so far
-                caption: 'Level',        // visible name
-                required: true,              // true or false
-                allowMultiple: false,
-                ui: {
-                  group: "data"
-                }
-              },
-              {   id: 'measures',
-                dataType: 'number',
-                dataStructure: 'column',
-                caption: 'Measure',
-                required: true,
-                allowMultiple: false,
-                ui: {
-                  group: "data"
-                }
-              },
-              {
-                id: 'calc',
-                dataType: 'string',
-                values: ["MIN", "MAX", "AVG"],
-                ui: {
-                  labels: ["Minimum", "Maximum", "Average"],
-                  group: "options",
-                  type: 'combo',
-                  caption: "Calculation"
-                }
-              }
-            ]
+        reqs : [
+          {
+            id: 'rows',              // id of the data element
+            dataType: 'string',      // data type - 'string', 'number', 'date', 'boolean', 'any' or a comma separated list
+            dataStructure: 'column', // 'column' or 'row' - only 'column' supported so far
+            caption: 'Level',        // visible name
+            required: true,          // true or false
+            allowMultiple: false,
+            ui: {
+              group: "data"
+            }
+          },
+          {   id: 'measures',
+            dataType: 'number',
+            dataStructure: 'column',
+            caption: 'Measure',
+            required: true,
+            allowMultiple: false,
+            ui: {
+              group: "data"
+            }
+          },
+          {
+            id: 'calc',
+            dataType: 'string',
+            values: ["MIN", "MAX", "AVG"],
+            ui: {
+              labels: ["Minimum", "Maximum", "Average"],
+              group: "options",
+              type: 'combo',
+              caption: "Calculation"
+            }
+          }
+        ]
       }
     ]
   });
@@ -77,43 +74,40 @@ require(["common-ui/vizapi/VizController"], function(){
     this.numSpan.style.fontSize = "42px";
     this.numSpan.style.position = "relative";
     this.canvasElement.appendChild(this.numSpan);
-
-  }
-  pentaho.sample.Calc.prototype.resize = function(width, height){
-    this.numSpan.style.left = ((this.canvasElement.offsetWidth - this.numSpan.offsetWidth) / 2) + "px"
-    this.numSpan.style.top = ((this.canvasElement.offsetHeight - this.numSpan.offsetHeight) / 2) + "px"
   };
 
-  pentaho.sample.Calc.prototype.draw = function(datView, vizOptions) {
-    var rows = datView.dataTable.jsonTable.rows;
-    var dataArray = [];
-    for(var i=0; i<rows.length; i++){
-      dataArray.push(rows[i].c[1].v);
-    }
+  pentaho.sample.Calc.prototype.resize = function(width, height) {
+    this.numSpan.style.left = ((this.canvasElement.offsetWidth  - this.numSpan.offsetWidth ) / 2) + "px";
+    this.numSpan.style.top  = ((this.canvasElement.offsetHeight - this.numSpan.offsetHeight) / 2) + "px";
+  };
+
+  pentaho.sample.Calc.prototype.draw = function(dataTable, vizOptions) {
+    // TODO: R === 0
+    // TODO: null values
+
+    var R = dataTable.getNumberOfRows(),
+        getValue = function(k) { return dataTable.getValue(k, 1); },
+        i;
+
     var value = 0;
-    switch(vizOptions.calc){
+    switch(vizOptions.calc) {
       case "MAX":
-        for(var i=0; i< dataArray.length; i++){
-          value = Math.max(value, dataArray[i]);
-        }
+        for(i = 0; i < R; i++) value = Math.max(value, getValue(i));
         break;
+
       case "MIN":
-        for(var i=0; i< dataArray.length; i++){
-          value = Math.min(value, dataArray[i]);
-        }
+        for(i = 0; i < R; i++) value = Math.min(value, getValue(i));
         break;
+
       case "AVG":
         var total = 0;
-        for(var i=0; i< dataArray.length; i++){
-          total += dataArray[i];
-        }
-        value = total / dataArray.length;
+        for(i = 0; i < R; i++) total += getValue(i);
+        value = total / R;
         break;
-      default:
-
     }
 
     this.numSpan.innerHTML = value;
+
     this.resize();
-  }
+  };
 });


### PR DESCRIPTION
* Refactoring and YUI Doc Documentation
* Removed DataView combinations feature and VizController.createCombination
* Removed DataTable.makePostable
* Renamed some DataTable and DataView properties to become private ("_")
* Removed DataTable.className and DataView.className (use instance instead)
* CCC_wrapper - removed unnecessary cell value translation from "-" to null. The "-" marker is used only in the PivotTable view.
* Sample visualization: refactored the code to not use private DataTable details.
* Added lint option to YUIDoc config.

Unit testing will come in a future PR.
Sorry for all the white-space changes. I've read somewhere that adding ?w=1 to the url will present diffs that ignore whitespace changed (untested).

@pminutillo please review.