### PR TITLE
[CLEANUP] Karma baseUrl and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,16 @@ lib/
 codegen-lib/
 test-lib/
 eclipse-bin/
+doc-js
+build-res/module-scripts/
+build-res/requireCfg-raw.js
+build-res/requireCfg.js
+build-res/pentaho-js-build/
+test-res/data/sampledata.log
+dev-res/dojo/
+node_modules/
 override.properties
+pentaho.log
 .classpath
 .project
 .idea

--- a/config/require-config.js
+++ b/config/require-config.js
@@ -6,7 +6,7 @@ var tests = Object.keys(window.__karma__.files).filter(function (file) {
 requireCfg['deps'] = tests;
 
 
-requireCfg['baseUrl'] = 'base/build-res/module-scripts/';
+requireCfg['baseUrl'] = '/base/build-res/module-scripts/';
 
 requireCfg['paths']['test/karma/unit/angular-directives'] = "../../package-res/resources/web/test/karma/unit/angular-directives";
 


### PR DESCRIPTION
* Fixed karma require config baseUrl to not cause the "no timestamp" error message
* Added common temporary stuff to .gitignore

@pminutillo please review. This is to restore tests and coverage to the common-ui master branch. 