### PR TITLE
[BACKLOG-2467] - Implement a standard method for registering Javascript plugin objects

### DIFF
--- a/build-res/subfloor-js.xml
+++ b/build-res/subfloor-js.xml
@@ -139,7 +139,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           </fileset>
         </path>
         <echo message="Collecting RequireJS Configurations"/>
-        <echo message="var requireCfg={paths:{},shim:{}};" file="build-res/requireCfg-raw.js" append="false"/>
+        <echo message="var requireCfg={paths: {}, shim: {}, map: {&quot;*&quot;: {}}, bundles: {}, config: {service: {}}, packages: []};" 
+              file="build-res/requireCfg-raw.js" append="false" />
         <concat destfile="build-res/requireCfg-raw.js" append="true" force="yes">
           <fileset dir="${js.module.script.agg.dir}" casesensitive="yes">
             <include name="*/*-require-js-cfg.js"/>

--- a/config/context.js
+++ b/config/context.js
@@ -13,14 +13,16 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 Pentaho Corporation. All rights reserved.
+ * Copyright 2015 Pentaho Corporation. All rights reserved.
  */
-
-requireCfg = {
+var requireCfg = {
     paths: {},
-    shim: {}
+    shim:  {},
+    map:   {"*": {}},
+    bundles:  {},
+    config:   {service: {}},
+    packages: []
 };
 var KARMA_RUN = true;
-
 var pen = {define : define, require : require};
 var SESSION_LOCALE="en";

--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 var prefix = (typeof CONTEXT_PATH != "undefined") ? CONTEXT_PATH + 'content/common-ui/resources/web' :
     (typeof KARMA_RUN != "undefined") ? "../../package-res/resources/web" :"common-ui"; //prod vs build
@@ -27,6 +26,7 @@ requireCfg['paths']['pentaho/common'] = prefix+'/dojo/pentaho/common';
 
 
 requireCfg['paths']['local'] = prefix+'/util/local';
+requireCfg['paths']['service'] = prefix+'/util/service';
 
 requireCfg['paths']['common-repo'] = prefix+'/repo';
 //requireCfg['paths']['common-repo/pentaho-ajax'] = prefix+'/repo/pentaho-ajax';

--- a/package-res/resources/web/util/service.js
+++ b/package-res/resources/web/util/service.js
@@ -1,0 +1,107 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * RequireJS Plugin which maintains a collection of Logical Modules and
+ * their dependencies.
+ * The dependency list for these logical modules or Dynamic Modules is described in
+ * the RequireJS Config object.
+ *
+ * Scripts require logical modules by name as the argument to this plugin
+ * (`"service!LOGICAL_MODULE_NAME"`).
+ * An array of the module dependencies is passed to the loading function.
+ *
+ * Combined, these capabilies form a simple plugin mechanism.
+ *
+ * @example
+ * Load all Home Screen modules
+ *
+ *     require.config({
+ *       config: {
+ *         "system": {
+ *           "myModule/myHomeScreenModule":    "IHomeScreen",
+ *           "anotherModule/homeScreenPlugin": "IHomeScreen"
+ *         }
+ *       }
+ *     });
+ *
+ *     require(["service!IHomeScreen"], function(arrayOfHomeScreenModules) {
+ *
+ *     });
+ */
+define(["module"], function(module) {
+  "use strict";
+
+  var A_slice  = Array.prototype.slice,
+      O_hasOwn = Object.prototype.hasOwnProperty,
+
+      /**
+       * Map from logical module names to an array of physical module dependencies.
+       * @type Array.<string[]>
+       */
+      logicalModules = {};
+
+  processConfig();
+
+  return {
+    load: loadLogicalModule
+  };
+
+  /**
+   * RequireJS Plugin `load` function.
+   *
+   * @param {String} name The name of the logical module to load.
+   * @param {function} require The global require function.
+   * @param {function} onLoad Callback function to call once all of the
+   *   the logical module's dependencies are satisfied.
+   * @param {Object} config The full require-JS config object.
+   */
+  function loadLogicalModule(name, require, onLoad, config) {
+    if(config.isBuild) {
+      // Resolved dynamically in the browser.
+      onLoad();
+    } else {
+      // Require all of the logical module's dependencies.
+      require(getLogicalModule(name), function() {
+        // Pass the resolved modules to the original onLoad function.
+        onLoad(A_slice.call(arguments));
+      });
+    }
+  }
+
+  /**
+   * Gets a dynamic module definition, creating it if necessary.
+   *
+   * @param logicalModuleName The name of the logical module.
+   * @returns {Array} An array of physical modules that
+   *    implement the logical module.
+   */
+  function getLogicalModule(logicalModuleName) {
+    return logicalModules[logicalModuleName] ||
+          (logicalModules[logicalModuleName] = []);
+  }
+
+  /**
+   * Processes the plugin configuration
+   * to extract logical module mappings.
+   */
+  function processConfig() {
+    var config = module.config();
+    for(var absModuleId in config)
+      if(O_hasOwn.call(config, absModuleId))
+        getLogicalModule(config[absModuleId]).push(absModuleId);
+  }
+});


### PR DESCRIPTION
* Initial **basic** implementation adapted from Nick's prototype.
* Adding common Require-JS properties to the `requireCfg` object
   * Also includes an `requireCfg.config.service` object, for easier configuration of the proposed AMD plugin, whose AMD module id is `service`.
   * Here, just changing `subfloor-js.xml` and `config/context.js` (used for testing); but there's a corresponding commit in "pentaho-platform/extensions", to affect the generation of `webcontext.js`.
   * I know changing "subfloor-js.xml" is always temporary - this commit would serve to propose the change to ENGOPS.

@pentaho-nbaker please review.