### PR TITLE
[CLEANUP] Stop building JavaScript in common-ui (build-js), as the outpu...

### DIFF
--- a/build-res/javascript.build.js
+++ b/build-res/javascript.build.js
@@ -32,10 +32,5 @@
 
 
   modules: [
-    {
-      name: "angular-directives",
-      include: ["common-ui/angular-directives/angular-directives"],
-      create: true
-    }
   ]
 })

--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,10 @@
 <!--===========================================================================
   This is the build file for the Pentaho Common UI Project
-  
+
   This build file will use the subfloor.xml file as the default build
   process and should only override the tasks that need to differ from
   the common build file.
-  
+
   See subfloor.xml for more details
 ============================================================================-->
 <project name="Pentaho Commons UI" basedir="." default="dist"
@@ -81,7 +81,7 @@
               description="production dojo staging directory"/>
 
 
-    <target name="dist" depends="jar, build-js, dist-js" description="Creates a distribution">
+    <target name="dist" depends="jar, dist-js" description="Creates a distribution">
     </target>
 
     <!-- sets up the project for development/build, you should only need to run this once -->
@@ -144,13 +144,6 @@
     <target name="assemble-plugin">
 
         <property environment="env"/>
-
-        <!-- overlay the built angular-directives js module -->
-        <copy todir="${web.prod.stage.dir}/angular-directives" overwrite="true">
-            <fileset dir="${js.build.output.dir}">
-                <include name="angular-directives.js"/>
-            </fileset>
-        </copy>
 
         <copy todir="${approot.stage.dir}/resources/web/dojo/dojo" overwrite="true">
             <fileset dir="${dojo.src}/dojo"/>


### PR DESCRIPTION
...t is not being used and some files are causing errors in the build.

Essentially, undoing excerpts from the following commits:
* https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/167ecb8dd9bfae79ea41373a2e10ddf5d721616a
* https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/5235d82cc0c3ef98e8648277dc04e109009363f3#diff-2cccd7bf48b7a9cc113ff564acd802a8R84

@pentaho-nbaker please review.