### PR TITLE
[BACKLOG-2540] - AMD Conversion - Adding AMD Module ids to documentation

### DIFF
--- a/package-res/resources/web/vizapi/colorPaletteRegistry.js
+++ b/package-res/resources/web/vizapi/colorPaletteRegistry.js
@@ -51,6 +51,14 @@ define(function() {
    * A singleton class that manages a set of discrete color palettes
    * available for visualizations to consume.
    *
+   * #### AMD
+   *
+   * **Module Id**: `"common-ui/vizapi/colorPaletteRegistry"`
+   *
+   * **Module Type**: {{#crossLink "ColorPaletteRegistry"}}{{/crossLink}}
+   *
+   * #### Standard Color Palettes
+   *
    * The registry comes pre-loaded with three color palettes:
    * 1. `"palette 1"` (13 colors):
    * <table style="font-family:courier; width:120px;">
@@ -122,8 +130,8 @@ define(function() {
     if(!palette) throw new Error("Argument required 'palette'.");
 
     var name = palette.name,
-        current = O_hasOwn.call(this._paletteMap, name) ? this._paletteMap[name] : null; 
-    
+        current = O_hasOwn.call(this._paletteMap, name) ? this._paletteMap[name] : null;
+
     if(!current)
       this._paletteList.push(palette);
     else

--- a/package-res/resources/web/vizapi/data/AbstractDataTable.js
+++ b/package-res/resources/web/vizapi/data/AbstractDataTable.js
@@ -21,6 +21,12 @@ define(function() {
   /**
    * An _AbstractDataTable_ represents a set of tabular data.
    *
+   * #### AMD
+   *
+   * **Module Id**: `"common-ui/vizapi/data/AbstractDataTable"`
+   *
+   * **Module Type**: The {{#crossLink "AbstractDataTable"}}{{/crossLink}} constructor.
+   *
    * @class AbstractDataTable
    * @constructor
    */

--- a/package-res/resources/web/vizapi/data/DataTable.js
+++ b/package-res/resources/web/vizapi/data/DataTable.js
@@ -22,6 +22,14 @@ define(['./AbstractDataTable'], function(AbstractDataTable) {
    * A {{#crossLink "DataTable"}}{{/crossLink}} is a
    * type of table that directly stores tabular data.
    *
+   * #### AMD
+   *
+   * **Module Id**: `"common-ui/vizapi/data/DataTable"`
+   *
+   * **Module Type**: The {{#crossLink "DataTable"}}{{/crossLink}} constructor.
+   *
+   * #### Description
+   *
    * A `DataTable` can be constructed empty, or from either:
    * * a {{#crossLink "AbstractDataTable"}}{{/crossLink}} object,
    *   in which case its data is copied, or

--- a/package-res/resources/web/vizapi/data/DataView.js
+++ b/package-res/resources/web/vizapi/data/DataView.js
@@ -22,6 +22,14 @@ define(['./AbstractDataTable', './DataTable'], function(AbstractDataTable, DataT
    * A **data view** is an object that
    * provides a way to access a subset of a source table.
    *
+   * #### AMD
+   *
+   * **Module Id**: `"common-ui/vizapi/data/DataView"`
+   *
+   * **Module Type**: The {{#crossLink "DataView"}}{{/crossLink}} constructor.
+   *
+   * #### Description
+   *
    * A data view can selectively show rows and/or columns from the source table
    * through use of the
    * {{#crossLink "DataView/setRows:method"}}{{/crossLink}}

--- a/package-res/resources/web/vizapi/vizTypeRegistry.js
+++ b/package-res/resources/web/vizapi/vizTypeRegistry.js
@@ -26,6 +26,12 @@ define(["service!IVizTypeProvider"], function(vizTypeProviders) {
    * A singleton class that manages visualization types
    * of which visualization instances can be created.
    *
+   * #### AMD
+   *
+   * **Module Id**: `"common-ui/vizapi/vizTypeRegistry"`
+   *
+   * **Module Type**: {{#crossLink "VizTypeRegistry"}}{{/crossLink}}
+   *
    * @class VizTypeRegistry
    * @constructor
    */


### PR DESCRIPTION
Had forgotten to document the AMD module Ids of classes/singleton-classes accessible by AMD.

@pminutillo, @DFieldFL please review.