### PR TITLE
[ANALYZER-3023] - JavaScript injection vulnerability

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -913,7 +913,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
           {
             className: "gem",
 
-            templateString: "<div id='${id}' class='${className} dojoDndItem' dndType='${dndType}'><div class='gem-label'>${model.value}</div><div class='gemMenuHandle'></div></div>",
+            templateString: "<div id='${id}' class='${className} dojoDndItem' dndType='${dndType}'><div class='gem-label'><span>${model.value}</span></div><div class='gemMenuHandle'></div></div>",
             constructor: function (options) {
               this.gemBar = options.gemBar;
               this.dndType = options.dndType;


### PR DESCRIPTION
- add <span> element to display escaped characters correctly

@rfellows, can you please review it?
I don't like that '<' and others are displayed as &-code, thus I added ```<span>``` to force browser to show them correctly

/cc @pentaho-nbaker, @mdamour1976  