### PR TITLE
[ANALYZER-3023] - JavaScript injection vulnerability

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -26,10 +26,9 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
   ,"dijit/TitlePane"
   ,"pentaho/common/Messages", "dojo/_base/array", "dojo/_base/lang", "dojo/html", "dojo/dom-construct",
   "dojo/string", "dojo/dom-class", "pentaho/common/propertiesPanel/Configuration", "dijit/registry", "dojo/dnd/Target",
-  "dojo/dnd/Source", "dojo/Evented", "dojo/topic", "dojo/dnd/Manager", "dojo/dom", "dojo/dom-geometry", "dojo/aspect",
-  "dojox/html/entities"],
+  "dojo/dnd/Source", "dojo/Evented", "dojo/topic", "dojo/dnd/Manager", "dojo/dom", "dojo/dom-geometry", "dojo/aspect"],
     function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, on, query, ContentPane, BorderContainer, HorizontalSlider, TextBox, ComboBox, ItemFileReadStore, Select, CheckBox, TitlePane, Messages, array, lang, html, construct, string, domClass, Configuration, registry, Target, Source, Evented, topic, ManagerClass,
-              dom, geometry, aspect, Entities) {
+              dom, geometry, aspect) {
 
       var Panel = declare("pentaho.common.propertiesPanel.Panel",
           [ContentPane, Evented],
@@ -912,13 +911,11 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
           [_WidgetBase, _TemplatedMixin, Evented, StatefulUI],
           {
             className: "gem",
-
-            templateString: "<div id='${id}' class='${className} dojoDndItem' dndType='${dndType}'><div class='gem-label'><span>${model.value}</span></div><div class='gemMenuHandle'></div></div>",
+            templateString: "<div id='${id}' class='${className} dojoDndItem' dndType='${dndType}'><div class='gem-label' title='${model.value}'></div><div class='gemMenuHandle'></div></div>",
             constructor: function (options) {
               this.gemBar = options.gemBar;
               this.dndType = options.dndType;
               this.id = options.id;
-              this.model.value = Entities.encode(this.model.value);
             },
             detach: function () {
               model.detach();
@@ -927,6 +924,9 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               on(this.domNode, "contextmenu", lang.hitch( this,  "onContextMenu"));
               var outterThis = this;
               this.menuHandle = query("div.gemMenuHandle", this.domNode)[0];
+
+              var gemLabel = query("div.gem-label", this.domNode)[0];
+              gemLabel.appendChild(document.createTextNode(this.model.value));
 
               on(query("div.gemMenuHandle",  this.domNode)[0], "mouseover",  function (e) {
                 if (!ManagerClass.manager().source) {

--- a/package-res/resources/web/test/dojo/pentaho/common/propertiesPanel/panelSpec.js
+++ b/package-res/resources/web/test/dojo/pentaho/common/propertiesPanel/panelSpec.js
@@ -15,11 +15,13 @@
  * Copyright 2015 Pentaho Corporation. All rights reserved.
  */
 
-define(["pentaho/common/propertiesPanel/Panel", "dijit/registry"], function(Panel, registry) {
+define(["pentaho/common/propertiesPanel/Panel", "dijit/registry", "dojo/query"], function(Panel, registry, query) {
 
   describe("GemUI", function() {
 
     var testId = 'test-id';
+
+    var gemUi = Panel.registeredTypes["gem"];
 
     afterEach(function() {
       registry.remove(testId);
@@ -37,27 +39,37 @@ define(["pentaho/common/propertiesPanel/Panel", "dijit/registry"], function(Pane
       };
     };
 
-    it("should encode input data to prevent XSS", function() {
-      var options = createStubOptions('<h1>XSS</h1>');
-
-      var gemUi = Panel.registeredTypes["gem"];
-      var encodedModelValue = new gemUi(options).model.value;
-
-      var leftBracketIndex = encodedModelValue.indexOf('<');
-      expect(leftBracketIndex).toEqual(-1);
-
-      var rightBracketIndex = encodedModelValue.indexOf('>');
-      expect(rightBracketIndex).toEqual(-1);
-    });
-
-    it("should not spoil correct input data", function() {
+    it("should put text value to title", function() {
       var value = 'Just a label';
-      var options = createStubOptions(value);
+      var instance = new gemUi(createStubOptions(value));
 
-      var gemUi = Panel.registeredTypes["gem"];
-      var encodedModelValue = new gemUi(options).model.value;
-
-      expect(encodedModelValue).toEqual(value);
+      var gemLabelNode = query("div.gem-label", instance.domNode)[0];
+      expect(gemLabelNode.title).toEqual(value);
     });
+
+    it("should create a text node if html is passed", function() {
+      var value = '<h1>XSS</h1>';
+      var instance = new gemUi(createStubOptions(value));
+
+      var gemLabelNode = query("div.gem-label", instance.domNode)[0];
+
+      var children = gemLabelNode.childNodes;
+      expect(children.length).toEqual(1);
+      expect(children[0].nodeType).toEqual(3);       // nodeType = 3 -> Text node
+      expect(children[0].nodeValue).toEqual(value);
+    });
+
+    it("should not create additional nodes if html is passed", function() {
+      var value = '<h1>XSS</h1>';
+      var instance = new gemUi(createStubOptions(value));
+
+      var gemLabelNode = query("div.gem-label", instance.domNode)[0];
+
+      var children = gemLabelNode.childNodes;
+      for (var i = 0; i < children.length; i++) {
+        expect(children[i].nodeType).not.toEqual(1); // nodeType = 1 -> Element node
+      }
+    });
+
   })
 })


### PR DESCRIPTION
- change the approach: do not encode input, but put it into text node with JS

@rfellows, review it once agains, please :)

I decided to change the approach completely and re-implemented it similarly to how pivot tables work in Analyzer. In this case we do not need to manually encode input, as it is passed to a text node, and that prevents us from misinterpreting tags by browser.

/cc @pentaho-nbaker, @mdamour1976  