### PR TITLE
[ANALYZER-3058] - Memory leaks during multiple changing of chart type

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -248,6 +248,10 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               this.propUIs.forEach(function (widget) {
                 widget.destroyRecursive();
               });
+              for(var gid in this.groups) {
+                this.groups[gid].destroyRecursive();
+              }
+
               this.propUIs = [];
               this.groups = {};
               this.domNode.innerHTML = "";
@@ -269,26 +273,37 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
       );
       Panel.registeredTypes = {};
 
-
       var StatefulUI = declare(
           [],
           {
-            constructor: function (options) {
+            constructor: function(options) {
               this.model = options.model;
               this.propPanel = options.propPanel;
-              var outterThis = this;
-              this.model.watch(function (propName, prevVal, newVal) {
 
-                switch (propName) {
+              var outterThis = this;
+
+              this._watchHandle = this.model.watch(function(propName, prevVal, newVal) {
+                switch(propName) {
                   case "value":
                   case "default":
-                    outterThis.set(propName, newVal);
+                    if(!outterThis._destroyed) outterThis.set(propName, newVal);
                     break;
                 }
               });
             },
-            onUIEvent: function (type, args) {
 
+            onUIEvent: function(type, args) {
+            },
+
+            destroy: function() {
+              this.inherited(arguments);
+
+              this.model = this.propPanel = null;
+
+              if(this._watchHandle) {
+                this._watchHandle.remove();
+                this._watchHandle = null;
+              }
             }
           }
       );
@@ -306,7 +321,6 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
           on(this.dropIndicator, "mouseover", lang.hitch(this, "_redirectMouseOver"));
           on(this.dropIndicator, "mouseup", lang.hitch(this, "_redirectMouseUp"));
           this.node.parentNode.appendChild(this.dropIndicator);
-
         },
 
         _redirectMouseOver: function (e) {
@@ -334,6 +348,11 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             }
 
           }
+        },
+
+        destroy: function() {
+          this.inherited(arguments);
+          this.dropIndicator = this.gemUIbeingInserted = this.gemBar = null;
         },
 
         _redirectMouseUp: function (e) {
@@ -666,6 +685,11 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
           var ok = this.dropZone.checkAcceptance(source, nodes, silent);
           ;
           return ok;
+        },
+
+        destroy: function() {
+          this.inherited(arguments);
+          this.dropZone = null;
         }
       });
 
@@ -684,6 +708,10 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             constructor: function (options) {
               this.id = this.model.id + "_ui";
               this.showPlaceholder = this.model.ui.showPlaceholder;
+
+              this.handles = [];
+              this.subscriptions = [];
+
               if (this.model.ui.placeholderText) {
                 this.placeholderText = this.model.ui.placeholderText;
               }
@@ -704,7 +732,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               // new pentaho.common.propertiesPanel.PlaceholderSource(this.domNode, {accept: this.model.ui.dndType, dropZone: this.dropZone});
 
               if (this.showPlaceholder && (this.model.allowMultiple || this.model.gems.length < 2)) {
-                new PlaceholderSource(this.placeholder, {accept: this.model.ui.dndType, dropZone: this.dropZone});
+                this._placeHolderSource = new PlaceholderSource(this.placeholder, {accept: this.model.ui.dndType, dropZone: this.dropZone});
 
 
                 // dojo.connect(this.placeholder.firstChild, "onmouseover", function(event){
@@ -733,29 +761,27 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               this.subscriptions.push(topic.subscribe("/dnd/cancel", unSubscribeFunc));
               this.subscriptions.push(topic.subscribe("/dnd/drop", unSubscribeFunc));
 
-
-              on(this.domNode,  "mouseover", function (event) {
+              this.handles.push(on(this.domNode,  "mouseover", function (event) {
                 if (ManagerClass.manager().source && outterThis.checkAcceptance(outterThis.dropZone,  ManagerClass.manager().nodes)) {
                   outterThis._showOver();
                 }
-              });
-              on(this.domNode, "mouseout", function (event) {
+              }));
+              this.handles.push(on(this.domNode, "mouseout", function (event) {
                 outterThis._hideOver();
-              });
-              on(this.domNode, "mouseup", function (event) {
+              }));
+              this.handles.push(on(this.domNode, "mouseup", function (event) {
                 outterThis._hideOver();
-              });
+              }));
 
-
-              // this.handles.push[on(this.dropZone,  "onDrop", lang.hitch( this,  "onDrop"))];
-              this.handles.push[on(this.dropZone,  "createDropIndicator", lang.hitch( this,  "createDropIndicator"))];
-              this.handles.push[on(this.dropZone,  "placeDropIndicator", lang.hitch( this,  "placeDropIndicator"))];
-              this.handles.push[on(this.dropZone,  "onMouseOver", lang.hitch( this,  "onMouseOver"))];
-              this.handles.push[on(this.dropZone,  "onMouseOut", lang.hitch( this,  "onMouseOut"))];
-              this.handles.push[on(this.dropZone,  "onDraggingOver", lang.hitch( this,  "onDraggingOver"))];
-              this.handles.push[on(this.dropZone,  "onDraggingOver", lang.hitch( this,  "onDraggingOut"))];
-              // this.handles.push[on(this.dropZone,  "checkAcceptance", lang.hitch( this,  "checkAcceptance"))];
-              this.handles.push[on(this.dropZone,  "insertNodes", lang.hitch( this,  "insertNodes"))];
+              // this.handles.push(on(this.dropZone,  "onDrop", lang.hitch( this,  "onDrop")));
+              this.handles.push(on(this.dropZone,  "createDropIndicator", lang.hitch( this,  "createDropIndicator")));
+              this.handles.push(on(this.dropZone,  "placeDropIndicator", lang.hitch( this,  "placeDropIndicator")));
+              this.handles.push(on(this.dropZone,  "onMouseOver", lang.hitch( this,  "onMouseOver")));
+              this.handles.push(on(this.dropZone,  "onMouseOut", lang.hitch( this,  "onMouseOut")));
+              this.handles.push(on(this.dropZone,  "onDraggingOver", lang.hitch( this,  "onDraggingOver")));
+              this.handles.push(on(this.dropZone,  "onDraggingOver", lang.hitch( this,  "onDraggingOut")));
+              // this.handles.push(on(this.dropZone,  "checkAcceptance", lang.hitch( this,  "checkAcceptance")));
+              this.handles.push(on(this.dropZone,  "insertNodes", lang.hitch( this,  "insertNodes")));
 
               array.forEach(this.model.gems, function (gem) {
                 var uiClass = Panel.registeredTypes["gem"];
@@ -772,7 +798,6 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               }, this);
               this.dropZone.sync();
               this.inherited(arguments);
-
             },
             _showOver: function() {
               if (this.domNode) {
@@ -893,14 +918,36 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               this.inherited(arguments);
               // destroyRecursive should do this, investigate
               array.forEach(this.gems, function (gem) {
-                gem.destroy();
+                gem.destroyRecursive();
               });
-              this.destroy();
-              array.forEach(this.handles, function(handle){handle.remove()});
             },
             destroy: function () {
-              array.forEach(this.subscriptions, function(handle){handle.remove()});
+              if(this.handles) {
+                array.forEach(this.handles, function(handle){handle.remove()});
+                this.handles = null;
+              }
+              if(this.subscriptions) {
+                array.forEach(this.subscriptions, function(handle){handle.remove()});
+                this.subscriptions = null;
+              }
+
+              this.dropZoneNode = null;
+              if(this.dropZone) {
+                this.dropZone.destroy();
+                this.dropZone = null;
+              }
+
+              this.placeholder = null;
+              if(this._placeHolderSource) {
+                this._placeHolderSource.destroy();
+                this._placeHolderSource = null;
+              }
+
               this.inherited(arguments);
+
+              // Prevent leak
+              this._startupWidgets = null;
+              this._supportingWidgets = null;
             }
           }
       );
@@ -912,36 +959,52 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
           {
             className: "gem",
             templateString: "<div id='${id}' class='${className} dojoDndItem' dndType='${dndType}'><div class='gem-label' title='${model.value}'></div><div class='gemMenuHandle'></div></div>",
-            constructor: function (options) {
-              this.gemBar = options.gemBar;
+            constructor: function(options) {
+              this.gemBar  = options.gemBar;
               this.dndType = options.dndType;
               this.id = options.id;
+              this.handles = [];
             },
             detach: function () {
               model.detach();
             },
+            destroy: function() {
+              this.inherited(arguments);
+              if(this.handles) {
+                array.forEach(this.handles, function(handle){handle.remove()});
+                this.handles = null;
+              }
+              this.menuHandle = null;
+              this.postDrop   = null;
+              this.gemBar     = null;
+
+              // Prevent leak
+              this._startupWidgets = null;
+              this._supportingWidgets = null;
+            },
             postCreate: function () {
-              on(this.domNode, "contextmenu", lang.hitch( this,  "onContextMenu"));
+              this.handles.push(on(this.domNode, "contextmenu", lang.hitch( this,  "onContextMenu")));
+
               var outterThis = this;
               this.menuHandle = query("div.gemMenuHandle", this.domNode)[0];
 
               var gemLabel = query("div.gem-label", this.domNode)[0];
               gemLabel.appendChild(document.createTextNode(this.model.value));
 
-              on(query("div.gemMenuHandle",  this.domNode)[0], "mouseover",  function (e) {
+              this.handles.push(on(query("div.gemMenuHandle",  this.domNode)[0], "mouseover",  function (e) {
                 if (!ManagerClass.manager().source) {
                   domClass.add(e.target, "over");
                 }
-              });
-              on(query("div.gemMenuHandle", this.domNode)[0], "mouseout", function (e) {
+              }));
+              this.handles.push(on(query("div.gemMenuHandle", this.domNode)[0], "mouseout", function (e) {
                 if (!ManagerClass.manager().source) {
                   domClass.remove(e.target, "over");
                 }
-              });
-              on(this.menuHandle, "click", lang.hitch( this,  "onContextMenu"));
+              }));
+              this.handles.push(on(this.menuHandle, "click", lang.hitch( this,  "onContextMenu")));
 
-              on(this.domNode, "mouseover", lang.hitch( this,  "onMouseOver"));
-              on(this.domNode, "mouseout", lang.hitch( this,  "onMouseOut"));
+              this.handles.push(on(this.domNode, "mouseover", lang.hitch( this,  "onMouseOver")));
+              this.handles.push(on(this.domNode, "mouseout", lang.hitch( this,  "onMouseOut")));
               this.inherited(arguments);
             },
             onMouseOver: function () {
@@ -952,7 +1015,6 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             onMouseOut: function () {
               domClass.remove(this.domNode, "over");
             },
-
 
             // to be overwritten by container
             onContextMenu: function (e) {
@@ -974,7 +1036,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             constructor: function (options) {
               this.name = options.id;
               this.options = [];
-
+              this.handles = [];
               array.forEach(this.model.values, function (val, idx) {
                 var opt = {label: val, value: val};
                 if (this.model.ui.labels) {
@@ -1030,7 +1092,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
                 // use the styled drop down
 
                 domClass.add(this.domNode, this.className);
-                var sel = new Select({
+                var sel = this.selNode = new Select({
                   options: opts,
                   onChange: function () {
                     me.model.set('value', this.value);
@@ -1053,6 +1115,14 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             destroy: function () {
               array.forEach(this.handles, function(handle){handle.remove()});
               this.inherited(arguments);
+              if(this.selNode) {
+                this.selNode.destroyRecursive();
+                this.selNode = null;
+              }
+
+              // Prevent leak
+              this._startupWidgets = null;
+              this._supportingWidgets = null;
             }
 
           }
@@ -1133,6 +1203,15 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             destroy: function () {
               array.forEach(this.handles, function(handle){handle});
               this.inherited(arguments);
+
+              if(this.checkbox) {
+                this.checkbox.destroyRecursive();
+                this.checkbox = null;
+              }
+
+              // Prevent leak
+              this._startupWidgets = null;
+              this._supportingWidgets = null;
             }
           }
       );
@@ -1156,6 +1235,14 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
 
             onClick: function () {
               this.model.set('clicked', true);
+            },
+
+            destroy: function() {
+              this.inherited(arguments);
+
+              // Prevent leak
+              this._startupWidgets = null;
+              this._supportingWidgets = null;
             }
           }
       );

--- a/package-res/resources/web/vizapi/Events.js
+++ b/package-res/resources/web/vizapi/Events.js
@@ -28,75 +28,61 @@ pentaho = typeof pentaho == "undefined" ? {} : pentaho;
 
 pentaho.events = {};
 
-// an array of event listeners
-pentaho.events.listeners = [];
-
 /*
     trigger
     Triggers an event by notifying all of the listeners that the event has occurred.
 */
-pentaho.events.trigger = function( object, eventName, args ) {
-
-    // examine each listener
-    for(var lNo=0; lNo<pentaho.events.listeners.length; lNo++ ) {
-        if( pentaho.events.listeners[lNo].object == object && pentaho.events.listeners[lNo].eventName == eventName ) {
-            // the event matches this listener's object and event name
-            pentaho.events.listeners[lNo].func( args );
+pentaho.events.trigger = function(object, eventName, arg) {
+    var events = object && object.__events__;
+    if(events) {
+        handlers = events[eventName];
+        if(handlers) {
+            var i = -1, L = handlers.length;
+            while(++i < L) handlers[i](arg);
         }
     }
-}
+};
 
 /*
     addListener
     Adds a listener for an event
-    
+
     object      The object to listen to
     eventName   The name of the event to listen to
     func        The function to call when the event happens
 */
-pentaho.events.addListener = function(object, eventName, func ) {
-    pentaho.events.listeners.push({
-        object: object,
-        eventName: eventName,
-        func: func
-    });
-}
+pentaho.events.addListener = function(object, eventName, func) {
+    if(object) {
+        var events   = (object.__events__ || (object.__events__ = {})),
+            handlers = (events[eventName] || (events[eventName] = []));
+        handlers.push(func);
+    }
+};
 
 /*
     removeListener
     Removes a listener for an event
-    
+
     object      The object to listen to
     eventName   The name of the event to listen to
 */
-pentaho.events.removeListener = function(object, eventName ) {
-
-    var lNo = 0;
-    while(lNo<pentaho.events.listeners.length ) {
-        if( pentaho.events.listeners[lNo].object == object && pentaho.events.listeners[lNo].eventName == eventName ) {
-            pentaho.events.listeners.splice(lNo,1);
+pentaho.events.removeListener = function(object, eventName) {
+    var events = object && object.__events__;
+    if(events) {
+        if(eventName) {
+            delete events[eventName];
         } else {
-            lNo++;
+            delete object.__events__;
         }
     }
-    
-}
+};
 
 /*
     removeSource
-    Removes all the listeners for the specified ibject
-    
+    Removes all the listeners for the specified object
+
     object      The object to listen to remove
 */
 pentaho.events.removeSource = function(object) {
-
-    var lNo = 0;
-    while(lNo<pentaho.events.listeners.length ) {
-        if( pentaho.events.listeners[lNo].object == object ) {
-            pentaho.events.listeners.splice(lNo,1);
-        } else {
-            lNo++;
-        }
-    }
-    
-}
+    pentaho.events.removeListener(object);
+};

--- a/package-res/resources/web/vizapi/VizController.js
+++ b/package-res/resources/web/vizapi/VizController.js
@@ -133,6 +133,17 @@ pentaho.VizController = function(id) {
   this.formatInfo = null;
 }
 
+pentaho.VizController.prototype.dispose = function() {
+  pentaho.events.removeSource(this);
+  if(this.chart) {
+    if(this.chart.dispose) this.chart.dispose();
+    pentaho.events.removeSource(this.chart);
+    this.chart = null;
+  }
+
+  this.domNode = this.visualPanelElement = null;
+};
+
 /*
  getError
  Returns the most recent Javascript error object

--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -65,7 +65,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 reqs: def.array.appendMany(
                     createDataReq('VERTICAL_BAR', {options: false}),
-                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],                    
+                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],
                     createTrendsDataReqs({separator: true}),
                     [ createChartOptionsDataReq(true) ])
             }],
@@ -102,7 +102,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 reqs: def.array.appendMany(
                     createDataReq('HORIZONTAL_BAR', {options: false}),
-                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],                    
+                    [ createColumnDataLabelsReq({separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}) ],
                     [ createChartOptionsDataReq(true) ])
             }],
             menuOrdinal: 130,
@@ -186,7 +186,7 @@ function(def, pvc, pv){
                      createLineWidthDataReq()
                     ],
                     createTrendsDataReqs(),
-                    [ 
+                    [
                      createChartOptionsDataReq(true)
                     ]
                 )
@@ -311,7 +311,7 @@ function(def, pvc, pv){
                         createMeaDataReq('VERTICAL_BAR_LINE_NUMLINE'),
                         'id', 'measuresLine',
                         'required', false),
-                    
+
                     createColumnDataLabelsReq({value_anchor: 'VALUE_COLUMN_ANCHOR',   separator: false, anchors:['none', 'center', 'inside_end', 'inside_base', 'outside_end']}),
                     createLabelsVisibleAnchorDataReq({labels_option: 'lineLabelsOption', value_anchor: 'VALUE_LINE_ANCHOR'}),
                     createMultiDataReq(),
@@ -405,7 +405,7 @@ function(def, pvc, pv){
                 name: 'Default',
                 drillOrder: ['rows','columns'],
                 hyperlinkOrder: ['rows','columns'],
-                reqs : def.array.appendMany(                    
+                reqs : def.array.appendMany(
                     createDataReq("MULTIPLE_PIE", {multi: false, options: false}),
                     [
                         createLabelsVisiblePositionDataReq(),
@@ -559,7 +559,7 @@ function(def, pvc, pv){
                           caption: dropZoneLabel('SUNBURST_SIZE'),
                           required: false,
                           allowMultiple: false
-                      },                      
+                      },
                       createMultiDataReq()],
                       [createLabelsVisibleAnchorDataReq({ hideOptions : ['left', 'right', 'top', 'bottom'] })],
                       createSortDataReqs(true),
@@ -805,7 +805,7 @@ function(def, pvc, pv){
                     }
                 }
             }
-            
+
             return {
                     id: def.get(keyArgs, 'labels_option', 'labelsOption'),
                     dataType: 'string',
@@ -818,11 +818,11 @@ function(def, pvc, pv){
                     }
                 };
         }
-        
+
         function createColumnDataLabelsReq(keyArgs){
-          
+
             var anchors = def.get(keyArgs, 'anchors');
-          
+
             return {
                 id: 'labelsOption',
                 dataType: 'string',
@@ -846,11 +846,11 @@ function(def, pvc, pv){
                     group: 'options',
                     type:  'checkbox',
                     seperator: def.get(keyArgs, 'separator', true),
-                    caption: 'Labels' // TODO i18n pending....                
+                    caption: 'Labels' // TODO i18n pending....
                 }
             };
         }
-        
+
         function createChartOptionsDataReq(hasSeparator){
             return {
                 id: "optionsBtn",
@@ -1388,17 +1388,17 @@ function(def, pvc, pv){
                     }
 
                     var suffix;
-                    
+
                     // It can happen that the scene has more than one datum.
                     // One is a null one and the other an interpolated one.
-                    // We may receive the null one in `complex` and 
+                    // We may receive the null one in `complex` and
                     // miss detecting that the scene is actually interpolated.
                     if(context && context.scene) {
                     	// create local variable for avoid double call datums()
                     	var datums = context.scene.datums();
                     	if (datums) {
                     		var complexInterp = datums.where(function(d) { return d.isInterpolated && d.interpDimName === cccDimName; }).first();
-                    		if(complexInterp) 
+                    		if(complexInterp)
                     			suffix = this.chart._message('chartTooltipGemInterp_' + complexInterp.interpolation);
                     		}
                     } else if(complex.isTrend/* && atom.label*/){
@@ -1438,9 +1438,9 @@ function(def, pvc, pv){
                     visRoles = context.panel.visualRolesOf(cccDimName, /*includeChart*/true);
 
                 if(visRoles && visRoles.some(function(r) { return r.isPercent; })) {
-                    var group = context.scene.group, 
-                        dim   = (group || data).dimensions(cccDimName), 
-                        pct   = group 
+                    var group = context.scene.group,
+                        dim   = (group || data).dimensions(cccDimName),
+                        pct   = group
                             ? dim.percentOverParent({visible: true})
                             : dim.percent(atom.value);
 
@@ -1667,6 +1667,14 @@ function(def, pvc, pv){
         _discreteColorRole: 'columns',
 
         /* PLUGIN INTERFACE  */
+
+        dispose: function() {
+           this._element = null;
+           if(this._chart && this._chart.dispose) {
+            this._chart.dispose();
+            this._chart = null;
+           }
+        },
 
         /**
          * Instructs the visualization to draw itself with
@@ -2393,8 +2401,8 @@ function(def, pvc, pv){
                                         }
 
                                         // Copy map values to ColorMap
-                                        // All color maps are joined together and there will be no 
-                                        // value collisions because the key is prefixed with the name 
+                                        // All color maps are joined together and there will be no
+                                        // value collisions because the key is prefixed with the name
                                         // of the category
                                         for (var j in map) {
                                             colorMap[j] = map[j];
@@ -2402,11 +2410,11 @@ function(def, pvc, pv){
                                     }
                                 }
                             } else {
-                                colorMap = memberPalette[colorGems[C - 1].formula];    
+                                colorMap = memberPalette[colorGems[C - 1].formula];
                             }
                         } else {
                             // Use measures (M === 1)
-                            
+
                             /*
                              * "[Measures].[MeasuresLevel]": {
                              *    "[MEASURE:0]": "violet",
@@ -2460,11 +2468,11 @@ function(def, pvc, pv){
                                         var keys     = compKey.split("~"),
                                             level    = keys.length - 1,
                                             keyLevel = keys[level];
-                                        
+
                                         // Obtain color for most specific key from color map.
                                         // If color map has no color and it is the 1st level,
                                         //  then reserve a color from the default color scale.
-                                        // Otherwise, return undefined, 
+                                        // Otherwise, return undefined,
                                         //  meaning that a derived color should be used.
                                         return def.getOwn(colorMap, keyLevel) ||
                                             (level ? undefined : defaultScale(keyLevel));
@@ -3305,12 +3313,12 @@ function(def, pvc, pv){
 
             configureColumnLabelsAlignmentOptions.call(this);
         },
-        
+
         _readUserOptions: function(options, vizOptions) {
             this.base(options, vizOptions);
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.label_textStyle = vizOptions.labelColor;
-        }        
+        }
     });
 
     // -------------------
@@ -3438,7 +3446,7 @@ function(def, pvc, pv){
 
             options.plot2ValuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.plot2Label_textStyle = vizOptions.labelColor;
-            
+
             configureLabelsOptions.call(this);
         },
 
@@ -3458,7 +3466,7 @@ function(def, pvc, pv){
             this._configureAxisTitle('ortho2',"");
 
             this.options.plot2OrthoAxis = 2;
-            
+
             configureLineLabelsAlignmentOptions.call(this);
 
             // Plot2 uses same color scale
@@ -3498,7 +3506,7 @@ function(def, pvc, pv){
                 options.dotsVisible = true;
                 options.extensionPoints.dot_shape = shape;
             }
-            
+
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
             options.extensionPoints.label_textStyle = vizOptions.labelColor;
 
@@ -3619,7 +3627,7 @@ function(def, pvc, pv){
 
             configureLabelsAnchorOptions.call(this);
         },
-        
+
         _readUserOptions: function(options, vizOptions) {
             this.base(options, vizOptions);
             options.valuesFont = defaultFont(readFont(vizOptions, 'label'));
@@ -3986,7 +3994,7 @@ function(def, pvc, pv){
             // configure value label
             if(this.options.valuesVisible){
                 this._configureValuesMask();
-            }            
+            }
         },
 
         _showLegend: function(){
@@ -4226,14 +4234,14 @@ function(def, pvc, pv){
                         var th = m.height * 0.85, // tight text bounding box
                             tb = pvLabel.textBaseline(),
                             // The effective height of text that must be covered.
-                            // one text margin, for the anchor, 
+                            // one text margin, for the anchor,
                             // half text margin for the anchor's opposite side.
                             // All on only one of the sides of the wedge.
                             thEf = 2 * (th + 3*tm/2);
 
                         // Minimum inner radius whose straight-arc has a length `thEf`
                         irmin = Math.max(
-                            irmin, 
+                            irmin,
                             thEf / (2 * Math.tan(a / 2)));
                     }
 
@@ -4251,7 +4259,7 @@ function(def, pvc, pv){
                     // Continue with normal processing for the main label.
                     return null;
                 };
-                
+
                 var me = this;
                 eps.label_add = function() {
                     return new pv.Label()
@@ -4261,8 +4269,8 @@ function(def, pvc, pv){
                         })
                         .text(function(scene) {
                             var pvMainLabel = this.proto;
-                            return !pvMainLabel.text() 
-                                ? "" 
+                            return !pvMainLabel.text()
+                                ? ""
                                 : me._formatSize(scene.vars.size, scene.firstAtoms.size.dimension);
                         })
                         .textBaseline("top");
@@ -4525,13 +4533,13 @@ function(def, pvc, pv){
 
         // Set Values Visible
         if(this._vizOptions.labelsVisible) {
-            this.options.valuesVisible = this._vizOptions.labelsVisible;    
+            this.options.valuesVisible = this._vizOptions.labelsVisible;
         }
 
         if (this._vizOptions.labelsAnchor) {
-            this.options.valuesAnchor = this._vizOptions.labelsAnchor;    
+            this.options.valuesAnchor = this._vizOptions.labelsAnchor;
         }
-        
+
         if (this._vizOptions.labelsTextAlign) {
              if (!this.options.extensionPoints) {
                 this.options.extensionPoints = {};
@@ -4548,7 +4556,7 @@ function(def, pvc, pv){
 
         if(!this._vizOptions.labelsOption || this._vizOptions.labelsOption == 'none') {
             return this.options.valuesVisible = false;
-        } 
+        }
 
         return this.options.valuesVisible = true;
     }
@@ -4560,7 +4568,7 @@ function(def, pvc, pv){
         }
     }
 
-    
+
     function configureColumnLabelsAlignmentOptions() {
         if (configureLabelsVisibilityOptions.call(this)) {
             if (!this.options.extensionPoints) {
@@ -4570,7 +4578,7 @@ function(def, pvc, pv){
             var labelsOption = this._vizOptions.labelsOption;
 
             this.options.extensionPoints.label_textMargin = 7;
-            
+
             if(labelsOption == 'center') {
                 this.options.valuesAnchor = 'center';
             }
@@ -4599,7 +4607,7 @@ function(def, pvc, pv){
             }
         }
     }
-    
+
     function configureLineLabelsAlignmentOptions() {
         var lineLabelsOption = this._vizOptions.lineLabelsOption;
         if(lineLabelsOption && lineLabelsOption != 'none') {


### PR DESCRIPTION
* Implemented a ccc wrapper dispose method that disposes the underlying CCC chart, if any, and clears DOM references
* Implemented a VizController dispose method that removes events from it and the viz, if any, and clears DOM references
* Replaced the VizAPI Events implementation by a non-leaky one that stores event listeners directly on the emitting objects
   * Was leaking every controller, chart...
* Panel
   * .subscriptions and .handles on the prototype... were leaking... a lot
   * detaching from DOM events
   * calling destroys that weren't being called
   * cleared lots of dom references
   * fixed this.handles.push[on(...)] ...

@pamval, @diogofscmariano, @bennychow please review.