### PR TITLE
[ANALYZER-3058] - Memory leaks during multiple changing of chart type

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -298,7 +298,8 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             destroy: function() {
               this.inherited(arguments);
 
-              this.model = this.propPanel = null;
+              // this.model = null;
+              // this.propPanel = null;
 
               if(this._watchHandle) {
                 this._watchHandle.remove();
@@ -352,7 +353,8 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
 
         destroy: function() {
           this.inherited(arguments);
-          this.dropIndicator = this.gemUIbeingInserted = this.gemBar = null;
+          this.dropIndicator = this.gemUIbeingInserted = null;
+          // this.gemBar = null
         },
 
         _redirectMouseUp: function (e) {
@@ -402,7 +404,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               gemUI.gemBar = this.gemBar;
             }
           } else {
-            var gem = this.createGemFromNode(droppedNode);
+            gem = this.createGemFromNode(droppedNode);
             gemUI = this.createGemUI(gem, droppedNode);
             nodes[0] = gemUI.domNode;
           }
@@ -932,16 +934,18 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               }
 
               this.dropZoneNode = null;
+              this.placeholder = null;
+              /*
               if(this.dropZone) {
                 this.dropZone.destroy();
                 this.dropZone = null;
               }
 
-              this.placeholder = null;
               if(this._placeHolderSource) {
                 this._placeHolderSource.destroy();
                 this._placeHolderSource = null;
               }
+              */
 
               this.inherited(arguments);
 
@@ -975,8 +979,8 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
                 this.handles = null;
               }
               this.menuHandle = null;
-              this.postDrop   = null;
-              this.gemBar     = null;
+              //this.postDrop   = null;
+              //this.gemBar     = null;
 
               // Prevent leak
               this._startupWidgets = null;


### PR DESCRIPTION
* Undoing some of the cleared references and disposed objects as drag and drop operations that destroyed the panel in the drop (Analyzer refreshReport called) would fail
* Not all memory is reclaimed now, but still much better than the initial state.

@diogofscmariano, @pamval, @bennychow please review.