### PR TITLE
[ANALYZER-3058] - Memory leaks during multiple changing of chart type

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Configuration.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Configuration.js
@@ -82,21 +82,39 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
           "pentaho.common.propertiesPanel.GemBar",
           [pentaho.common.propertiesPanel.Property],
           {
-            gems: [],
+            gems: null,
+            selectedGem: null,
             allowMultiple: true,
-            constructor: function (item) {
+
+            constructor: function(item) {
             },
-            initializeGem: function (gemJson) {
-              var gem = new pentaho.common.propertiesPanel.Configuration.registeredTypes["gem"](gemJson);
-              gem.postCreate();
-              this.gems.push(gem);
-            },
+
             postCreate: function () {
               var originalGems = this.gems;
               this.gems = [];
               array.forEach(originalGems, this.initializeGem, this);
-
             },
+
+            initializeGem: function(gemJson) {
+              var gem = new Configuration.registeredTypes["gem"](gemJson);
+              gem.postCreate();
+              this.gems.push(gem);
+            },
+
+            createGemFromNode: function(sourceNode) {
+              var GemClass = Configuration.registeredTypes["gem"];
+              var options = {
+                      id:         "gem-" + sourceNode.id,
+                      value:      sourceNode.innerHTML,
+                      gemBar:     this,
+                      sourceNode: sourceNode,
+                      dndType:    sourceNode.getAttribute("dndType")
+                    };
+
+              // check to see if it's a factory class
+              return GemClass.create ? GemClass.create(options) : new GemClass(options);
+            },
+
             remove: function (gem) {
               this.gems.splice(this.gems.indexOf(gem), 1);
 
@@ -104,6 +122,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
               this.set("gems", this.gems);
               this.onModelEvent("removedGem", {gem: gem});
             },
+
             add: function (gem) {
               this.gems.push(gem);
 
@@ -111,10 +130,12 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
               this.set("gems", this.gems);
               this.onModelEvent("insertAt", {gem: gem, idx: this.gems.length, oldIdx: -1});
             },
+
             reorder: function () {
               this.set("gems", this.gems);
               this.onModelEvent("reorderedGems", {});
             },
+
             insertAt: function (gem, newIdx, oldIdx) {
               var currIdx = array.indexOf(this.gems, gem);
               this.gems.splice(newIdx, 0, gem); // add it to the new pos
@@ -130,13 +151,9 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
                 newIdx--;
               }
               this.onModelEvent("insertAt", {gem: gem, idx: newIdx, oldIdx: oldIdx});
-            },
+            }
+          });
 
-            gems: [],
-            selectedGem: null
-
-          }
-      );
       Configuration.registeredTypes["gemBar"] = pentaho.common.propertiesPanel.GemBar;
       Configuration.registeredTypes["gem"] = pentaho.common.propertiesPanel.Property;
       Configuration.registeredTypes["combo"] = pentaho.common.propertiesPanel.Property;

--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -1669,7 +1669,11 @@ function(def, pvc, pv){
         /* PLUGIN INTERFACE  */
 
         dispose: function() {
-           this._element = null;
+           this._element =
+           this.options  =
+           this.controller =
+           this._vizOptions = null;
+
            if(this._chart && this._chart.dispose) {
             this._chart.dispose();
             this._chart = null;


### PR DESCRIPTION
This fixes the current memory leaks completely. The implemented solution is destroying the replaced UI components (by refreshReport) in a future tick.
However, dojo doesn't store a whole component sub-tree — the Widget.getChildren() method discovers child widgets through the DOM and the global dojo/registry of widgets. The widgets of the relevant sub-component tree were using well-known, repeatable ids, and when asked, a destroyed widget would state the new widgets as their children... Unique ids had to be assigned to widgets, each time, so that the two sub-trees could co-exist (the new and the to be destroyed one). Because of this, the places where the dojo/registry was queried to find the Gem widget corresponding to a given dropped node ID would not work anymore, as there was now a divergence between the node id (partly random) and the gem id it represented. So a new dictionary of Gem widgets indexed by Gem ID needed to be devised in the Properties Panel.

@pamval please review.