### PR TITLE
[BACKLOG-2548] VizController - Refactoring - GEO and 12 Days plugins

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -173,7 +173,7 @@
 
   // Visual API - CCC
   requireService["pentaho/visual/ccc/visualTypeProvider"] = "IVisualTypeProvider";
-  requireService["pentaho/visual/ccc/visualTypeConfig"  ] = "IVisualApiConfiguration";
+  requireService["pentaho/visual/ccc/visualApiConfig"] = "IVisualApiConfiguration";
 
   // Sample visualizations
   requireService["pentaho/visual/sample/visualTypeProvider"] = "IVisualTypeProvider";

--- a/package-res/resources/web/test/karma/unit/vizapi/editor/utilsSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/editor/utilsSpec.js
@@ -15,7 +15,9 @@
  */
 define(["pentaho/visual/editor/utils"], function(singletonEditorUtils) {
 
-  function MapEditorProps(dict) {
+  function MapEditorProps(editorTypeId, dict) {
+    this.editorTypeId = editorTypeId;
+
     this.get = function(p) {
       return dict.hasOwnProperty(p) ? dict[p] : null;
     };
@@ -39,103 +41,92 @@ define(["pentaho/visual/editor/utils"], function(singletonEditorUtils) {
 
   describe("Visual Editor Utils -", function() {
 
-    describe("#translateEditorProperties(type, editorTypeId, editorProps, filterPropsList)", function() {
+    describe("#getEditorProperties(type, editorDoc, filterPropsList)", function() {
       it("should be a function", function() {
-        expect(typeof singletonEditorUtils.translateEditorProperties).toBe("function");
+        expect(typeof singletonEditorUtils.getEditorProperties).toBe("function");
       });
 
       it("should throw if `type` is not specified", function() {
         expect(function() {
-          singletonEditorUtils.translateEditorProperties();
+          singletonEditorUtils.getEditorProperties();
         }).toThrow();
       });
 
-      it("should throw if `editorTypeId` is not specified", function() {
+      it("should throw if `editorDoc` is not specified", function() {
         expect(function() {
-          singletonEditorUtils.translateEditorProperties({});
+          singletonEditorUtils.getEditorProperties({});
         }).toThrow();
       });
 
-      it("should throw if `editorProps` is not specified", function() {
-        expect(function() {
-          singletonEditorUtils.translateEditorProperties({}, "fooo");
-        }).toThrow();
-      });
-
-      describe("type/config specifies `translateEditorProperties`", function() {
-        it("should call `translateEditorProperties` with `type` as `this` JS context", function() {
+      describe("type/config specifies `getEditorProperties`", function() {
+        it("should call `getEditorProperties` with `type` as `this` JS context", function() {
           var type = {
             id: "ccc_bar",
-            translateEditorProperties: function() {}
+            getEditorProperties: function() {}
           };
 
-          var editorTypeId = "analyzer";
-          var editorProps = {};
+          var editorDoc = {type: "analyzer"};
 
-          spyOn(type, "translateEditorProperties");
+          spyOn(type, "getEditorProperties");
 
-          singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps);
+          singletonEditorUtils.getEditorProperties(type, editorDoc);
 
-          expect(type.translateEditorProperties).toHaveBeenCalled();
-          expect(type.translateEditorProperties.calls.first().object).toBe(type);
+          expect(type.getEditorProperties).toHaveBeenCalled();
+          expect(type.getEditorProperties.calls.first().object).toBe(type);
         });
 
-        it("should call `translateEditorProperties` with all the expected arguments", function() {
+        it("should call `getEditorProperties` with all the expected arguments", function() {
           var type = {
             id: "ccc_bar",
-            translateEditorProperties: function() {}
+            getEditorProperties: function() {}
           };
 
-          var editorTypeId = "analyzer";
-          var editorProps = {};
+          var editorDoc = {editorTypeId: "analyzer"};
           var filterPropsList = ["foo", "bar"];
 
-          spyOn(type, "translateEditorProperties");
+          spyOn(type, "getEditorProperties");
 
-          singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps, filterPropsList);
+          singletonEditorUtils.getEditorProperties(type, editorDoc, filterPropsList);
 
-          expect(type.translateEditorProperties).toHaveBeenCalled();
+          expect(type.getEditorProperties).toHaveBeenCalled();
 
-          var call = type.translateEditorProperties.calls.first();
+          var call = type.getEditorProperties.calls.first();
 
-          expect(call.args.length).toBe(4);
+          expect(call.args.length).toBe(3);
 
-          expect(call.args[0]).toBe(editorTypeId);
-          expect(call.args[1]).toBe(editorProps);
-          expect(call.args[2]).toBe(filterPropsList);
+          expect(call.args[0]).toBe(editorDoc);
+          expect(call.args[1]).toBe(filterPropsList);
 
-          var filterPropsMap = call.args[3];
+          var filterPropsMap = call.args[2];
           expect(filterPropsMap instanceof Object).toBe(true);
           filterPropsList.forEach(function(p) {
             expect(filterPropsMap[p]).toBe(true);
           });
         });
 
-        it("should return an empty object if `translateEditorProperties` returns nully", function() {
+        it("should return an empty object if `getEditorProperties` returns nully", function() {
           var type = {
             id: "ccc_bar",
-            translateEditorProperties: function() {}
+            getEditorProperties: function() {}
           };
 
-          var editorTypeId = "analyzer";
-          var editorProps = {};
+          var editorDoc = {editorTypeId: "analyzer"};
 
-          var result = singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps);
+          var result = singletonEditorUtils.getEditorProperties(type, editorDoc);
 
           expect(result).toEqual({});
         });
 
-        it("should filter the result of `translateEditorProperties` to respect `filterPropsList`", function() {
+        it("should filter the result of `getEditorProperties` to respect `filterPropsList`", function() {
           var type = {
             id: "ccc_bar",
-            translateEditorProperties: function() { return {"foo": 1, "bar": 2, "dudu": 3}; }
+            getEditorProperties: function() { return {"foo": 1, "bar": 2, "dudu": 3}; }
           };
 
-          var editorTypeId = "analyzer";
-          var editorProps = {};
+          var editorDoc = {editorTypeId: "analyzer"};
           var filterPropsList = ["foo", "bar"];
 
-          var result = singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps, filterPropsList);
+          var result = singletonEditorUtils.getEditorProperties(type, editorDoc, filterPropsList);
 
           expect(result.foo).toBe(1);
           expect(result.bar).toBe(2);
@@ -143,7 +134,7 @@ define(["pentaho/visual/editor/utils"], function(singletonEditorUtils) {
         });
       });
 
-      describe("type/config does not specify translateEditorProperties", function() {
+      describe("type/config does not specify getEditorProperties", function() {
 
         it("should copy defined editor props that have the name of a general data req", function() {
           var type = {
@@ -154,14 +145,13 @@ define(["pentaho/visual/editor/utils"], function(singletonEditorUtils) {
                 {id: "bar"}
               ]}]
             };
-          var editorTypeId = "analyzer";
-          var editorProps = new MapEditorProps({
+          var editorDoc = new MapEditorProps("analyzer", {
               foo: 1,
               bar: undefined,
-              zas: 3,
+              zas: 3
             });
 
-          var visualProps = singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps);
+          var visualProps = singletonEditorUtils.getEditorProperties(type, editorDoc);
 
           expect(visualProps instanceof Object).toBe(true);
           expect(visualProps.foo).toBe(1);
@@ -178,15 +168,14 @@ define(["pentaho/visual/editor/utils"], function(singletonEditorUtils) {
                 {id: "bar"}
               ]}]
             };
-          var editorTypeId = "analyzer";
-          var editorProps = new MapEditorProps({
+          var editorDoc = new MapEditorProps("analyzer", {
               foo: 1,
               bar: 2,
-              zas: 3,
+              zas: 3
             });
           var filterPropsList = ["foo", "zas"];
 
-          var visualProps = singletonEditorUtils.translateEditorProperties(type, editorTypeId, editorProps, filterPropsList);
+          var visualProps = singletonEditorUtils.getEditorProperties(type, editorDoc, filterPropsList);
 
           expect(visualProps instanceof Object).toBe(true);
           expect(visualProps.foo).toBe(1);

--- a/package-res/resources/web/test/karma/unit/vizapi/spec/helperSpec.js
+++ b/package-res/resources/web/test/karma/unit/vizapi/spec/helperSpec.js
@@ -15,6 +15,7 @@
  */
 define(["pentaho/visual/spec/helper"], function(singletonSpecHelper) {
   var standardSpec = {
+      action: 1,
       type:   1,
       state:  1,
       data:   1,
@@ -56,14 +57,14 @@ define(["pentaho/visual/spec/helper"], function(singletonSpecHelper) {
         expect(spec.type).toBe(type.id);
       });
 
-      it("should return a spec object in which every standard property is present, albeit possibly `undefined`", function() {
+      it("should return a spec object in which every standard IVisualSpec property is present, albeit possibly `undefined`", function() {
         var type = {
           id: "foo"
         };
 
         var spec = singletonSpecHelper.create(type);
         for(var p in standardSpec) {
-          if(standardSpec.hasOwnProperty(p)) {
+          if(p !== "action" && standardSpec.hasOwnProperty(p)) {
             expect(spec.hasOwnProperty(p)).toBe(true);
           }
         }

--- a/package-res/resources/web/vizapi/Wrapper.js
+++ b/package-res/resources/web/vizapi/Wrapper.js
@@ -380,6 +380,10 @@ define([
      */
     updateHighlights: function() {
       if(this._visual.setHighlights) {
+        this._checkVisualState();
+
+        this._drawSpec.highlights = this.highlights;
+
         this._visual.setHighlights(this.highlights);
       }
     },

--- a/package-res/resources/web/vizapi/Wrapper.js
+++ b/package-res/resources/web/vizapi/Wrapper.js
@@ -461,7 +461,7 @@ define([
      * @param {boolean} [options.saveData=false] Indicates if the current visual
      *    data should be included.
      *
-     * @return {object} A visual specification.
+     * @return {IVisualSpec} The current visual specification.
      */
     save: function(options) {
       this._checkVisualState();

--- a/package-res/resources/web/vizapi/Wrapper.js
+++ b/package-res/resources/web/vizapi/Wrapper.js
@@ -89,20 +89,14 @@ define([
     this._drawSpec   = null; // last .draw(, drawSpec) argument
     this._visual     = null;
 
+    this._lastAction  = null;
+    this._actionCount = 0;
+
     // --------
 
     this._dataTable = null;
 
-    /**
-     * Gets the current highlights.
-     *
-     * Do **not** modify the returned array or its contents.
-     *
-     * @property highlights
-     * @type ISelection[]
-     * @readonly
-     */
-    this.highlights = [];
+    this._highlights = [];
   }
 
   utils.extend(VisualWrapper.prototype, {
@@ -110,10 +104,12 @@ define([
     // PROPS
 
     /**
-     * Gets or sets the data table instance that will be used by the next
-     * {{#crossLink "VisualWrapper/update:method"}}{{/crossLink}} call.
+     * Gets or sets the data to display.
      *
-     * A data table must be set before a visual can be drawn.
+     * Data must be set before a visual can be displayed.
+     *
+     * To update the visualization display,
+     * call {{#crossLink "VisualWrapper/update:method"}}{{/crossLink}}.
      *
      * @property data
      * @type DataTable
@@ -130,20 +126,57 @@ define([
           value = new DataTable(value);
 
         this._dataTable = value;
+
+        this._setAction("setData");
       }
+    },
+
+    /**
+     * Gets or sets the current highlights.
+     *
+     * When set to _nully_, all highlights are cleared.
+     *
+     * When the visual specification is defined, its highlights are updated.
+     *
+     * To update the visualization display,
+     * call {{#crossLink "VisualWrapper/update:method"}}{{/crossLink}}.
+     *
+     * Do **not** directly modify the returned array or its contents.
+     *
+     * @property highlights
+     *
+     * @type ISelection[]
+     */
+    get highlights() {
+      return this._highlights;
+    },
+
+    set highlights(highlights) {
+      if(!highlights) {
+        if(!this._highlights.length) return;
+
+        this._highlights.length = 0;
+      } else {
+        // TODO: do deep equality test on set highlights ?
+        this._highlights = highlights;
+      }
+
+      if(this._visualSpec) this._visualSpec.highlights = this._highlights;
+
+      this._setAction("setHighlights");
     },
 
     /**
      * Gets or sets a visual specification.
      *
-     * When set to _nully_, the current visual display will be cleared if updated.
-     *
-     * When the visual specification is a _nully_ value,
-     * the current visual display will be cleared, if updated.
+     * When set to _nully_, the current visual display will be cleared, if updated.
      *
      * An error is thrown if the type of the specified visual is not defined or
      * is disabled for the wrapper's container type,
      * {{#crossLink "VisualWrapper/containerTypeId:property"}}{{/crossLink}}.
+     *
+     * To update the visualization display,
+     * call {{#crossLink "VisualWrapper/update:method"}}{{/crossLink}}.
      *
      * @property visualSpec
      *
@@ -156,25 +189,39 @@ define([
     set visualSpec(visualSpec) {
       var prevVisualSpec = this._visualSpec;
       if(prevVisualSpec) {
-
         // Clear, even when the same object.
         // spec.type may have been mutated.
         this._visualSpec = this._drawSpec = null;
 
         if(!visualSpec || this._visualType.id !== visualSpec.type) {
           // Clear visual and visualType.
+          // NOTE: resets _lastAction and _actionCount!
           this._disposeVisual();
           this._visualType = null;
         }
         // else
-        // Same visual type. Keep visual and update with new spec.
+        // Same visual type. Keep the Visual and update it with new spec.
+
+        // Also, keep existing highlights, whether or not the visual type has changed,
+        // unless present in the new visualSpec.
       }
 
       if(visualSpec) {
-        if(!this._visualType)
-          this._visualType = typeRegistry.get(visualSpec.type, this.containerTypeId, /*assert:*/true);
+        // We don't check if any property actually changed its value.
+        // A deep equality test would need to be performed, and, for that,
+        // a deep-clone would need to be kept, and, still,
+        // would remain vulnerable to problems with custom class objects.
+        this._setAction("setProps");
+
+        // Registers "setHighlights" if highlights change,
+        // causing the `visualSpec` set operation to cause a future full draw.
+        var specHighlights = visualSpec.highlights;
+        if(specHighlights) this.highlights = specHighlights;
 
         this._visualSpec = visualSpec;
+
+        if(!this._visualType)
+          this._visualType = typeRegistry.get(visualSpec.type, this.containerTypeId, /*assert:*/true);
       }
     },
 
@@ -212,12 +259,10 @@ define([
     // OPERS
 
     // TODO: document when highlights/events are refactored.
-    // [DCL] NEW
     on: function(name, handler) {
       visualEvents.addListener(this, name, handler);
     },
 
-    // [DCL] NEW
     off: function(name) {
       visualEvents.removeListener(this, name);
     },
@@ -226,8 +271,7 @@ define([
      * Displays a visual.
      *
      * When a visual specification is not defined,
-     * the current visual display is cleared and the returned promise
-     * is immediately resolved.
+     * the current visual display is cleared and the returned promise is immediately resolved.
      *
      * If any of the visual specification properties
      * {{#crossLink "IVisual/width:property"}}{{/crossLink}} and
@@ -235,7 +279,7 @@ define([
      * it takes the value of the current corresponding dimension
      * of {{#crossLink "VisualWrapper/domElement:property"}}{{/crossLink}}.
      * Otherwise, when specified, it is the corresponding element's dimension
-     * that takes that value.
+     * that is set with that value.
      *
      * The following errors are thrown, synchronously, if:
      *
@@ -243,18 +287,41 @@ define([
      * 2. no data has been set.
      *
      * @method update
+     *
      * @param {object} [drawOptions] A map of contextual, transient, arbitrary options to pass to the visual.
      *   Its properties are used to set any `undefined` properties of the visual specification.
-     *   Its properties are not saved with the visual specification.
+     *   Its properties are _not_ saved along with the visual specification.
+     * @param {string} [drawOptions.action] The action that triggered the update call and
+     *   feeds {{#crossLink "IVisualDrawSpec/action:property"}}{{/crossLink}}.
+     *
+     *   When unspecified and a single operation was performed on the wrapper since
+     *   the last update call, the action passed to the _visual_ is
+     *   the corresponding standard action (like `"setHighlights"`, `"setData"` or `"setProps"`).
+     *
+     *   Otherwise, the action passed to the _visual_ will be `null`.
      *
      * @return {Promise} A promise that is resolved when the visual has been displayed.
      */
     update: function(drawOptions) {
       this._checkAsyncState();
 
-      if(!this._visualSpec) return Promise.resolve(undefined);
+      if(!this._visualSpec) {
+        // TODO: Clear the display?
+        return Promise.resolve(undefined);
+      }
 
-      // Reset so that any updates to visualSpec may pass-through.
+      // TODO: Should prevent action from being a standard action?
+      if((!drawOptions || !drawOptions.action) &&
+         this._drawSpec && this._actionCount === 1) {
+        switch(this._lastAction) {
+          case "setHighlights":
+            if(this._visual.setHighlights) return this._updateHighlights();
+            break;
+        }
+      }
+
+      // Reset so that `visualSpec` mutations pass-through even when
+      // the user does not call `this.visualSpec = .` again.
       this._drawSpec = null;
 
       return this._updateVisual(drawOptions);
@@ -262,14 +329,18 @@ define([
 
     // -----------------
 
-    processHighlights: function(args) {
+    _processHighlights: function(args) {
       var mode = args.selectionMode || "TOGGLE";
 
-      if (mode == "REPLACE") {
-        // only use the selections from the arguments passed in
-        this.highlights = [];
+      if(mode === "REPLACE") {
+        // Only use the selections from the arguments passed in.
+        this.highlights.length = 0;
       }
 
+      // Just assume these changed, for now.
+      this._setAction("setHighlights");
+
+      var highlights = this.highlights;
       for (var i = 0; i < args.selections.length; i++) {
         var selectedItem = args.selections[i];
 
@@ -307,8 +378,8 @@ define([
 
         if(mode == "TOGGLE") {
           // previous selection should be retained or if re-selected should be toggled
-          for( var hNo=0; hNo<this.highlights.length; hNo++) {
-            var highlight = this.highlights[hNo];
+          for( var hNo=0; hNo< highlights.length; hNo++) {
+            var highlight = highlights[hNo];
             var highlightRowItem = highlight.rowItem;
             var highlightColItem = highlight.colItem;
 
@@ -344,7 +415,7 @@ define([
                 }
 
                 // remove this
-                this.highlights.splice( hNo, 1 );
+                highlights.splice( hNo, 1 );
                 removed = true;
                 break;
             }
@@ -368,35 +439,23 @@ define([
             highlight.id = colId;
             highlight.value = colLabel;
           }
-          this.highlights.push( highlight );
+          highlights.push( highlight );
         }
       }
-      //this.updateHighlights();
     },
 
-    /*
-     updateHighlights
-     Updates all of the highlights on the visual
-     */
-    updateHighlights: function() {
-      if(this._visual.setHighlights) {
-        this._checkVisualState();
+    // TODO: remove when IVisual#setHighlights is removed.
+    _updateHighlights: function() {
+      var hs = this._drawSpec.highlights = this.highlights;
 
-        this._drawSpec.highlights = this.highlights;
+      var promise = utils.promiseCall(this._visual.setHighlights.bind(this._visual, hs))
+          .then(drawn.bind(this));
 
-        this._visual.setHighlights(this.highlights);
+      return this._async().until(promise);
+
+      function drawn() {
+        this._setAction(null);
       }
-    },
-
-    // TODO: Missing setHighlights and getHighlights...
-    // TODO: Should be called clearHighlights??
-    /*
-     updateHighlights
-     Clears all of the highlights on the visual
-     */
-    clearSelections: function() {
-      this.highlights = [];
-      // [DCL] Why isn't visual updated?
     },
 
     // -----------------
@@ -414,7 +473,8 @@ define([
      * Calls the visual's {{#crossLink "IVisual/resize:method"}}{{/crossLink}} method,
      * if implemented, or, otherwise,
      * calls the {{#crossLink "IVisual/draw:method"}}{{/crossLink}} method with
-     * the __same arguments__ used in the previous call.
+     * the __same arguments__ used in the previous call
+     * and with a `"resize"` action.
      *
      * The following errors are thrown, synchronously, if:
      *
@@ -426,8 +486,7 @@ define([
      * @param {number} [width] The new width, in pixels. Defaults to the DOM element's current width.
      * @param {number} [height] The new height, in pixels. Defaults to the DOM element's current height.
      *
-     * @return {Promise} A promise that is
-     *    resolved when the current visual display has finished.
+     * @return {Promise} A promise that is resolved when the update operation has ended.
      */
     resize: function(width, height) {
       this._checkVisualState();
@@ -438,18 +497,25 @@ define([
           w = drawSpec.width  = this._resizeDomDim("width",  width ),
           h = drawSpec.height = this._resizeDomDim("height", height);
 
+      this._setAction("resize");
+
       // Method IVisual#resize is optional.
-      // Call draw with same args when missing.
+      // When not implemented, call draw with the same args and a "resize" action.
       if(!this._visual.resize)
         return this._updateVisual();
 
-      var promise = utils.promiseCall(this._visual.resize.bind(this._visual, w, h));
+      var promise = utils.promiseCall(this._visual.resize.bind(this._visual, w, h))
+          .then(drawn.bind(this));
 
       return this._async().until(promise);
+
+      function drawn() {
+        this._setAction(null);
+      }
     },
 
     /**
-     * Updates the visual specification with the current highlights, state or data.
+     * Updates the visual specification with the current state and/or data.
      *
      * The following errors are thrown, synchronously, if:
      *
@@ -473,8 +539,6 @@ define([
       var visualSpec = this._visualSpec;
 
       if(utils.option(options, "saveState", true)) {
-        visualSpec.highlights = this.highlights;
-
         // Method IVisual#getState is optional.
         if(this._visual.getState)
           visualSpec.state = this._visual.getState() || null;
@@ -574,7 +638,9 @@ define([
       var dataTable = this._dataTable;
       if(!dataTable) throw new Error("No Data");
 
-      var promise = this._getVisual().then(drawItNow.bind(this));
+      var promise = this._getVisual()
+          .then(drawItNow.bind(this))
+          .then(drawn.bind(this));
 
       return this._async().until(promise);
 
@@ -583,6 +649,10 @@ define([
         var drawSpec = this._getDrawSpec(drawOptions);
 
         return this._visual.draw(dataView, drawSpec);
+      }
+
+      function drawn() {
+        this._setAction(null);
       }
     },
 
@@ -630,6 +700,10 @@ define([
         specHelper.setProperties(drawSpec, drawOptions,           ONLY_DEFAULTS);
       }
 
+      // Always set
+      drawSpec.action = (drawOptions && drawOptions.action) ||
+          (this._actionCount === 1 ? this._lastAction : null);
+
       return drawSpec;
     },
 
@@ -644,10 +718,12 @@ define([
      * @param {object} ev The event object.
      */
     _onVisualSelect: function(ev) {
-      this.processHighlights(ev);
+      this._processHighlights(ev);
 
       // Forward event
       visualEvents.trigger(this, "select", ev);
+
+      if(this._actionCount) this.update();
     },
 
     /***
@@ -687,9 +763,38 @@ define([
 
         if(visual.dispose) visual.dispose();
 
-        if(!finalDispose) this._resetDomElem();
+        if(!finalDispose) {
+          this._resetDomElem();
+          this._setAction(null);
+        }
 
         this._visual = visual = null;
+      }
+    },
+
+    /***
+     * Registers an action performed.
+     *
+     * When _nully_, resets the action registry.
+     *
+     * The action registry is tied to the lifetime of a visual instance.
+     * As such, a call to this method only takes effect if there is a current one.
+     *
+     * @method _setAction
+     * @param {string} [action=null] The action performed.
+     * @private
+     */
+    _setAction: function(action) {
+      if(this._visual) {
+        if(action) {
+          if(action !== this._lastAction) {
+            this._lastAction = "setHighlights";
+            this._actionCount++;
+          }
+        } else {
+          this._lastAction  = null;
+          this._actionCount = 0;
+        }
       }
     },
 

--- a/package-res/resources/web/vizapi/_doc/IVisual.js
+++ b/package-res/resources/web/vizapi/_doc/IVisual.js
@@ -80,6 +80,7 @@
  * is subsequently called to inform it of the new highlights.
  *
  * @event select
+ *
  * @param {IVisual} source The visual that triggered the event.
  * @param {Array} selections An array of {{#crossLink "ISelection"}}{{/crossLink}}.
  * @param {String} [selectionMode="REPLACE"] The mode by which the specified _selections_
@@ -97,6 +98,7 @@
  * and affect subsequent handlers.
  *
  * @event doubleclick
+ *
  * @param {IVisual} source The visual that triggered the event.
  * @param {Array} selections An array of {{#crossLink "ISelection"}}{{/crossLink}}.
  */
@@ -106,15 +108,17 @@
  * with the given data.
  *
  * @method draw
+ *
  * @param {DataTable} dataTable The data to encode visually.
  * @param {IVisualDrawSpec} drawSpec The visual _draw_ specification.
+ *
+ * @return {Promise} A promise that is resolved when the operation completes, or _nully_.
  */
 
 /**
  * **Optional** method that resizes the visual to new given dimensions.
  *
- * This method can only be called if the visual
- * has been previously rendered,
+ * This method can only be called if the visual has been previously rendered,
  * with a call to {{#crossLink "IVisual/draw:method"}}{{/crossLink}}.
  *
  * When a visual does not implement it,
@@ -132,51 +136,33 @@
  * before calling this method.
  *
  * @method resize
+ *
  * @param {number} width  The new width, in pixels. A non-negative number.
  * @param {number} height The new height, in pixels. A non-negative number.
+ *
+ * @return {Promise} A promise that is resolved when the operation completes, or _nully_.
  */
 
 /**
  * **Optional** method that gets the state of a visual.
  *
- * This method can only be called if the visual
- * has been previously rendered,
+ * This method can only be called if the visual has been previously rendered,
  * with a call to {{#crossLink "IVisual/draw:method"}}{{/crossLink}}.
  *
  * Note that state information should not include properties
- * that are otherwise present in a
- * {{#crossLink "IVisualSpec"}}visual specification{{/crossLink}}.
+ * that are otherwise present in a {{#crossLink "IVisualSpec"}}visual specification{{/crossLink}}.
  *
  * In general, state information _can_ be related to the current dataset.
  * However, there are no guarantees that the returned state object will only be
  * specified in a subsequent {{#crossLink "IVisual/draw:method"}}{{/crossLink}} call,
  * in {{#crossLink "IVisualSpec/state:property"}}visualSpec.state{{/crossLink}},
- * along with the current dataset.
- * However, it can be assumed that it will only be used with a dataset
- * having the _same structure_ as the current one.
+ * along with the current dataset, or even with a different one but having the _same structure_.
  *
  * State information must be JSON-serializable.
  *
  * @method getState
+ *
  * @return {Object} An object containing the visual's state, or a _nully_ value.
- */
-
-/**
- * **Optional** method that sets the state of a visual,
- * previously obtained by a call to {{#crossLink "IVisual/getState:method"}}{{/crossLink}}.
- *
- * This method can only be called if the visual
- * has been previously rendered,
- * with a call to {{#crossLink "IVisual/draw:method"}}{{/crossLink}}.
- *
- * Usually, state will be provided in the
- * {{#crossLink "IVisualSpec/state:property"}}visualSpec.state{{/crossLink}}
- * argument of a {{#crossLink "IVisual/draw:method"}}{{/crossLink}} method call.
- * However, this method is provided for completness with the
- * {{#crossLink "IVisual/getState:method"}}{{/crossLink}}.
- *
- * @method setState
- * @param {Object} state A non _nully_ object containing the visual's state.
  */
 
 /**
@@ -189,8 +175,7 @@
  * A visual implements this method if it _can_ visually represent the
  * highlighted state of represented entities.
  *
- * This method can only be called if the visual
- * has been previously rendered,
+ * This method can only be called if the visual has been previously rendered,
  * with a call to {{#crossLink "IVisual/draw:method"}}{{/crossLink}}.
  *
  * This method can be called with an empty array, or with a _nully_ value,
@@ -211,14 +196,17 @@
  * and not in a immediately following call to this method.
  *
  * @method setHighlights
+ *
  * @param {Array} [highlights] The current highlights, or,
  *     when none, an empty array or a _nully_ value.
+ *
+ * @return {Promise} A promise that is resolved when the operation completes, or _nully_.
  */
 
 /**
  * **Optional** method that disposes a visual.
  *
- * Allows a visual to release important shared or memory-leaking resources.
+ * Allows a visual to release important resources.
  *
  * @method dispose
  * @since 3.0

--- a/package-res/resources/web/vizapi/_doc/IVisualDrawSpec.js
+++ b/package-res/resources/web/vizapi/_doc/IVisualDrawSpec.js
@@ -33,9 +33,42 @@
  */
 
 /**
- * Gets some value.
+ * Gets the name of the action that triggered the draw operation.
  *
- * @property todo
+ * The following are _standard, reserved action names_:
+ *
+ * 1. `"setData"` — used when the _data_ argument was the only change since the previous draw operation.
+ *
+ * 2. `"setHighlights"` — used when (and only when) a _visual_ does not implement the
+ *     {{#crossLink "IVisual/setHighlights:method"}}{{/crossLink}} method and, as such,
+ *     {{#crossLink "IVisual/draw:method"}}{{/crossLink}}
+ *     is called instead with an updated {{#crossLink "IVisualSpec/highlights:property"}}{{/crossLink}}
+ *     property value.
+ *
+ * 3. `"resize"` — used when (and only when) a _visual_ does not implement the
+ *     {{#crossLink "IVisual/resize:method"}}{{/crossLink}} method and, as such,
+ *     {{#crossLink "IVisual/draw:method"}}{{/crossLink}}
+ *     is called instead with updated
+ *     {{#crossLink "IVisualSpec/width:property"}}{{/crossLink}} and
+ *     {{#crossLink "IVisualSpec/height:property"}}{{/crossLink}} property values.
+ *
+ * 4. `"setProps"` — used when one or more of the generic visual properties, _which_ is unknown,
+ *     were the only change since the previous draw operation.
+ *     Note that this also means that _data_, _highlights_ and _available size_ have _not_ changed.
+ *
+ * Actions that correspond to a single generic visual property changing its value _must_ follow
+ * the pattern: `"change:&lt;propertyId&gt;"` (angle brackets not included).
+ *
+ * Containers are not required to specify visual property change actions,
+ * however, when they do, then it must be the case that no other argument
+ * (data, visual property, highlights, etc.) has changed since the previous draw operation.
+ *
+ * Visuals _can_ take advantage of the action property to optimize certain draw calls.
+ *
+ * Visuals _must_ react to an _unknown_ or _falsy_ action by performing a full (re-)draw.
+ *
+ * @property action
  * @type string
  * @since 3.0
+ * @optional
  */

--- a/package-res/resources/web/vizapi/ccc/visualApiConfig.js
+++ b/package-res/resources/web/vizapi/ccc/visualApiConfig.js
@@ -25,15 +25,15 @@ define(function() {
         id:        /^ccc_/,
         container: "analyzer",
 
-        translateEditorProperties: function(editorTypeId, editorProps, filterPropsList, filterPropsMap) {
+        getEditorProperties: function(editorDoc, filterPropsList, filterPropsMap) {
           // Let every Analyzer option pass-through except certain ignored ones.
           // This is true even if some/all don't have corresponding data requirements.
 
           var visualProps = {};
 
-          (filterPropsList || editorProps).forEach(function(p) {
+          (filterPropsList || editorDoc).forEach(function(p) {
               if(!isIgnoredEditorProp(p)) {
-                var value = editorProps.get(p);
+                var value = editorDoc.get(p);
                 switch(p) {
                   // boolean
                   case "autoRange":

--- a/package-res/resources/web/vizapi/ccc/wrapper/charts/BarChart.js
+++ b/package-res/resources/web/vizapi/ccc/wrapper/charts/BarChart.js
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 define([
-    "./AbstractBarChart"
+    "./AbstractBarChart",
+    "../trends"
 ], function(AbstractBarChart) {
 
     return AbstractBarChart.extend({

--- a/package-res/resources/web/vizapi/ccc/wrapper/charts/LineChart.js
+++ b/package-res/resources/web/vizapi/ccc/wrapper/charts/LineChart.js
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 define([
-    "./AbstractCategoricalContinuousChart"
+    "./AbstractCategoricalContinuousChart",
+    "../trends"
 ], function(AbstractCategoricalContinuousChart) {
 
     return AbstractCategoricalContinuousChart.extend({

--- a/package-res/resources/web/vizapi/ccc/wrapper/charts/MetricDotChart.js
+++ b/package-res/resources/web/vizapi/ccc/wrapper/charts/MetricDotChart.js
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 define([
-    "./AbstractCartesianChart"
+    "./AbstractCartesianChart",
+    "../trends"
 ], function(AbstractCartesianChart) {
 
     return AbstractCartesianChart.extend({

--- a/package-res/resources/web/vizapi/config.js
+++ b/package-res/resources/web/vizapi/config.js
@@ -42,7 +42,7 @@ define(function() {
       {
         priority:  -1,
         id:        ["ccc_bulletchart", "ccc_treemap", "ccc_waterfall", "ccc_boxplot"],
-        enabled:   false,
+        enabled:   false
       },
 
       // Override/Configure the CCC Line chart for Analyzer

--- a/package-res/resources/web/vizapi/editor/_doc/IVisualEditorDocument.js
+++ b/package-res/resources/web/vizapi/editor/_doc/IVisualEditorDocument.js
@@ -19,17 +19,35 @@
  */
 
 /**
- * A minimal interface for reading properties exposed by a visuals editor.
+ * A minimal interface for accessing a visualization editor document counterpart and
+ * also for providing a way to generically read the properties it exposes.
  *
- * Used by {{#crossLink "IVisualTypeConfiguration/translateEditorProperties:property"}}{{/crossLink}}.
+ * Used by {{#crossLink "IVisualTypeConfiguration/getEditorProperties:property"}}{{/crossLink}}.
  *
- * @class IVisualEditorProperties
+ * @class IVisualEditorDocument
  * @constructor
  */
 
 /**
- * Calls a function once for each editor property,
- * passing it its name.
+ * The editor type id.
+ *
+ * @property editorTypeId
+ * @type string
+ */
+
+/**
+ * An editor specific object that represents and gives access to the underlying document
+ * and, possibly, to the editor itself.
+ *
+ * Can be _nully_, always or only in certain environments (like when printing), so code
+ * should be able to handle both situations.
+ *
+ * @property source
+ * @type object
+ */
+
+/**
+ * Calls a function once for each editor property, passing it its name.
  *
  * @method forEach
  * @param {function} fun The mapping function.

--- a/package-res/resources/web/vizapi/editor/utils.js
+++ b/package-res/resources/web/vizapi/editor/utils.js
@@ -36,25 +36,24 @@ define([
    */
 
   return {
-      translateEditorProperties: translateEditorProperties,
-      processEditModelChange:    processEditModelChange
+      getEditorProperties:    getEditorProperties,
+      processEditModelChange: processEditModelChange
     };
 
   /**
-   * Translates editor _external_ properties to properties of visuals.
+   * Gets the visualization properties exposed by a visualization editor's document.
    *
    * If the visual type has been configured with
-   * {{#crossLink "IVisualTypeConfiguration/translateEditorProperties:method"}}{{/crossLink}},
-   * it is called to perform the translation.
+   * {{#crossLink "IVisualTypeConfiguration/getEditorProperties:method"}}{{/crossLink}},
+   * it is called to perform the retrieval.
    *
    * When _filterPropsList_ is specified,
    * the returned properties surely only contain properties present in the list.
    *
-   * @method translateEditorProperties
+   * @method getEditorProperties
    *
    * @param {IVisualType} type The visual type.
-   * @param {string} editorType The id of the editor type that is the source of _editorProps_.
-   * @param {IVisualEditorProperties} editorProps An object that allows reading the editor's properties.
+   * @param {IVisualEditorDocument} editorDoc An object that allows accessing the editor's document and properties.
    * @param {string|string[]} [filterPropsList] A string or an array of strings with
    *   the editor property names
    *   that should be processed. When this is unspecified, _nully_,
@@ -65,12 +64,11 @@ define([
    *
    * @return {Object} A map of "visual properties".
    */
-  function translateEditorProperties(type, editorType, editorProps, filterPropsList) {
+  function getEditorProperties(type, editorDoc, filterPropsList) {
     if(!type)        throw utils.error.argRequired("type");
-    if(!editorType)  throw utils.error.argRequired("editorType");
-    if(!editorProps) throw utils.error.argRequired("editorProps");
+    if(!editorDoc) throw utils.error.argRequired("editorDoc");
 
-    var translateProps = type.translateEditorProperties || defaultTranslateProperties;
+    var getProps = type.getEditorProperties || defaultGetProperties;
 
     // Create an index for `filterPropsList` on property name.
     var filterPropsMap;
@@ -83,10 +81,10 @@ define([
       filterPropsList = filterPropsMap = null;
     }
 
-    var visualProps = translateProps.call(type, editorType, editorProps, filterPropsList, filterPropsMap);
+    var visualProps = getProps.call(type, editorDoc, filterPropsList, filterPropsMap);
 
     // Ensure only props specified in filterPropsList are output.
-    if(visualProps && filterPropsList && translateProps !== defaultTranslateProperties) {
+    if(visualProps && filterPropsList && getProps !== defaultGetProperties) {
       var visualProps2 = {};
       filterPropsList.forEach(function(p) {
         if(utils.O_hasOwn.call(visualProps, p))
@@ -140,7 +138,7 @@ define([
 
   // @private
   // @this IVisualType
-  function defaultTranslateProperties(editorType, editorProps, filterPropsList, filterPropsMap) {
+  function defaultGetProperties(editorDoc, filterPropsList, filterPropsMap) {
     // Copy all editor options that have the same name of a non-structure data req,
     // filtered by filterPropsMap
 
@@ -148,7 +146,7 @@ define([
 
     typeHelper.mapGeneralRequirements(this, function(req) {
       var id = req.id, value;
-      if((value = editorProps.get(id)) !== undefined &&
+      if((value = editorDoc.get(id)) !== undefined &&
          (!filterPropsMap || utils.O_hasOwn.call(filterPropsMap, id))) {
         visualProps[id] = value;
       }

--- a/package-res/resources/web/vizapi/sample/visualTypeProvider.js
+++ b/package-res/resources/web/vizapi/sample/visualTypeProvider.js
@@ -21,7 +21,9 @@ define(["require", "es6-promise-shim"], function(require) {
 
   function visualFactory(createOptions) {
     return new Promise(function(resolve, reject) {
-      require(["./Calc"], function(Calc) { return new Calc(createOptions); }, reject);
+      require(["./Calc"], function(Calc) {
+        resolve(new Calc(createOptions));
+      }, reject);
     });
   }
 

--- a/package-res/resources/web/vizapi/spec/helper.js
+++ b/package-res/resources/web/vizapi/spec/helper.js
@@ -36,6 +36,7 @@ define([
    */
 
   var standardSpec = {
+          action: 1,
           type:   1,
           state:  1,
           data:   1,
@@ -49,6 +50,7 @@ define([
       create: create,
       clone:  clone,
       setProperties: setProperties,
+      eachProperties: eachProperties,
       isStandardProperty: isStandardProperty
     };
 
@@ -56,7 +58,8 @@ define([
    * Indicates if a name is that of a standard property name.
    *
    * Standard specification properties are those defined
-   * by the {{#crossLink "IVisualSpec"}}{{/crossLink}} interface:
+   * by the {{#crossLink "IVisualSpec"}}{{/crossLink}} and
+   * {{#crossLink "IVisualDrawSpec"}}{{/crossLink}} interfaces:
    *
    * * `type`
    * * `state`
@@ -65,6 +68,7 @@ define([
    * * `direct`
    * * `width`
    * * `height`
+   * * `action`
    *
    * @method isStandardProperty
    *
@@ -131,6 +135,26 @@ define([
   }
 
   /**
+   * Calls a function for each generic (non-standard), defined property of a visual specification.
+   *
+   * @method eachProperties
+   *
+   * @param {IVisualSpec} spec The specification whose properties to map.
+   * @param {function} fun The mapping function.
+   *   Called with each property's value and name as arguments.
+   *   Iteration is cancelled if the function returns the value `false`.
+   * @param {object} [ctx] The `this` context on which to call `fun`.
+   *
+   * @return {boolean} `true` if iteration was not cancelled, `false` otherwise.
+   */
+  function eachProperties(spec, fun, ctx) {
+    return utils.O_eachOwnDefined.call(spec, function(v, p) {
+      if(!isStandardProperty(p))
+        return fun.call(ctx, v, p); // maybe stop
+    });
+  }
+
+  /**
    * Sets properties in a visual specification, given a property map.
    *
    * Optionally, only sets properties that are not yet defined in
@@ -148,8 +172,8 @@ define([
    * of the specification that have no value should be set.
    */
   function setProperties(spec, props, defaultsOnly) {
-    if(props) utils.O_eachOwnDefined.call(props, function(v, p) {
-      if(!isStandardProperty(p) && (!defaultsOnly || spec[p] === undefined))
+    if(props) eachProperties(props, function(v, p) {
+      if(!defaultsOnly || spec[p] === undefined)
         spec[p] = v;
     });
   }

--- a/package-res/resources/web/vizapi/type/_doc/IVisualRoleRequirement.js
+++ b/package-res/resources/web/vizapi/type/_doc/IVisualRoleRequirement.js
@@ -84,10 +84,32 @@
  * Indicates if a visual role requirement supports
  * multiple data properties.
  *
+ * Specifying this option with value `false` is equivalent to
+ * specifying {{#crossLink "IVisualRoleRequirement/maxOccur:property"}}{{/crossLink}}
+ * with a value of `1`.
+ *
+ * The most restrictive (minimum of occurrence limits) between
+ * this property and {{#crossLink "IVisualRoleRequirement/maxOccur:property"}}{{/crossLink}} wins.
+ *
  * @property allowMultiple
  * @type boolean
  * @optional
- * @default false
+ * @default true
+ */
+
+/**
+ * The maximum number of data properties that a
+ * visual role requirement supports.
+ *
+ * A number greater than or equal to `1`.
+ *
+ * The most restrictive (minimum of occurrence limits) between
+ * this property and {{#crossLink "IVisualRoleRequirement/allowMultiple:property"}}{{/crossLink}} wins.
+ *
+ * @property maxOccur
+ * @type number
+ * @optional
+ * @default Infinity
  */
 
 /**
@@ -95,10 +117,29 @@
  *
  * The visual role must be bound to at least one data property.
  *
+ * Specifying this option with value `true` is equivalent to
+ * specifying {{#crossLink "IVisualRoleRequirement/minOccur:property"}}{{/crossLink}}
+ * with a value of `1`.
+ *
+ * The most restrictive (maximum of occurrence limits) between
+ * this property and {{#crossLink "IVisualRoleRequirement/minOccur:property"}}{{/crossLink}} wins.
+ *
  * @property required
  * @type boolean
  * @optional
  * @default false
+ */
+
+/**
+ * The minimum number of data properties that a visual role requirement must be bound to.
+ *
+ * The most restrictive (maximum of occurrence limits) between
+ * this property and {{#crossLink "IVisualRoleRequirement/required:property"}}{{/crossLink}} wins.
+ *
+ * @property minOccur
+ * @type number
+ * @optional
+ * @default 0
  */
 
 /**

--- a/package-res/resources/web/vizapi/type/_doc/IVisualType.js
+++ b/package-res/resources/web/vizapi/type/_doc/IVisualType.js
@@ -198,3 +198,20 @@
  * @param {string} [changedProp] The name of the property that has changed.
  *    When unspecified, it is assumed that all properties have changed.
  */
+
+/**
+ * Validates a given edit model based on the current requirement values.
+ *
+ * This method can assume that basic validation —
+ * "requiredness" and minimum occurrence —
+ * has been performed and was successful.
+ *
+ * The returned {{#crossLink "Error"}}{{/crossLink}} objects can
+ * have a string `code` property with an error code.
+ *
+ * @method validateEditModel
+ *
+ * @param {IVisualEditModel} editModel The visual edit model to validate.
+ * @return {Error[]|null} A non-empty array of error objects,
+ *    or `null`, when there are no validation errors.
+ */

--- a/package-res/resources/web/vizapi/type/_doc/IVisualTypeConfiguration.js
+++ b/package-res/resources/web/vizapi/type/_doc/IVisualTypeConfiguration.js
@@ -152,15 +152,14 @@
  */
 
 /**
- * **Optional** method that translates editor _external_ properties to properties of visuals.
+ * **Optional** method that gets the visualization properties exposed by a visualization editor's document.
  *
  * This method is called with the configured visual type,
  * {{#crossLink "IVisualType"}}{{/crossLink}}, as the `this` JavaScript context.
  *
- * @method translateEditorProperties
+ * @method getEditorProperties
  *
- * @param {string} editorTypeId The id of the editor type that is the source of _editorProps_.
- * @param {IVisualEditorProperties} editorProps An object that allows reading the editor's properties.
+ * @param {IVisualEditorDocument} editorDoc An object that allows accessing the editor's document and properties.
  * @param {string|string[]} [filterPropsList] A string or an array of strings with
    *   the editor property names
    *   that should be processed. When this is unspecified, _nully_,

--- a/package-res/resources/web/vizapi/type/helper.js
+++ b/package-res/resources/web/vizapi/type/helper.js
@@ -41,7 +41,8 @@ define([
       createInstance: createInstance,
       mapGeneralRequirements: mapGeneralRequirements,
       mapVisualRoleRequirements: mapVisualRoleRequirements,
-      getRequirements: getRequirements
+      getRequirements: getRequirements,
+      getRequirementOccurRange: getRequirementOccurRange
     };
 
   /**
@@ -60,8 +61,6 @@ define([
    * @param {function} fun The mapping function.
    *   Called with the general requirement
    *   {{#crossLink "IGeneralRequirement"}}{{/crossLink}} as only argument.
-   *   Standard specification properties are ignored
-   *   (`type`, `state`, `data`, `highlights`, `width` and `height`).
    * @param {object} [ctx] The `this`context on which to call `fun`.
    */
   function mapGeneralRequirements(type, fun, ctx) {
@@ -89,8 +88,6 @@ define([
    * @param {function} fun The mapping function.
    *   Called with the visual role requirement
    *   {{#crossLink "IVisualRoleRequirement"}}{{/crossLink}} as only argument.
-   *   Standard specification properties are ignored
-   *   (`type`, `state`, `data`, `highlights`, `width` and `height`).
    * @param {object} [ctx] The `this`context on which to call `fun`.
    */
   function mapVisualRoleRequirements(type, fun, ctx) {
@@ -123,6 +120,29 @@ define([
     if(!type) throw utils.error.argRequired("type");
     var dataReqs = type.dataReqs;
     return (dataReqs && dataReqs[0] && dataReqs[0].reqs) || null;
+  }
+
+  /**
+   * Gets the normalized occurrence range of a requirement.
+   *
+   * @method getRequirementOccurRange
+   *
+   * @param {IRequirement} req The data requirement.
+   *
+   * @return {Object} An object with `min` and `max` properties.
+   */
+  function getRequirementOccurRange(req) {
+    var minOccur = Math.max(req.required ? 1 : 0, req.minOccur || 0); // >= 0
+
+    var allowMultiple = req.allowMultiple == null || !!req.allowMultiple;
+    var maxOccur = Math.min( // >=  1
+          allowMultiple ? Infinity : 1,
+          req.maxOccur == null ? Infinity : Math.max(req.maxOccur, 1));
+
+    return {
+      min: minOccur,
+      max: minOccur > maxOccur ? minOccur : maxOccur
+    };
   }
 
   /**


### PR DESCRIPTION
This pull-request should only be accepted if https://github.com/pentaho/pentaho-analyzer/pull/656 is also accepted.

* Re-adding CCC/VisualAPI trends synchronization, lost in the last commit
* Fixes highlights not being set in drawSpec when `VisualWrapper#updateHighlights` is called.
  * This is required by the GEO plugin.
  * The whole highlights functionality is still to be refactored so no tests or great care is given for now.
* Renaming "visualTypeConfig.js" to the more appropriate name "visualApiConfig.js"
* Renaming `VisualEditorUtils#translateEditorProperties` and `IVisualTypeConfiguration#translateEditorProperties` to `#getEditorProperties`. Translation gave the impression of 1-1, and that every source of visualization properties were _editor properties_. Actually, visualization properties provided by an editor may reflect arbitrary editor state, like navigation history and such.

##### VizController refactor - validateEditModel, minOccur, maxOccur and action

* The new `VisualEditorUtils#validateEditModel` and `IVisualType#validateEditModel` pair with the already existing `processEditModelChange`, and allow covering validation cases not covered by the standard requirement validation attributes (required, allowMultiple, minOccur, maxOccur).
* The new `VisualTypeHelper#getRequirementOccurRange` exposes the logic for interpreting the standard requirement validation attributes.
* The new IVisualDrawSpec#action property now allows a visualization to receive an `action` argument that informs about the type of expected `draw` operation. Action is either one of the standard actions: "setHighlights", "setData", "setProps" and "resize" or a "change:<propertyId>" pattern, for single property changes. The `VisualWrapper` "implements" the first 4 actions, while the property change pattern must be ensured by the container/editor.

@pamval please review.