### PR TITLE
[BACKLOG-4055]

### DIFF
--- a/config/context.js
+++ b/config/context.js
@@ -15,6 +15,20 @@
  *
  * Copyright 2015 Pentaho Corporation. All rights reserved.
  */
+
+/**
+ * The possible configurations to define the environment where the require-cfg files are running.
+ * This allows the build and test environments, differing between several plugins to fully configure the path where
+ * the files from the external lib are served
+ *
+ * @type {{paths: {common-ui: string, cdf: string}}}
+ */
+var ENVIRONMENT_CONFIG = {
+  paths: {
+    "cdf": "../../build-res/module-scripts/cdf/js",
+    "cdf/lib": "../../build-res/module-scripts/cdf/js/lib"
+  }
+};
 var KARMA_RUN = true;
 var pen = {define : define, require : require};
 var SESSION_LOCALE="en";

--- a/config/karma.ci.conf.js
+++ b/config/karma.ci.conf.js
@@ -48,6 +48,7 @@ module.exports = function (config) {
       "package-res/resources/web/plugin-handler/**/*.js": ["coverage"],
       "package-res/resources/web/angular-directives/**/*.js": ["coverage"],
       "package-res/resources/web/vizapi/**/*.js": ["coverage"],
+      "package-res/resources/web/prompting/**/*.js": ["coverage"],
       "**/*.html": []
     },
 

--- a/config/require-config.js
+++ b/config/require-config.js
@@ -22,8 +22,6 @@ requireCfg.paths["common-ui/prompting"] = "common-ui/prompting";
 requireCfg.paths["pentaho/visual/type/registryMock"] =
     "/base/package-res/resources/web/test/karma/unit/vizapi/type/registryMock";
 
-requireCfg.paths["cdf/lib"] = "cdf/js/lib";
-
 // Reset "service" module configuration.
 requireCfg.config.service = {};
 

--- a/package-res/resources/web/prompting/components/StaticAutocompleteBoxComponent.js
+++ b/package-res/resources/web/prompting/components/StaticAutocompleteBoxComponent.js
@@ -15,8 +15,8 @@
  *
  */
 
-define(['cdf/components/BaseComponent', 'dojo/number', 'cdf/lib/jquery.ui'],
-    function (BaseComponent, DojoNumber) {
+define(['cdf/components/BaseComponent', 'dojo/number', 'amd!cdf/lib/jquery.ui'],
+    function (BaseComponent, DojoNumber, $) {
 
       /**
        *


### PR DESCRIPTION
- Updated the way cdf code is referenced within code stage.
- In cdf the ability to fully configure the location of the cdf source code was added. This configuration was added in context.js
- Fixed unit test for StaticAutocompleteBoxComponent due to missing jquery.ui dependency