### PR TITLE
[BACKLOG-4132] - Develop unit tests for builders

### DIFF
--- a/package-res/resources/web/prompting/builders/DateInputBuilder.js
+++ b/package-res/resources/web/prompting/builders/DateInputBuilder.js
@@ -22,7 +22,8 @@ define(['./ValueBasedParameterWidgetBuilder', '../components/DojoDateTextBoxComp
         build: function (args) {
           var formatter = args.promptPanel.createFormatter(args.promptPanel.paramDefn, args.param);
 
-          $.extend(this.base(args), {
+          var widget = this.base(args);
+          $.extend(widget, {
             type: 'DojoDateTextBoxComponent',
             transportFormatter: args.promptPanel.createDataTransportFormatter(args.promptPanel.paramDefn, args.param, formatter),
             formatter: formatter

--- a/package-res/resources/web/prompting/builders/ExternalInputBuilder.js
+++ b/package-res/resources/web/prompting/builders/ExternalInputBuilder.js
@@ -22,7 +22,8 @@ define(['./ValueBasedParameterWidgetBuilder', '../components/ExternalInputCompon
         build: function (args) {
           var formatter = args.promptPanel.createFormatter(args.promptPanel.paramDefn, args.param);
 
-          $.extend(this.base(args), {
+          var widget = this.base(args);
+          $.extend(widget, {
             type: 'ExternalInputComponent',
             transportFormatter: args.promptPanel.createDataTransportFormatter(args.promptPanel.paramDefn, args.param, formatter),
             formatter: formatter,

--- a/package-res/resources/web/test/prompting/builders/CheckBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/CheckBuilderSpec.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/CheckBuilder'], function(CheckBuilder) {
+
+  describe("CheckBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var checkBuilder;
+
+    beforeEach(function() {
+      checkBuilder = new CheckBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(checkBuilder.build).toThrow();
+    });
+
+    it("should return a CheckComponent", function() {
+      var component = checkBuilder.build(args);
+      expect(component.type).toBe('CheckComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/DateInputBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/DateInputBuilderSpec.js
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/DateInputBuilder'], function(DateInputBuilder) {
+
+  describe("DateInputBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        createFormatter: function() { },
+        createDataTransportFormatter: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var dateInputBuilder;
+
+    beforeEach(function() {
+      dateInputBuilder = new DateInputBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(dateInputBuilder.build).toThrow();
+    });
+
+    it("should return a DojoDateTextBoxComponent", function() {           
+      var component = dateInputBuilder.build(args);
+      expect(component.type).toBe('DojoDateTextBoxComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/DropDownBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/DropDownBuilderSpec.js
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/DropDownBuilder'], function(DropDownBuilder) {
+
+  describe("DropDownBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        paramDefn: {
+          ignoreBiServer5538: true
+        }
+      }, 
+      param:  {
+        values: { },
+        attributes: { },
+        hasSelection: function() { return true; }
+      }
+    };
+
+    var dropDownBuilder;
+
+    beforeEach(function() {
+      dropDownBuilder = new DropDownBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(dropDownBuilder.build).toThrow();
+    });
+
+    it("should return a SelectComponent", function() {
+      var component = dropDownBuilder.build(args);
+      expect(component.type).toBe('SelectComponent');
+      expect(component.preExecution).toBeDefined();
+    });
+
+    it("should create an empty selection if no value is selected", function() {
+      spyOn(args.param, 'hasSelection').and.returnValue(false);
+
+      var component = dropDownBuilder.build(args);
+      expect(args.param.hasSelection).toHaveBeenCalled();
+      expect(component.valuesArray.length > 0).toBeTruthy();
+      expect(component.valuesArray[0][0]).toEqual("");
+      expect(component.valuesArray[0][1]).toEqual("");
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ErrorLabelBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ErrorLabelBuilderSpec.js
@@ -1,0 +1,53 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ErrorLabelBuilder'], function(ErrorLabelBuilder) {
+
+  describe("ErrorLabelBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { 
+          label: 'test-label'
+        }
+      }
+    };
+
+    var errorLabelBuilder;
+
+    beforeEach(function() {
+      errorLabelBuilder = new ErrorLabelBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(errorLabelBuilder.build).toThrow();
+    });
+
+    it("should return a TextComponent", function() {
+      var component = errorLabelBuilder.build(args);
+      expect(component.type).toBe('TextComponent');
+      expect(component.expression).toBeDefined();
+      expect(component.isErrorIndicator).toBeTruthy();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ExternalInputBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ExternalInputBuilderSpec.js
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ExternalInputBuilder'], function(ExternalInputBuilder) {
+
+  describe("ExternalInputBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        createFormatter: function() { },
+        createDataTransportFormatter: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var externalInputBuilder;
+
+    beforeEach(function() {
+      externalInputBuilder = new ExternalInputBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {      
+      expect(externalInputBuilder.build).toThrow();
+    });
+
+    it("should return a ExternalInputComponent", function() {
+      var component = externalInputBuilder.build(args);
+      expect(component.type).toBe('ExternalInputComponent');
+    });
+
+  });
+});

--- a/package-res/resources/web/test/prompting/builders/GarbageCollectorBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/GarbageCollectorBuilderSpec.js
@@ -1,0 +1,53 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/GarbageCollectorBuilder'], function(GarbageCollectorBuilder) {
+
+  describe("GarbageCollectorBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { return "12345"},
+        getParameterName: function() { },
+        removeDashboardComponents: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      },
+      components: []
+    };
+
+    var garbageCollectorBuilder;
+
+    beforeEach(function() {
+      garbageCollectorBuilder = new GarbageCollectorBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(garbageCollectorBuilder.build).toThrow();
+    });
+
+    it("should return a GarbageCollectorComponent", function() {
+      var component = garbageCollectorBuilder.build(args);
+      expect(component.name.indexOf('gc') == 0).toBeTruthy();
+      expect(component.preExecution).toBeDefined();
+      expect(component.preExecution()).toBeFalsy();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/LabelBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/LabelBuilderSpec.js
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/LabelBuilder'], function(LabelBuilder) {
+
+  describe("LabelBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { },
+        name: 'label-test'
+      }
+    };
+
+    var labelBuilder;
+
+    beforeEach(function() {
+      labelBuilder = new LabelBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(labelBuilder.build).toThrow();
+    });
+
+    it("should return a TextComponent", function() {
+      var component = labelBuilder.build(args);
+      expect(component.type).toBe('TextComponent');
+      expect(component.expression()).toEqual(args.param.name);
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ListBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ListBuilderSpec.js
@@ -1,0 +1,79 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ListBuilder'], function(ListBuilder) {
+
+  describe("ListBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { },
+        multiSelect: false
+      }
+    };
+
+    var listBuilder;
+
+    beforeEach(function() {
+      listBuilder = new ListBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(listBuilder.build).toThrow();
+    });
+
+    it("should return a SelectComponent if multiSelect is set to false", function() {
+      var component = listBuilder.build(args);
+      expect(component.type).toBe('SelectComponent');
+      expect(component.preExecution).toBeDefined();
+    });
+
+    it("should return a MultiSelectComponent if multiSelect is set to true", function() {
+      args.param.multiSelect = true;
+      var component = listBuilder.build(args);
+      expect(component.type).toBe('SelectMultiComponent');
+      expect(component.preExecution).toBeDefined();
+    });
+
+    it("should return a component with the specified number of items", function() {
+      args.param.attributes['parameter-visible-items'] = 3;
+      var component = listBuilder.build(args);
+      expect(component.size).toEqual(args.param.attributes['parameter-visible-items']);
+      expect(component.preExecution).toBeDefined();
+    });
+
+    it("should return a component with the changeMode set to 'immediate' when multiSelect is set to false", function() {
+      args.param.multiSelect = false;
+      var component = listBuilder.build(args);
+      expect(component.changeMode).toEqual('immediate');
+      expect(component.preExecution).toBeDefined();
+    });
+
+    it("should return a component with the changeMode set to 'timeout-focus' when multiSelect is set to true", function() {
+      args.param.multiSelect = true;
+      var component = listBuilder.build(args);
+      expect(component.changeMode).toEqual('timeout-focus');
+      expect(component.preExecution).toBeDefined();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/MultiButtonBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/MultiButtonBuilderSpec.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/MultiButtonBuilder'], function(MultiButtonBuilder) {
+
+  describe("MultiButtonBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var multiButtonBuilder
+
+    beforeEach(function() {
+      multiButtonBuilder = new MultiButtonBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(multiButtonBuilder.build).toThrow();
+    });
+
+    it("should return a MultiButtonComponent", function() {
+      var component = multiButtonBuilder.build(args);
+      expect(component.type).toBe('MultiButtonComponent');
+      expect(component.expression).toBeDefined();
+      expect(component.postExecution).toBeDefined();
+    });
+
+    it("should add class on postExecution", function() {
+      var component = multiButtonBuilder.build(args);
+      spyOn($.fn, 'addClass');
+      component.postExecution();
+      expect($.fn.addClass).toHaveBeenCalled();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ParameterGroupPanelBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ParameterGroupPanelBuilderSpec.js
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ParameterGroupPanelBuilder'], function(ParameterGroupPanelBuilder) {
+
+  describe("ParameterGroupPanelBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        paramDefn: {
+          layout: ''
+        }
+      }, 
+      param:  {
+        values: { },
+        attributes: { },
+      },
+      paramGroup: {
+        name: ''
+      }
+    };
+
+    var parameterPanelBuilder;
+
+    beforeEach(function() {
+      parameterPanelBuilder = new ParameterGroupPanelBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(parameterPanelBuilder.build).toThrow();
+    });
+
+    it("should return a HorizontalTableBasedPromptLayoutComponent when layout is 'horizontal'", function() {
+      args.promptPanel.paramDefn.layout = 'horizontal';
+      var component = parameterPanelBuilder.build(args);
+      expect(component.type).toBe('HorizontalTableBasedPromptLayoutComponent');
+    });
+
+    it("should return a FlowPromptLayoutComponent when layout is 'flow'", function() {
+      args.promptPanel.paramDefn.layout = 'flow';
+      var component = parameterPanelBuilder.build(args);
+      expect(component.type).toBe('FlowPromptLayoutComponent');
+    });
+
+    it("should return a VerticalTableBasedPromptLayoutComponent when layout is 'vertical'", function() {
+      args.promptPanel.paramDefn.layout = 'vertical';
+      var component = parameterPanelBuilder.build(args);
+      expect(component.type).toBe('VerticalTableBasedPromptLayoutComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ParameterPanelBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ParameterPanelBuilderSpec.js
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ParameterPanelBuilder'], function(ParameterPanelBuilder) {
+
+  describe("ParameterPanelBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        buildPanelComponents: function() { }
+      }
+    };
+
+    var parameterPanelBuilder;
+
+    beforeEach(function() {
+      parameterPanelBuilder = new ParameterPanelBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(parameterPanelBuilder.build).toThrow();
+    });
+
+    it("should return a ParameterPanelComponent", function() {
+      var component = parameterPanelBuilder.build(args);
+      expect(component.type).toBe('ParameterPanelComponent');
+      expect(component.name.indexOf('panel-') == 0).toBeTruthy();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ParameterWidgetBuilderBaseSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ParameterWidgetBuilderBaseSpec.js
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ParameterWidgetBuilderBase'], function(ParameterWidgetBuilderBase) {
+
+  describe("ParameterWidgetBuilderBase", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: []
+      }
+    };
+
+    var parameterWidgetBuilderBase;
+
+    beforeEach(function() {
+      parameterWidgetBuilderBase = new ParameterWidgetBuilderBase();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(parameterWidgetBuilderBase.build).toThrow();
+    });
+
+    it("should return build successfully", function() {
+      var component = parameterWidgetBuilderBase.build(args);
+      expect(component.postExecution).toBeDefined();
+      expect(component.type).toBeUndefined();
+      expect(component.promptType).toEqual('prompt');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/PlainPromptBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/PlainPromptBuilderSpec.js
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/PlainPromptBuilder'], function(PlainPromptBuilder) {
+
+  describe("PlainPromptBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        createFormatter: function() { },
+        createDataTransportFormatter: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var plainPromptBuilder;
+
+    beforeEach(function() {
+      plainPromptBuilder = new PlainPromptBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(plainPromptBuilder.build).toThrow();
+    });
+
+    it("should return a StaticAutocompleteBoxComponent", function() {
+      var component = plainPromptBuilder.build(args);
+      expect(component.type).toBe('StaticAutocompleteBoxComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/PromptPanelBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/PromptPanelBuilderSpec.js
@@ -1,0 +1,55 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/PromptPanelBuilder'], function(PromptPanelBuilder) {
+
+  describe("PromptPanelBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        buildPanelComponents: function() { },
+        _ready: function() { }
+      }
+    };
+
+    var promptPanelBuilder;
+
+    beforeEach(function() {
+      promptPanelBuilder = new PromptPanelBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(promptPanelBuilder.build).toThrow();
+    });
+
+    it("should return a ScrollingPromptPanelLayoutComponent", function() {
+      var component = promptPanelBuilder.build(args.promptPanel);
+      expect(component.type).toBe('ScrollingPromptPanelLayoutComponent');
+      expect(component.postExecution).toBeDefined();
+    });
+
+    it("should execute _ready on postExecution", function() {
+      var component = promptPanelBuilder.build(args.promptPanel); 
+      spyOn(args.promptPanel, '_ready').and.callThrough();
+      component.postExecution();
+      expect(args.promptPanel._ready).toHaveBeenCalled();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/RadioBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/RadioBuilderSpec.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/RadioBuilder'], function(RadioBuilder) {
+
+  describe("RadioBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var radioBuilder;
+
+    beforeEach(function() {
+      radioBuilder = new RadioBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(radioBuilder.build).toThrow();
+    });
+
+    it("should return a RadioComponent", function() {
+      var component = radioBuilder.build(args);
+      expect(component.type).toBe('radio');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/SubmitComponentBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/SubmitComponentBuilderSpec.js
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/SubmitComponentBuilder'], function(SubmitComponentBuilder) {
+
+  describe("SubmitComponentBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        getString: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var submitComponentBuilder;
+
+    beforeEach(function() {
+      submitComponentBuilder = new SubmitComponentBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(submitComponentBuilder.build).toThrow();
+    });
+
+    it("should return a SubmitPromptComponent", function() {
+      var component = submitComponentBuilder.build(args);
+      expect(component.type).toBe('SubmitPromptComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/TextAreaBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/TextAreaBuilderSpec.js
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/TextAreaBuilder'], function(TextAreaBuilder) {
+
+  describe("TextAreaBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { },
+        createFormatter: function() { },
+        createDataTransportFormatter: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var textAreaBuilder;
+
+    beforeEach(function() {
+      textAreaBuilder = new TextAreaBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(textAreaBuilder.build).toThrow();
+    });
+
+    it("should return a TextAreaComponent", function() {            
+      var component = textAreaBuilder.build(args);
+      expect(component.type).toBe('TextAreaComponent');
+    });
+  
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/TextInputBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/TextInputBuilderSpec.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/TextInputBuilder'], function(TextInputBuilder) {
+
+  describe("TextInputBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: { }
+      }
+    };
+
+    var textInputBuilder;
+
+    beforeEach(function() {
+      textInputBuilder = new TextInputBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(textInputBuilder.build).toThrow();
+    });
+
+    it("should return a TextInputComponent", function() {           
+      var component = textInputBuilder.build(args);
+      expect(component.type).toBe('TextInputComponent');
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ToggleButtonBaseBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ToggleButtonBaseBuilderSpec.js
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ToggleButtonBaseBuilder'], function(ToggleButtonBaseBuilder) {
+
+  describe("ToggleButtonBaseBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: { },
+        attributes: {
+          'parameter-layout': 'vertical'
+        }
+      }
+    };
+
+    var toggleButtonBaseBuilder;
+
+    beforeEach(function() {
+      toggleButtonBaseBuilder = new ToggleButtonBaseBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(toggleButtonBaseBuilder.build).toThrow();
+    });
+
+    it("should return a ToggleButtonBaseBuilder with verticalOrientation set to true when parameter-layout is set to 'vertical'", function() {
+      var component = toggleButtonBaseBuilder.build(args);
+      expect(component.type).toBe(undefined);
+      expect(component.verticalOrientation).toBeTruthy();
+    });
+
+    it("should return a ToggleButtonBaseBuilder with verticalOrientation set to false when parameter-layout is set to other than 'vertical'", function() {
+      args.param.attributes['parameter-layout'] = '';
+      var component = toggleButtonBaseBuilder.build(args);
+      expect(component.type).toBe(undefined);
+      expect(component.verticalOrientation).toBeFalsy();
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/ValueBasedParameterWidgetBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/ValueBasedParameterWidgetBuilderSpec.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/builders/ValueBasedParameterWidgetBuilder'], function(ValueBasedParameterWidgetBuilder) {
+
+  describe("ValueBasedParameterWidgetBuilder", function() {
+
+    var args = {
+      promptPanel: {
+        generateWidgetGUID: function() { },
+        getParameterName: function() { }
+      }, 
+      param:  {
+        values: []
+      }
+    };
+
+    var valueBasedParameterWidgetBuilder;
+
+    beforeEach(function() {
+      valueBasedParameterWidgetBuilder = new ValueBasedParameterWidgetBuilder();
+    });
+
+    it("should throw an error building component with no parameters", function() {
+      expect(valueBasedParameterWidgetBuilder.build).toThrow();
+    });
+
+    it("should return build successfully", function() {
+      var component = valueBasedParameterWidgetBuilder.build(args);
+      expect(component.valuesArray.length == 0).toBeTruthy();
+    });
+
+    it("should return build successfully and have a values array", function() {
+      args.param.values = [
+        { label: 'test 1', value: 'value test 1' },
+        { label: 'test 2', value: 'value test 2' }
+      ];
+      var component = valueBasedParameterWidgetBuilder.build(args);
+      expect(component.valuesArray.length).toBe(2);
+    });
+
+  });
+
+});

--- a/package-res/resources/web/test/prompting/builders/WidgetBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/WidgetBuilderSpec.js
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+define(['common-ui/prompting/WidgetBuilder', 'common-ui/prompting/builders/PromptPanelBuilder'],  function (WidgetBuilder, PromptPanelBuilder) {
+
+  describe("WidgetBuilder", function() {
+
+    var wb = WidgetBuilder.WidgetBuilder;
+
+    it("should have mappings array", function() {       
+      expect(wb.mapping).toBeDefined();
+    });
+
+    it("should throw an error trying to build a prompt-panel with no arguments", function() {
+      expect(wb.build).toThrow();
+    });
+
+    it("should successfully build a prompt panel", function() {
+      var buildPanelComponentsFn = jasmine.createSpy('buildPanelComponents');
+      var args = {
+        buildPanelComponents: buildPanelComponentsFn
+      } 
+
+      var panel = wb.build(args, 'prompt-panel');
+      expect(panel.type).toEqual('ScrollingPromptPanelLayoutComponent');
+      expect(buildPanelComponentsFn).toHaveBeenCalled();
+      expect(panel.promptPanel).toBeDefined();
+    });
+
+  });
+
+});


### PR DESCRIPTION
- Included unit tests for prompting builders;
- These tests will only test correct building of components, not their behaviour;
- Changed two of the builders to return correct widget (DateInputBuilder and ExternalInputBuilder);