### PR TITLE
[BACKLOG-4144] - Restore VizAPI 2 visualization implementation

### DIFF
--- a/package-res/plugin.xml
+++ b/package-res/plugin.xml
@@ -68,10 +68,9 @@
          Uncomment to test.
          Also, enable VizAPI version 3 visualizations by editing the configuration file:
          "resources/web/visual/config.js".
-      -->
 
     <file context="analyzer">content/common-ui/resources/web/visual/ccc/analyzer_plugin_loader.js</file>
     <file context="analyzer">content/common-ui/resources/web/visual/sample/analyzer_plugin_loader.js</file>
-
+    -->
   </external-resources>
 </plugin>

--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -42,7 +42,12 @@
   requirePaths["json"   ] = basePath + "/util/require-json/json";
   requirePaths["text"   ] = basePath + "/util/require-text/text";
   // Using `map` is important for use in r.js and correct AMD config of the other files of the package.
-  requireMap["*"]["css" ] = "common-ui/util/require-css/css" + minSuffix;
+  // Placing the minSuffix in the path ensures building works well,
+  // so that the resolved module id is the same in both debug and non-debug cases.
+  if(minSuffix) {
+    requirePaths["common-ui/util/require-css/css"] = basePath + "/util/require-css/css" + minSuffix;
+  }
+  requireMap["*"]["css" ] = "common-ui/util/require-css/css";
 
   // SHIMS
   requirePaths["es6-promise-shim"] = basePath + "/util/es6-promise-shim";


### PR DESCRIPTION
* Commenting VizAPI 3 Analyzer plugins in plugin.xml
* Changing the AMD mapping for the CSS plugin as it would use different module ids in build and in production, causing css to be loaded inline, by the build and dynamically as well...

@pamval please review.