### PR TITLE
[BACKLOG-4177] - PIR - Filter Specify from the list doesn't work

### DIFF
--- a/package-res/plugin.xml
+++ b/package-res/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin title="common-ui">
+<plugin loader="OVERRIDING" title="common-ui">
 
   <!-- uncomment these menu items to access the test pages via the User Console menu -->
   <!-- menu-items>


### PR DESCRIPTION
- changed plugin attributes to use the overriding class loader.