### PR TITLE
[BACKLOG-4070] Refactor errors processing without re-creating all panel

### DIFF
--- a/package-res/resources/web/prompting/components/CompositeComponent.js
+++ b/package-res/resources/web/prompting/components/CompositeComponent.js
@@ -59,6 +59,16 @@ define([ 'cdf/lib/jquery', 'cdf/components/BaseComponent', 'cdf/dashboard/Utils'
     },
 
     /**
+     * Removes the component
+     *
+     * @name CompositeComponent#remove
+     * @method
+     */
+    remove: function() {
+      this.placeholder().remove();
+    },
+
+    /**
      * Gets the CssClass assigned to the component
      *
      * @name CompositeComponent#getClassFor

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -131,12 +131,12 @@ define([], function() {
             var oldParam = oldParamDefn.getParameter(param.name);
             if (!oldParam || oldParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toAdd", group, param); // found newest parameters
-            } else if (this._isBehavioralAttrsChanged(oldParam, param)
-              || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
+            } else if (this._isBehavioralAttrsChanged(oldParam, param)) {
               // add parameter to remove and add arrays for recreating components
               this._fillWrapObj(result, "toRemove", group, oldParam);
               this._fillWrapObj(result, "toAdd", group, param);
             } else if (this._isDataChanged(oldParam, param)) {
+              param.isErrorChanged = this._isErrorsChanged(param.name, oldParamDefn, newParamDefn);
               this._fillWrapObj(result, "toChangeData", group, param);
             }
           }

--- a/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
+++ b/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
@@ -231,17 +231,17 @@ define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parame
                 spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
                 spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
                 spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(true);
-                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(true);
 
                 var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
 
                 expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
                 expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
-                expect(parameterDefinitionDiffer._isDataChanged).not.toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
                 expect(result).toBeDefined();
-                expect(Object.keys(result.toAdd).length).toBe(1);
-                expect(Object.keys(result.toChangeData).length).toBe(0);
-                expect(Object.keys(result.toRemove).length).toBe(1);
+                expect(Object.keys(result.toAdd).length).toBe(0);
+                expect(Object.keys(result.toChangeData).length).toBe(1);
+                expect(Object.keys(result.toRemove).length).toBe(0);
             });
 
             it("should return result with changed parameters by changed values", function() {
@@ -282,7 +282,7 @@ define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parame
                 var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
 
                 expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
-                expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).not.toHaveBeenCalled();
                 expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
                 expect(result).toBeDefined();
                 expect(Object.keys(result.toAdd).length).toBe(0);


### PR DESCRIPTION
What was done:
1. Refactored processing error's components without re-creating panel.
2. Fix clearing html elements when remove components.
3. Small refactoring

@plagoa @diogofscmariano @rfellows @krivera-pentaho @scottyaslan @pamval please review