### PR TITLE
[BACKLOG-4070] - Fixed lifecycle update because the set parameter was…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -851,8 +851,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
               var param = params[i];
 
               // Find selected value in param values list and set it. This works, even if the data in valuesArray is different
-              var selectedValues = param.getSelectedValuesValue();
-              this.setParameterValue(param, selectedValues);
+              this._initializeParameterValue(null, param);
 
               var component = _getComponentByParam.call(this, param);
               if (component != null) {

--- a/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
+++ b/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
@@ -81,6 +81,7 @@ define(['cdf/components/BaseComponent', 'dijit/form/DateTextBox', 'dijit/registr
          * @name DojoDateTextBoxComponent#update
          */
         update: function () {
+          this.clear();
           var myself = this;
 
           var parameterValue = this.dashboard.getParameterValue(this.parameter),
@@ -91,10 +92,6 @@ define(['cdf/components/BaseComponent', 'dijit/form/DateTextBox', 'dijit/registr
           this.dijitId = this.htmlObject + '_input';
 
           $('#' + this.htmlObject).html($('<input/>').attr('id', this.dijitId));
-
-          if(registry.byId(this.dijitId)) {
-            registry.remove(this.dijitId);
-          }
 
           var dateFormat = this.dateFormat;
           var dateTextBox = new DateTextBox({


### PR DESCRIPTION
… defining all parameters as arrays. Applied _initializeParameterValue that handles that situation.

[BACKLOG-4030] - Fixed Dojo Date picker update cycle due to multiple dojo objects registered with the same id

@pamval @scottyaslan @rfellows @annapopova1 @krivera-pentaho @plagoa please review