### PR TITLE
[BACKLOG-4030]

### DIFF
--- a/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
+++ b/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
@@ -54,10 +54,12 @@
  * @class
  * @extends BaseComponent
  */
-define(['cdf/components/BaseComponent', 'dijit/form/DateTextBox', 'dijit/registry', 'cdf/lib/jquery', 'dojo/on'],
-    function (BaseComponent, DateTextBox, registry, $, on) {
+define(['cdf/components/BaseComponent', "dojo/date/locale", 'dijit/form/DateTextBox', 'dijit/registry', 'cdf/lib/jquery', 'dojo/on'],
+    function (BaseComponent, locale, DateTextBox, registry, $, on) {
 
       return BaseComponent.extend({
+        localeFormatter: locale,
+
         /**
          * Clears the widget from the dojo namespace
          *
@@ -86,33 +88,58 @@ define(['cdf/components/BaseComponent', 'dijit/form/DateTextBox', 'dijit/registr
 
           var parameterValue = this.dashboard.getParameterValue(this.parameter),
               value = undefined;
+
+          if(parameterValue.length == 1) {
+            parameterValue = parameterValue[0];
+          }
+
           if(this.transportFormatter) {
             value = this.transportFormatter.parse(parameterValue);
+          } else if(this._isLegacyDateFormat()) {
+            this._convertFormat();
+            value = this.localeFormatter.parse(parameterValue, {datePattern: myself.dateFormat, selector: "date"});
           }
           this.dijitId = this.htmlObject + '_input';
 
           $('#' + this.htmlObject).html($('<input/>').attr('id', this.dijitId));
 
-          var dateFormat = this.dateFormat;
+          var constraints = {
+            datePattern: this.dateFormat ? this.dateFormat : this.param.attributes['data-format'],
+            selector: 'date',
+            formatLength: 'medium' // Used if datePattern is not defined, locale specific
+          };
+
+          if(myself.startDate == 'TODAY') {
+            constraints.min = new Date();
+          } else if(myself.startDate) {
+            constraints.min = this.localeFormatter.format(myself.startDate, {datePattern: myself.dateFormat, selector: "date"});
+          }
+
+          if(myself.endDate == 'TODAY') {
+            constraints.max = new Date();
+          } else if(myself.endDate) {
+            constraints.max = this.localeFormatter.format(myself.endDate, {datePattern: myself.dateFormat, selector: "date"});
+          }
+
           var dateTextBox = new DateTextBox({
             name: this.name,
-            constraints: {
-              datePattern: dateFormat ? dateFormat : this.param.attributes['data-format'],
-              selector: 'date',
-              formatLength: 'medium' // Used if datePattern is not defined, locale specific
+            constraints: constraints,
+            onChange: function() {
+              myself.dashboard.processChange(myself.name);
             }
           }, this.dijitId);
 
           dateTextBox.set('value', value, false);
-          this.onChangeHandle = on(dateTextBox, "change", function () {
-            myself.dashboard.processChange(this.name);
-          }.bind(this));
 
           this._doAutoFocus();
         },
 
         /**
          * Returns the value assigned to the component
+         *
+         * Due to legacy reasons we can't format the numbers in the same way in the Dashboards plugin.
+         * Dashboards plugin do not have the notion of timezone and we need to keep the jquery date picker plain date
+         * picking.
          *
          * @method
          * @name DojoDateTextBoxComponent#getValue
@@ -123,8 +150,61 @@ define(['cdf/components/BaseComponent', 'dijit/form/DateTextBox', 'dijit/registr
           var date = registry.byId(this.dijitId).get('value');
           if(this.transportFormatter) {
             return this.transportFormatter.format(date);
+          } else if(this._isLegacyDateFormat()) {
+            this._convertFormat();
+            return this.localeFormatter.format(date, {datePattern: this.dateFormat, selector: "date"});
           }
           return date;
+        },
+
+        /**
+         * Checks if the date format assigned to the component is legacy or not
+         *
+         * @returns {boolean}
+         * @private
+         */
+        _isLegacyDateFormat: function() {
+          var dojoFormat;
+
+          var dateFormat = this.dateFormat ? this.dateFormat : this.param.attributes['data-format'];
+
+          try {
+            dojoFormat = this.localeFormatter.format(new Date(), {datePattern: dateFormat, selector: "date"});
+          } catch(e) { //in case we have an invalid format and the format breaks
+            return true;
+          }
+
+          return dojoFormat != $.datepicker.formatDate(dateFormat, new Date());
+        },
+
+        /**
+         * Converts the date format from jquery to dojo
+         * Based on https://api.jqueryui.com/datepicker/#utility-formatDate and http://dojotoolkit.org/reference-guide/1.10/dojo/date/locale/format.html#dojo-date-locale-format
+         *
+         * @private
+         */
+        _convertFormat: function() {
+          var myself = this;
+          myself.dateFormat = this.dateFormat ? this.dateFormat : this.param.attributes['data-format'];
+
+          var regexConvertYear =      [[/(^|(?!y).)(y{1}(?!y))/, "$1yy"],  [/(^|(?!y).)(y{2}(?!y))/, "$1yyyy"]],
+              regexConvertMonth =     [[/(^|(?!m).)(m{1}(?!m))/, "$1M"],   [/(^|(?!m).)(m{2}(?!m))/, "$1MM"]],
+              regexConvertMonthText = [[/(^|(?!M).)(M{1}(?!M))/, "$1MMM"], [/(^|(?!M).)(M{2}(?!M))/, "$1MMMM"]],
+              regexConvertDayText =   [[/(^|(?!D).)(D{1}(?!D))/, "$1EEE"], [/(^|(?!D).)(D{2}(?!D))/, "$1EEEE"]],
+              regexConvertDayMonth =  [[/(^|(?!o).)(o{1}(?!o))/, "$1D"],   [/(^|(?!o).)(o{2}(?!o))/, "$1DD"], [/(^|(?!o).)(o{3}(?!o))/, "$1DDD"]];
+
+          var replacer = function(i,v){
+            if(v[0].test(myself.dateFormat)) {
+              myself.dateFormat = myself.dateFormat.replace(v[0], v[1]);
+              return false;
+            }
+          };
+
+          $.each(regexConvertYear, replacer);
+          $.each(regexConvertMonthText, replacer);
+          $.each(regexConvertMonth, replacer);
+          $.each(regexConvertDayText, replacer);
+          $.each(regexConvertDayMonth, replacer);
         }
       });
     });


### PR DESCRIPTION
- Added changes to date picker to allow Dashboards plugin usage
- Added conversion of jquery date format to dojo. Unit tests added to it
- Fixed issue when parameter from dashboards is an array (the use case from Dashboards includes it when the default value is defined in the gwt window of the prompt creation)
- Added formatter from dojo to properly format dates in Dashboards plugin
- Added ability to define start and end date of the date picker (needed for Dashboards plugin)
- Styles still need to be adjusted for Dashboards plugin