### PR TITLE
[BACKLOG-4038]

### DIFF
--- a/package-res/resources/web/prompting/components/ParameterPanelComponent.js
+++ b/package-res/resources/web/prompting/components/ParameterPanelComponent.js
@@ -21,6 +21,11 @@ define("common-ui/prompting/components/ParameterPanelComponent", ['./PanelCompon
       if (component.promptType === 'label') {
         return 'parameter-label';
       }
+    },
+
+    removeErrorClass: function(){
+      var $htmlObject = this.placeholder();
+      $htmlObject.removeClass('error');
     }
   });
 });

--- a/package-res/resources/web/prompting/components/PromptLayoutComponent.js
+++ b/package-res/resources/web/prompting/components/PromptLayoutComponent.js
@@ -22,7 +22,7 @@ define(['./CompositeComponent'], function(CompositeComponent){
       if (!component.param) {
         return;
       }
-      return 'parameter' + (component.cssClass ? ' ' + component.cssClass : '');
+      return 'parameter';
     }
   });
 

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -786,7 +786,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           beforeEach(function() {
             paramSpy = jasmine.createSpy("paramSpy");
 
-            componentSpy = jasmine.createSpyObj("componentSpy", [ "clear" ]);
+            componentSpy = jasmine.createSpyObj("componentSpy", [ "clear", "removeErrorClass" ]);
             componentSpy.parameter = paramName;
             componentSpy.type = "TestPanel";
 
@@ -1011,13 +1011,25 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
               panel._changeComponentsByDiff(change);
 
-              expect(panel.dashboard.updateComponent).toHaveBeenCalledWith(panelSpy);
+              expect(panel.dashboard.updateComponent).toHaveBeenCalledWith(componentSpy);
               expect(panel.dashboard.getComponentByName).toHaveBeenCalledWith(groupName);
-              expect(panel.dashboard.getComponentByName).toHaveBeenCalledWith("prompt"+guid);
               expect(groupPanelSpy.components[0]).toBe(componentSpy);
               expect(componentSpy.valuesArray).toBe(valuesArray);
               expect(panel.widgetBuilder.build).toHaveBeenCalled();
-              expect(panel.forceSubmit).not.toBeDefined();
+              expect(panel.forceSubmit).toBe(true);
+
+              spyOn(changedParam, "getSelectedValuesValue").and.callFake(function(){
+                return ["a"];
+              });
+              panel.dashboard.getParameterValue.and.returnValue("a");
+              panel.dashboard.updateComponent.calls.reset();
+              panel._changeComponentsByDiff(change);
+              expect(panel.dashboard.updateComponent).not.toHaveBeenCalled();
+
+              panel.dashboard.getParameterValue.and.returnValue("b");
+              panel.dashboard.updateComponent.calls.reset();
+              panel._changeComponentsByDiff(change);
+              expect(panel.dashboard.updateComponent).toHaveBeenCalledWith(componentSpy);
             });
           });
 
@@ -1074,6 +1086,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               expect(componentSpy.components[1].label).toBe(panel.paramDefn.errors[paramSpy.name][1]);
               expect(panel.removeDashboardComponents).toHaveBeenCalled();
               expect(componentSpy.cssClass).toContain("error");
+              expect(componentSpy.removeErrorClass).not.toHaveBeenCalled();
             });
 
             it("should process without errors", function() {
@@ -1088,6 +1101,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               expect(componentSpy.components.length).toBe(0);
               expect(panel.removeDashboardComponents).not.toHaveBeenCalled();
               expect(componentSpy.cssClass).not.toContain("error");
+              expect(componentSpy.removeErrorClass).toHaveBeenCalled();
             });
           });
         });

--- a/package-res/resources/web/test/prompting/components/PromptLayoutComponentSpec.js
+++ b/package-res/resources/web/test/prompting/components/PromptLayoutComponentSpec.js
@@ -33,12 +33,12 @@ define([ 'common-ui/prompting/components/PromptLayoutComponent' ], function(Prom
         expect(css).toBe('parameter');
       });
 
-      it("should return specific css result for component", function() {
+      it("should not return specific css result for component", function() {
         var testCss = "test-css";
         paramComponent.param = jasmine.createSpy("param");
         paramComponent.cssClass = testCss;
         var css = comp.getClassFor(paramComponent);
-        expect(css).toBe('parameter ' + testCss);
+        expect(css).toBe('parameter');
       });
 
       it("should return undefined result if not exist param", function() {


### PR DESCRIPTION
 - Added logic to avoid need of updating the prompts if the parameter from CDF already has the value selected
 - Removed update of all components if valuesArray of a single component have changed
 - Fixed issue in report viewer that was not removing the error labels after the user gets the input defined

@pamval @krivera-pentaho @annapopova1 @rfellows @scottyaslan @plagoa please review
Dont merged it yet. Tomorrow i want to do more tests and check every unit test. But the implementation should be finished