### PR TITLE
[BACKLOG-4916] Running Prpt sample, report does not render correctly …

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -1186,6 +1186,8 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
             // Create a label and a CDF widget for each parameter
             $.each(group.parameters, function (i, param) {
               if (param.attributes['hidden'] == 'true') {
+                // initialize parameter values regardless of whether we're showing the parameter or not
+                this._initializeParameterValue(this.paramDefn, param);
                 return;
               }
               components.push(this._buildPanelForParameter(param));


### PR DESCRIPTION
…[regression]

We should initialize all parameters, also with hidden attribute. Because hidden parameters can be used by plugins. For example, "htmlProportionalWidth" parameter is used by Report Viewer to choose concrete css class.

@plagoa @diogofscmariano @rfellows @krivera-pentaho @scottyaslan @pamval please review