### PR TITLE
[ANALYZER-3138] - Sunburst - tooltip does not show when data contains a GEO "location" column

### DIFF
--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -1137,7 +1137,7 @@ define([
              * Using the scene's group, preferably, because the datum (here the complex) may have dimensions
              * that are null in the groups' own atoms.
              */
-            if(this._nonMultiGemFilter(gem) &&
+            if(gem.cccDimName && this._nonMultiGemFilter(gem) &&
                !(this.chart._hideNullMembers && this._isNullMember(context.scene.group || complex, gem))) {
                 this.base.apply(this, arguments);
             }


### PR DESCRIPTION
* Extra latitude and longitude columns were not mapped to CCC (cccDimName == null) and later caused problems in the isNullMember test.

At this time, this issue hasn't yet been triaged yet, so please *do not* accept this pull-request yet.