### PR TITLE
[BACKLOG-5307] - PIR: Error message "This prompt is mandatory" appear…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -638,7 +638,8 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
             this.nullValueParams.push(param);
           }
 
-          this.refreshPrompt();
+          var myself = this;
+          setTimeout(function() { myself.refreshPrompt() }, 0);
           this.parametersChanged = true;
         },
 
@@ -871,7 +872,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          * @private
          */
         _changeErrors: function(param) {
-          if (param.isErrorChanged || (param.getSelectedValuesValue() != null && param.mandatory)) {
+          if (param.isErrorChanged) {
             var errors = this.paramDefn.errors[param.name];
             var panel = _getComponentByParam.call(this, param, true);
             var existingErrors = _findErrorComponents.call(this, panel);


### PR DESCRIPTION
…s for prompt with selected value

- Added timeout set to zero to allow for error message to be added to the DOM by the time the lifecycle is clearing it;