### PR TITLE
[BACKLOG-2544] DataTable - JSON and API changes

### DIFF
--- a/package-res/resources/web/visual/ccc/wrapper/charts/AbstractChart.js
+++ b/package-res/resources/web/visual/ccc/wrapper/charts/AbstractChart.js
@@ -613,6 +613,7 @@ define([
                 this._gemsMap = gemsMap;
                 this._visualMapInfo = visualMapInfo;
                 this._genericMeasuresCount = genericMeasuresCount;
+                this.measureDiscrimGem = null;
 
                 var hasDiscrim = genericMeasuresCount > 1;
                 if(hasDiscrim) this._addGenericMeasureDiscriminator();


### PR DESCRIPTION
* Fix regression to the CCC vizs when alternating between vizs with and without measure discrim. (more than one gem in the "measures" gembar).

@pamval please review (this is a regression found by the DET team, back in October)