### PR TITLE
SP-2242 - Backport of PIR-1192 - Interactive Reports does not show fields with datasource name has Japanese characters (6.0 Suite)

### DIFF
--- a/package-res/resources/web/dataapi/models-mql.js
+++ b/package-res/resources/web/dataapi/models-mql.js
@@ -201,7 +201,7 @@ pentaho.pda.model.mql.prototype.discoverModelDetail = function() {
 
   // get the info about the models from the server
   var url = this.handler.METADATA_SERVICE_URL+'/loadModel';
-  var query = 'domainId='+escape(this.domainId)+'&modelId='+escape(this.modelId);
+  var query = 'domainId='+encodeURIComponent(this.domainId)+'&modelId='+encodeURIComponent(this.modelId);
   var result = pentahoGet( url, query );
   // parse the XML
   var xml = parseXML( result );


### PR DESCRIPTION
Cherry-pick of https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/525
@pamval 
Please review.