### PR TITLE
BISERVER-12961 - Setting drop-down parameter causes text box to revert…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -966,7 +966,15 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
 
                 // Compare values array from param (which is formatted into valuesArray) with the current valuesArray
                 // We need to update the components if autoSubmit is off
-                if (JSON.stringify(component.valuesArray) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
+                var valArr;
+                if ( component.valuesArray ) {
+                  valArr = component.valuesArray.slice();
+                  if ( "" == component.valuesArray[0][0] && "" == component.valuesArray[0][1] ) {
+                    //no update needed if component.valuesArray equals newValuesArray except first empty(default) value
+                    valArr = component.valuesArray.slice(1);
+                  }
+                }
+                if (JSON.stringify(valArr) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
                   // Find selected value in param values list and set it. This works, even if the data in valuesArray is different
                   this._initializeParameterValue(null, param);
 

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -1005,6 +1005,36 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               expect(panel.forceSubmit).toEqual(true);
             });
 
+            it("should not update the components if old value array differs from new one only with default value", function() {
+
+              spyOn(panel, "_initializeParameterValue");
+              panel.dashboard.getParameterValue.and.returnValue("do");
+
+              var valuesArrayWithSpaces = [["", ""],["test1", "test1"],["test2", "test2"]];
+              componentSpy.valuesArray = valuesArrayWithSpaces;
+
+              changedParam = new Parameter();
+              changedParam.type = "java.lang.String";
+              changedParam.name = paramName;
+              changedParam.values = [ value1, value2 ];
+              var valuesArray = [["test1", "test1"],["test2", "test2"]];
+              spyOn(panel.widgetBuilder, "build").and.callFake(function(obj, type) {
+                return { "valuesArray": valuesArray };
+              });
+
+              change = {};
+              change[groupName] = {
+                params: [changedParam]
+              };
+
+              panel._changeComponentsByDiff(change);
+
+              expect(componentSpy.valuesArray).toBe(valuesArrayWithSpaces);
+              expect(panel.widgetBuilder.build).toHaveBeenCalled();
+              expect(panel._initializeParameterValue).not.toHaveBeenCalled();
+              expect(panel.dashboard.updateComponent).not.toHaveBeenCalled();
+            });
+
             it("should compare the data values to determine if a change was made.", function() {
 
               var submitComponentSpy = jasmine.createSpy("submitComponentSpy");


### PR DESCRIPTION
… to default values

When drop-down parameter array formatted
https://github.com/pentaho/pentaho-platform-plugin-common-ui/blob/master/package-res/resources/web/prompting/PromptPanel.js#L962
extra value (emty) added and this check
https://github.com/pentaho/pentaho-platform-plugin-common-ui/blob/master/package-res/resources/web/prompting/PromptPanel.js#L969
is passing, which leads to update with default values.