### PR TITLE
[BISERVER-12958] Date Picker Parameters default to Today's date in pr…

### DIFF
--- a/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
+++ b/package-res/resources/web/prompting/components/DojoDateTextBoxComponent.js
@@ -117,12 +117,12 @@ define(['cdf/components/BaseComponent', "dojo/date/locale", 'dijit/form/DateText
               parameterValue = parameterValue.length == 0 ? undefined : (parameterValue.length == 1 ? parameterValue[0] : parameterValue);
             }
             if(!parameterValue) {
-              value = new Date();
+              value = null;
             } else {
               value = this._parseDate(parameterValue);
             }
           } else {
-            value = new Date();
+            value = null;
           }
 
           $('#' + this.htmlObject).html($('<input/>').attr('id', this.dijitId));


### PR DESCRIPTION
…pt reports when running on BA Server
@pentaho-nbaker , @rfellows , @mdamour1976 , could you review it, please?
Fix: DojoDateTextBoxComponent default value is null (instead of now).
Now the DateTextBox default value is null wherever this component is used.