### PR TITLE
[SP-2330] - Backport of ANALYZER-2893 - Long measure names are not rendered correctly on Analyzer Layout pane (5.4 Suite)

### DIFF
--- a/package-res/resources/web/dojo/dijit/themes/pentaho/layout/LayoutPanel.css
+++ b/package-res/resources/web/dojo/dijit/themes/pentaho/layout/LayoutPanel.css
@@ -94,6 +94,8 @@
   height: 18px;
   line-height: 17px;
   display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .gem .gemMenuHandle{


### PR DESCRIPTION
- crop long names
(cherry picked from commit 309ed6e)

@krivera-pentaho, review it please. This is a backport of https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/532 