### PR TITLE
[BISERVER-12918] the report parameter/prompt panel flashes when autosubmit off

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -305,6 +305,27 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
         }
       };
 
+      /**
+       * Compares the parameter value to its stored value
+       * @name _isParamsDifferent
+       * @method
+       * @private
+       * @param {String|Date|Number} paramValue The stored parameter value
+       * @param {String|Date|Number} paramSelectedValue The value of the selected parameter
+       * @param {String} paramType The parameter type
+       * @returns {bool} The result of comparison
+       */
+      var _isParamsDifferent = function(paramValue, paramSelectedValue, paramType) {
+        switch (paramType) {
+          case "java.lang.String": // Used upper case to eliminate UPPER() post-process formula influence on the strings comparison
+            return paramValue.toUpperCase() != paramSelectedValue.toUpperCase();
+          case "java.sql.Date": // Set time to zero to eliminate its influence on the days comparison
+            return (new Date(paramValue).setHours(0,0,0,0)) != (new Date(paramSelectedValue).setHours(0,0,0,0));
+          default:
+            return paramValue != paramSelectedValue;
+        }
+      };
+
       var PromptPanel = Base.extend({
 
         guid: undefined,
@@ -946,13 +967,15 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                   this.forceSubmit = true;
                 }
 
+                var paramType = null;
                 var paramSelectedValues = param.getSelectedValuesValue();
                 if (paramSelectedValues.length == 1) {
                   paramSelectedValues = paramSelectedValues[0];
+                  paramType = param.type;
                 }
                 var paramValue = this.dashboard.getParameterValue(component.parameter);
 
-                if (paramValue != paramSelectedValues || updateNeeded) {
+                if (_isParamsDifferent(paramValue, paramSelectedValues, paramType) || updateNeeded) {
                   var groupPanel = this.dashboard.getComponentByName(groupName);
                   _mapComponents(groupPanel, function (component) {
                     this.dashboard.updateComponent(component);


### PR DESCRIPTION
Added comparison function for parameter value to its stored value, to eliminate UPPER() post-process formula and server GMT influences, and escape double components updating. 

@pamval , @diogofscmariano , @krivera-pentaho could you please review? Does it make sense?