### PR TITLE
[BACKLOG-5837] - Prompt API - Implement setParameterValue

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -395,6 +395,9 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          * @returns {String} The parameter name
          */
         getParameterName: function (parameter) {
+          if (typeof parameter === 'string') {
+            return this.guid + parameter;
+          }
           return this.guid + parameter.name;
         },
 

--- a/package-res/resources/web/prompting/api/OperationAPI.js
+++ b/package-res/resources/web/prompting/api/OperationAPI.js
@@ -114,5 +114,18 @@ define(['common-ui/prompting/PromptPanel', 'common-ui/prompting/parameters/Param
     this.getParameterValues = function() {
       return this._getPromptPanel().getParameterValues();
     };
+
+    /**
+     * Sets the value of a dashboard parameter by parameter name. 
+     * This operation won't trigger any event on the prompt panel.
+     *
+     * @name OperationAPI#setParameterValue
+     * @method
+     * @param {String}    param The name of the parameter that's going to be set
+     * @param {Object}    value The new value for the parameter
+     */
+    this.setParameterValue = function(param, value) {
+      this._getPromptPanel().setParameterValue(param, value);
+    }
   };
 });

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -83,12 +83,18 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         });
       });
 
-      it("getParameterName", function() {
+      it("getParameterName with parameter object", function() {
         var parameter = {
           name : "test_name"
         };
         var name = panel.getParameterName(parameter);
         expect(name).toBe(panel.guid + parameter.name);
+      });
+
+      it("getParameterName with string", function() {
+        var parameter = "test_name";
+        var name = panel.getParameterName(parameter);
+        expect(name).toBe(panel.guid + parameter);
       });
 
       describe("getParameterValues", function() {

--- a/package-res/resources/web/test/prompting/api/OperationAPISpec.js
+++ b/package-res/resources/web/test/prompting/api/OperationAPISpec.js
@@ -20,7 +20,7 @@ define(["common-ui/prompting/api/OperationAPI"], function(OperationAPI) {
     var operationApi, apiSpy, promptPanelSpy, xmlStr, xmlStr1, htmlId, paramDefnSpy;
     beforeEach(function() {
 
-      promptPanelSpy = jasmine.createSpyObj("PromptPanel", ["refresh", "init", "getParameterValues", "getParameterDefinition"]);
+      promptPanelSpy = jasmine.createSpyObj("PromptPanel", ["refresh", "init", "getParameterValues", "getParameterDefinition", "setParameterValue"]);
 
       apiSpy = jasmine.createSpy("PromptingAPI");
       apiSpy.log = jasmine.createSpyObj("Log", ["info", "warn", "error"]);
@@ -152,6 +152,13 @@ define(["common-ui/prompting/api/OperationAPI"], function(OperationAPI) {
 
       expect(operationApi._getPromptPanel).toHaveBeenCalled();
       expect(promptPanelSpy.getParameterValues).toHaveBeenCalled();
+    });
+
+    it("should test setParameterValue", function() {
+      operationApi.setParameterValue("param", "value");
+
+      expect(operationApi._getPromptPanel).toHaveBeenCalled();
+      expect(promptPanelSpy.setParameterValue).toHaveBeenCalledWith("param", "value");
     });
   });
 });


### PR DESCRIPTION
- added the ability to getParameterName using a string as an input instead of an object