### PR TITLE
[BACKLOG-5844] Prompt API - Change api.operation.render so callback "…

### DIFF
--- a/package-res/resources/web/prompting/api/UtilAPI.js
+++ b/package-res/resources/web/prompting/api/UtilAPI.js
@@ -15,8 +15,27 @@
  *
  */
 
-define([], function() {
+/**
+ * The Prompting Util API Class
+ * Provides utility functions for working with prompting.
+ *
+ * @name UtilAPI
+ * @class
+ */
+define(["common-ui/prompting/parameters/ParameterXmlParser"], function(ParameterXmlParser) {
   return function(api) {
+    this._parameterXmlParser = new ParameterXmlParser();
 
+    /**
+     * Parses the xml string and returns an instance of ParameterDefinition.
+     *
+     * @name UtilAPI#parseParameterXml
+     * @method
+     * @param  {String} xmlString    String with the xml, format is described on the {@link http://wiki.pentaho.com/display/Reporting/Specification+for+the+BI-Server+Plugin+Parameter-XML+format|wiki page}
+     * @return {ParameterDefinition} Parameter Definition instance
+     */
+    this.parseParameterXml = function(xmlString) {
+      return this._parameterXmlParser.parseParameterXml(xmlString);
+    };
   }
 });

--- a/package-res/resources/web/prompting/api/promptApiSample.html
+++ b/package-res/resources/web/prompting/api/promptApiSample.html
@@ -48,16 +48,18 @@
     </style>
 
     <script type="text/javascript">
-      require(['common-ui/prompting/api/PromptingAPI', 'common-ui/jquery-clean'], function(PromptingAPI, $) {
+      require(['common-ui/prompting/api/PromptingAPI', 'common-ui/prompting/parameters/ParameterXmlParser', 'common-ui/jquery-clean'], function(PromptingAPI, ParameterXmlParser, $) {
 
         $(document).ready(function() {
-            var promptApi = new PromptingAPI();
-            
+            var id = "promptPanel";
+            var promptApi = new PromptingAPI(id);
+            var parameterXmlParser = new ParameterXmlParser();
+
             $("#create-prompt").bind("click", function() {
-                
-                var id = "promptPanel";
-                promptApi.operation.render(id, function() {
-                    return $('#parameterXml').val();
+                promptApi.operation.render(function(api, callback) {
+                    var xml = $('#parameterXml').val();
+                    var paramDefn = parameterXmlParser.parseParameterXml(xml);
+                    callback(paramDefn);
                 });
 
                 var eventArea = $('#eventsLogArea');

--- a/package-res/resources/web/prompting/parameters/Parameter.js
+++ b/package-res/resources/web/prompting/parameters/Parameter.js
@@ -28,7 +28,7 @@
  * @property {Boolean} strict {true} if the parameter is strict, {false} otherwise
  * @property {String} timezoneHint The timezone of the parameter
  * @property {Object|String} attributes Hash of string for the remaining parameter attributes
- * @property {Array|Object} values The array of possible values of the parameter
+ * @property {Array|ParameterValue} values The array of possible values of the parameter
  */
 define(['common-ui/jquery-clean'], function ($) {
   return function () {
@@ -87,7 +87,7 @@ define(['common-ui/jquery-clean'], function ($) {
        *
        * @name Parameter#getSelectedValuesValue
        * @method
-       * @return {Array} Array with the values selected
+       * @return {Array|Object} Array with the values selected
        */
       getSelectedValuesValue: function () {
         var selected = [];

--- a/package-res/resources/web/test/prompting/api/UtilAPISpec.js
+++ b/package-res/resources/web/test/prompting/api/UtilAPISpec.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file expect in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+define(["common-ui/prompting/api/UtilAPI"], function(UtilAPI) {
+
+  describe("UtilAPI unit tests", function() {
+    var utilApi, apiSpy;
+    beforeEach(function() {
+      apiSpy = jasmine.createSpy("PromptingAPI");
+      utilApi = new UtilAPI(apiSpy);
+    });
+
+    it("test parseParameterXml", function() {
+      var paramDefnSpy = jasmine.createSpy("ParamDefn");
+      spyOn(utilApi._parameterXmlParser, "parseParameterXml").and.returnValue(paramDefnSpy);
+      var paramDefn = utilApi.parseParameterXml("test str");
+      expect(utilApi._parameterXmlParser.parseParameterXml).toHaveBeenCalled();
+      expect(paramDefn).toBe(paramDefnSpy);
+    });
+  });
+});


### PR DESCRIPTION
…getParameterXML" will return parsed ParameterDefinition.

- changed render function to apply ParameterDefinition
- changed unit tests, also add tests for init function
- changed promptApiSample.html. Probably need remove it if we do not want support it.

@krivera-pentaho @pamval @diogofscmariano @plagoa @afrjorge @jvelasques  please review