### PR TITLE
[SP-2383] - Backport of PPP-3455 - Dynamic code injection vulnerabilities found (6.0 Suite)

### DIFF
--- a/package-res/resources/web/dataapi/cda.js
+++ b/package-res/resources/web/dataapi/cda.js
@@ -36,8 +36,8 @@ pentaho.cda = {
 					async: true,
 					dataType: "json",
 					type: "GET",
-					complete: function(response){
-						var fileList = eval('(' + response + ')' );
+					complete: function(response) {
+						var fileList = JSON.parse(response);
 						var fileCount = fileList.resultset.length;
 						var result;
 						if ( fileCount > 0) {
@@ -130,8 +130,8 @@ pentaho.cda.Descriptor.prototype = {
 					path: that.path,
 					outputType:'json'
 				},
-				complete: function(data){
-					var queryList = eval('(' + data + ')' ),
+				complete: function(data) {
+					var queryList = JSON.parse(data),
 					rs=queryList.resultset, query, loc;
 					for (query in rs){
 						loc = rs[query];

--- a/package-res/resources/web/dataapi/models-mql.js
+++ b/package-res/resources/web/dataapi/models-mql.js
@@ -319,7 +319,7 @@ pentaho.pda.model.mql.prototype.submit = function( jsonString, rowLimit, callbac
     var nodes = result.getElementsByTagName('return');
     resultJson = this.getText( nodes[0] );
 //          alert(resultJson);
-    var result = eval('('+resultJson+')');
+    var result = JSON.parse(resultJson);
     if (callback) {
       callback(result);
     }
@@ -362,7 +362,7 @@ pentaho.pda.model.mql.prototype.submitXmlQuery = function( queryObject, rowLimit
     var nodes = result.getElementsByTagName('return');
     resultJson = this.getText( nodes[0] );
 //            alert(resultJson);
-    var result = eval('('+resultJson+')');
+    var result = JSON.parse(resultJson);
     return result;
   } catch (e) {
     alert(e.message);
@@ -377,8 +377,8 @@ pentaho.pda.model.mql.prototype.submitXmlQuery = function( queryObject, rowLimit
 pentaho.pda.model.mql.prototype.parseResultSetXml = function(xml) {
   var oXML  = parseXML(xml);
   var rowNodes = oXML.getElementsByTagName('rows');        //initialize array of all DATA-ROW returned in SOAP
-  var colNameNodes = oXML.getElementsByTagName('columnNames'); //initialize arry of all COLUMN-HDR-ITEM in SOAP
-  var colTypeNodes = oXML.getElementsByTagName('columnTypes'); //initialize arry of all COLUMN-HDR-ITEM in SOAP
+  var colNameNodes = oXML.getElementsByTagName('columnNames'); //initialize array of all COLUMN-HDR-ITEM in SOAP
+  var colTypeNodes = oXML.getElementsByTagName('columnTypes'); //initialize array of all COLUMN-HDR-ITEM in SOAP
   if( !colNameNodes || colNameNodes.length == 0 ) {
     return null;
   }

--- a/package-res/resources/web/dataapi/models-svc.js
+++ b/package-res/resources/web/dataapi/models-svc.js
@@ -109,7 +109,7 @@ pentaho.pda.model.svc.prototype.discoverModelDetail = function() {
 	var resultStr = pentahoPost( url, '', null, 'text/text' );
 	// parse the XML
 
-    this.state = eval( '('+resultStr+')' );
+    this.state = JSON.parse(resultStr);
     
     this.categories = this.state.categories;
     this.capabilities = this.state.capabilities;
@@ -193,7 +193,7 @@ pentaho.pda.model.svc.prototype.submit = function( jsonString, rowLimit, callbac
 //        alert(jsonString);
         var handleResultCallback = dojo.hitch(this, function(resultJson) {
 //alert(resultJson);
-          var jsonTable = eval('('+resultJson+')');
+          var jsonTable = JSON.parse(resultJson);
           result = new pentaho.DataTable(jsonTable);
           if (callback) {
             callback(result);

--- a/package-res/resources/web/test/dataapi/cdaSpec.js
+++ b/package-res/resources/web/test/dataapi/cdaSpec.js
@@ -1,0 +1,102 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2015 Pentaho Corporation. All rights reserved.
+ */
+
+CONTEXT_PATH = (typeof CONTEXT_PATH === 'undefined') ? '' : CONTEXT_PATH;
+define(["common-data/cda", "common-data/xhr"], function(cda, xhr) {
+
+  describe("PPP-3455", function() {
+
+    var bogusResponse = 'pentaho.cda.callCatcher.injection();';
+
+    var callCatcher;
+
+    beforeEach(function() {
+      cda.descriptors = [];
+      callCatcher = jasmine.createSpyObj('callCatcher', ['injection', 'func']);
+    });
+
+    afterEach(function() {
+      if (typeof cda.callCatcher !== 'undefined') {
+        delete cda.callCatcher;
+      }
+    });
+
+
+    callbackInvokerFunction = function(response) {
+      return function(url, callback) {
+        callback.complete(response);
+      };
+    }
+
+    it("discoverDescriptors() should not call eval() for obtained result", function() {
+      spyOn(xhr, 'execute').and.callFake(callbackInvokerFunction(bogusResponse));
+
+      cda.callCatcher = callCatcher;
+      var call = function() { cda.discoverDescriptors(callCatcher.func); };
+      expect(call).toThrowError(SyntaxError);
+
+      expect(pentaho.xhr.execute).toHaveBeenCalled();
+      expect(callCatcher.injection).not.toHaveBeenCalled();
+      expect(callCatcher.func).not.toHaveBeenCalled();
+    });
+
+    it("discoverDescriptors() should parse valid response", function() {
+      var response = JSON.stringify({ resultset: [ ['name', 'path'] ] });
+      spyOn(xhr, 'execute').and.callFake(callbackInvokerFunction(response))
+
+      cda.discoverDescriptors(callCatcher.func);
+
+      var expectedDescriptors = [{name: 'name', path: 'path'}];
+
+      expect(pentaho.xhr.execute).toHaveBeenCalled();
+      expect(cda.descriptors).toEqual(expectedDescriptors);
+      expect(callCatcher.func).toHaveBeenCalledWith(expectedDescriptors);
+    });
+
+
+    it("Descriptor.discoverQueries() should not call eval() for obtained result", function() {
+      spyOn(xhr, 'execute').and.callFake(callbackInvokerFunction(bogusResponse))
+
+      var desc = new cda.Descriptor('');
+      var call = function() {
+        desc.discoverQueries(callCatcher.func);
+      };
+      expect(call).toThrowError(SyntaxError);
+
+      expect(pentaho.xhr.execute).toHaveBeenCalled();
+      expect(callCatcher.injection).not.toHaveBeenCalled();
+      expect(callCatcher.func).not.toHaveBeenCalled();
+    });
+
+    it("Descriptor.discoverQueries() should parse valid response", function() {
+      var response = JSON.stringify({ resultset: [ ['id', 'name', 'type'] ] });
+      spyOn(xhr, 'execute').and.callFake(callbackInvokerFunction(response));
+
+      var desc = new cda.Descriptor('');
+      desc.discoverQueries(callCatcher.func);
+
+      expect(pentaho.xhr.execute).toHaveBeenCalled();
+      expect(callCatcher.func).toHaveBeenCalled();
+
+      expect(desc.queries.length).toEqual(1);
+      expect(desc.queries[0].id).toEqual('id');
+      expect(desc.queries[0].name).toEqual('name');
+      expect(desc.queries[0].type).toEqual('type');
+    });
+
+  });
+})

--- a/package-res/resources/web/test/dataapi/models-mqlSpec.js
+++ b/package-res/resources/web/test/dataapi/models-mqlSpec.js
@@ -1,0 +1,89 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2015 Pentaho Corporation. All rights reserved.
+ */
+
+define(["common-data/models-mql"], function(modelsMql) {
+  describe("PPP-3455", function() {
+
+    parseXML = function() {
+        return {
+          getElementsByTagName: function() { return {} }
+        }
+    };
+
+    var flag;
+    setFlag = function() {
+      flag = true;
+    }
+
+    var mql;
+    var queryObject;
+    beforeEach(function() {
+      mql = new pentaho.pda.model.mql('');
+      mql.pentahoGet = function() { return {} };
+      mql.handler = { METADATA_SERVICE_URL: '' };
+
+      queryObject = { serialize: function() { return ''; } };
+    });
+
+
+    returnTextFunction = function(text) {
+      return function() {
+        return text;
+      };
+    }
+
+    it("mql.submit() should parse valid response", function() {
+      var obj = { field: 'value' };
+      mql.getText = returnTextFunction(JSON.stringify(obj));
+
+      var result = mql.submit('');
+      expect(result).toEqual(obj);
+    });
+
+    it("mql.submit() should not call eval() for obtained result", function() {
+      var bogusResponse = 'setFlag()';
+      mql.getText = returnTextFunction(bogusResponse);
+
+      flag = false;
+      var result = mql.submit('');
+      // returns null on errors
+      expect(result).toBeNull();
+      expect(flag).toBeFalsy();
+    });
+
+
+    it("mql.submitXmlQuery() should parse valid response", function() {
+      var obj = { field: 'value' };
+      mql.getText = returnTextFunction(JSON.stringify(obj));
+
+      var result = mql.submitXmlQuery(queryObject);
+      expect(result).toEqual(obj);
+    });
+
+    it("mql.submitXmlQuery() should not call eval() for obtained result", function() {
+      var bogusResponse = 'setFlag()';
+      mql.getText = returnTextFunction(bogusResponse);
+
+      flag = false;
+      var result = mql.submit('');
+      // returns null on errors
+      expect(result).toBeNull();
+      expect(flag).toBeFalsy();
+    });
+
+  });
+})

--- a/package-res/resources/web/test/dataapi/models-svcSpec.js
+++ b/package-res/resources/web/test/dataapi/models-svcSpec.js
@@ -1,0 +1,115 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2015 Pentaho Corporation. All rights reserved.
+ */
+
+CONTEXT_PATH = (typeof CONTEXT_PATH === 'undefined') ? '' : CONTEXT_PATH;
+define(["common-data/models-svc", "common-repo/pentaho-ajax"], function(modelsSvc, pentahoAjax) {
+  describe("PPP-3455", function() {
+
+    // fake definition
+    pentaho.DataTable = function( jsonTable ) {
+      this.jsonTable = jsonTable;
+    };
+
+    var flag;
+    setFlag = function() {
+      flag = true;
+    }
+
+    var bogusResponse = 'setFlag()';
+
+    var svc;
+    var _pentahoPost;
+    beforeEach(function() {
+      svc = new pentaho.pda.model.svc('');
+      svc.handler = { SERVICE_URL: '' };
+
+      if (typeof pentahoPost !== 'undefined') {
+        _pentahoPost = pentahoPost;
+      }
+    });
+
+    afterEach(function() {
+      if (typeof _pentahoPost !== 'undefined') {
+        pentahoPost = _pentahoPost;
+      }
+    });
+
+
+    returnTextFunction = function(text) {
+      return function() {
+        return text;
+      };
+    }
+
+    it("svc.discoverModelDetail() should parse valid response", function() {
+      var obj = {
+        categories: [ { name: 'category' } ],
+        capabilities: [ { name: 'capability' } ],
+        elements: [ { name: 'element' } ]
+      };
+      pentahoPost = returnTextFunction(JSON.stringify(obj));
+
+      svc.categories = null;
+      svc.capabilities = null;
+      svc.elements = null;
+
+      svc.discoverModelDetail();
+      expect(svc.categories).toEqual(obj.categories);
+      expect(svc.capabilities).toEqual(obj.capabilities);
+      expect(svc.elements).toEqual(obj.elements);
+    });
+
+    it("svc.discoverModelDetail() should not call eval() for obtained result", function() {
+      pentahoPost = returnTextFunction(bogusResponse);
+
+      flag = false;
+      svc.categories = null;
+      svc.capabilities = null;
+      svc.elements = null;
+
+      var call = function() {
+        svc.discoverModelDetail();
+      };
+      expect(call).toThrowError(SyntaxError);
+
+      expect(flag).toBeFalsy();
+      expect(svc.categories).toBeNull();
+      expect(svc.capabilities).toBeNull();
+      expect(svc.elements).toBeNull();
+    });
+
+
+    it("svc.submit() should parse valid response", function() {
+      var obj = { name: 'name' };
+      pentahoPost = returnTextFunction(JSON.stringify(obj));
+
+      var result = svc.submit('');
+      expect(result.jsonTable).toEqual(obj);
+    });
+
+    it("svc.submit() should not call eval() for obtained result", function() {
+      pentahoPost = returnTextFunction(bogusResponse);
+
+      flag = false;
+      var result = svc.submit('');
+      // returns null on errors
+      expect(result).toBeNull();
+      expect(flag).toBeFalsy();
+    });
+
+  });
+})


### PR DESCRIPTION
- in cda.js, models-mql.js, models-svc.js
  - replace eval() with JSON.parse()
  - add tests for valid and invalid input cases
(cherry picked from commit 4c27f84)

@rfellows, @krivera-pentaho, @diogofscmariano, review it please. This is a backport of https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/545