### PR TITLE
[BACKLOG-5846] - Extend EventAPI#parameterChanged to subscribe to cha…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -26,6 +26,7 @@
  * @property {Boolean} autoSubmit True if the prompt is in auto submit mode, false otherwise
  * @property {Dashboard} dashboard The dashboard object assigned to the prompt
  * @property {Boolean} parametersChanged True if the parameters have changed, False otherwise
+ * @property {Object} onParameterChanged collection of parameterNames and the callback called when that parameter is changed
  * @property {Function} onBeforeRender Callback called if defined before any change is performed in the prompt components
  * @property {Function} onAfterRender Callback called if defined after any change is performed in the prompt components
  * @property {Function} onBeforeUpdate Callback called if defined before the prompt update cycle is called
@@ -744,7 +745,14 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          */
         parameterChanged: function (param, name, value) {
           if (this.onParameterChanged) {
-            this.onParameterChanged(name, value);
+            var paramCallback = this.onParameterChanged[name];
+            if (paramCallback) {
+              if (typeof paramCallback === 'function') {
+                paramCallback(name, value); 
+              } else {
+                Logger.warn("The parameterChanged callback for '" + name + "' is not a function");
+              }
+            }
           }
 
           if (!value || value == "" || value == "null") {

--- a/package-res/resources/web/prompting/api/EventAPI.js
+++ b/package-res/resources/web/prompting/api/EventAPI.js
@@ -79,13 +79,31 @@ define([], function() {
      * @method
      * @param {Function} callback   The function to be executed when the event is triggered.
      *                              Pass null if you wish to unbind this event
-     * @example
+     * @param {String} paramName    The name of the parameter to which the callback will be called
+     *                              This argument is optional. If no parameter name is passed on
+     *                              the callback will be assigned to all the parameters. If paramName is
+     *                              not a valid string the callback will be registered to all parameters.
+     *
+     * @example <caption>Register a parameter changed event to all parameters</caption>
      *  api.event.parameterChanged(function(parameterName, parameterValue) {
      *    // Execute event based code
      *  })
+     *
+     * @example <caption>Register a parameter changed event to the parameter called "parameterName"</caption>
+     *  api.event.parameterChanged(function(parameterName, parameterValue) {
+     *    // Execute event based code
+     *  }, "parameterName")
      */
-    this.parameterChanged = function(callback) {
-      api.operation._getPromptPanel().onParameterChanged = callback;
+    this.parameterChanged = function(callback, paramName) {
+      if (callback) {
+        if (!api.operation._getPromptPanel().onParameterChanged) {
+          api.operation._getPromptPanel().onParameterChanged = {};
+        }
+        paramName = (typeof paramName === "string" && paramName) || '';
+        api.operation._getPromptPanel().onParameterChanged[paramName] = callback; 
+      } else {
+        api.operation._getPromptPanel().onParameterChanged = null;
+      }
     };
 
     /**

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -354,6 +354,32 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         expect(panel.nullValueParams[0]).toBe(param);
       });
 
+      it("parameterChanged with specific parameter callback", function() {
+        var param = {};
+        var name = "paramName";
+        var parameterChangedSpy = jasmine.createSpy("ParameterChangedSpy");
+        panel.onParameterChanged = {};
+        panel.onParameterChanged[name] = parameterChangedSpy;
+        panel.parameterChanged(param, name);
+        expect(parameterChangedSpy).toHaveBeenCalled();
+      });
+
+      it("parameterChanged with multiple parameter callback", function() {
+        var param = {};
+        panel.onParameterChanged = {};
+        var name1 = "paramName1";
+        var name2 = "paramName2";
+        var parameterChangedSpy1 = jasmine.createSpy("ParameterChangedSpy1");
+        var parameterChangedSpy2 = jasmine.createSpy("ParameterChangedSpy2");
+        panel.onParameterChanged = {};
+        panel.onParameterChanged[name1] = parameterChangedSpy1;
+        panel.onParameterChanged[name2] = parameterChangedSpy2;
+        panel.parameterChanged(param, name1);
+        expect(parameterChangedSpy1).toHaveBeenCalled();
+        panel.parameterChanged(param, name2);
+        expect(parameterChangedSpy2).toHaveBeenCalled();
+      });
+
       it("getParameterDefinition", function() {
         var promptPanel = {};
         var fn = jasmine.createSpyObj("callbackObj", [ "test" ]);

--- a/package-res/resources/web/test/prompting/api/EventAPISpec.js
+++ b/package-res/resources/web/test/prompting/api/EventAPISpec.js
@@ -74,6 +74,46 @@ define([
           expect(promptPanelSpy.onParameterChanged).toBe(callback);
         });
 
+        it("should clear callbacks if passed null", function () {
+          eventApi.parameterChanged(null);
+          expect(promptPanelSpy.onParameterChanged).toBe(null);
+        });
+
+        it("should assign overall callback if parameter name is null or empty", function () {
+          var parameterCallback = function() {};
+          eventApi.parameterChanged(parameterCallback);
+          eventApi.parameterChanged(parameterCallback, '');          
+          expect(promptPanelSpy.onParameterChanged).toBeDefined();
+          expect(promptPanelSpy.onParameterChanged['']).toBe(parameterCallback);
+        });
+
+        it("should register a parameterChanged event for a specific parameter", function() {
+          var parameterCallback = function() {};
+          eventApi.parameterChanged(parameterCallback, 'param');
+          expect(promptPanelSpy.onParameterChanged).toBeDefined();
+          expect(promptPanelSpy.onParameterChanged['param']).toBe(parameterCallback);
+        });
+
+        it("should register a parameterChanged event for multiple parameter", function() {
+          var parameterCallback1 = function() {};
+          var parameterCallback2 = function() {};
+          eventApi.parameterChanged(parameterCallback1, 'param1');
+          eventApi.parameterChanged(parameterCallback2, 'param2');
+          expect(promptPanelSpy.onParameterChanged).toBeDefined();
+          expect(promptPanelSpy.onParameterChanged['param1']).toBe(parameterCallback1);
+          expect(promptPanelSpy.onParameterChanged['param2']).toBe(parameterCallback2);
+        });
+
+        it("should register a parameterChanged event for a specific parameter and another for all parameters", function() {
+          var parameterCallback1 = function() {};
+          var parameterCallback2 = function() {};
+          eventApi.parameterChanged(parameterCallback1, 'param1');
+          eventApi.parameterChanged(parameterCallback2, '');
+          expect(promptPanelSpy.onParameterChanged).toBeDefined();
+          expect(promptPanelSpy.onParameterChanged['param1']).toBe(parameterCallback1);
+          expect(promptPanelSpy.onParameterChanged['']).toBe(parameterCallback2);
+        });
+
         it("should register a postInit event", function () {
           eventApi.postInit(callback);
           expect(dashboardSpy.on).toHaveBeenCalledWith('cdf:postInit', callback);


### PR DESCRIPTION
…nges in specifc, named parameters

- updated the parameterChanged method on the event api to allow the registration of a callback to the change of a specific parameter;
- updated the promptPanel onParameterChanged property to have an object of "parameter / callback" pairs instead of a function;
- updated the promptPanel parameterChanged method to call the callback for a specific parameter ;
- added tests for the event api;
- added tests for the promptPanel;