### PR TITLE
[BACKLOG-5981] - Common Client-Side Metadata Model

### DIFF
--- a/package-res/resources/web/pentaho/_doc/nully.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/nully.jsdoc
@@ -15,7 +15,7 @@
  */
 
 /**
- * The `nully` type contains the two values: `null` and `undefined`.
+ * The `Nully` type contains the two values: `null` and `undefined`.
  *
- * @typedef {null|undefined} nully
+ * @typedef {null|undefined} Nully
  */

--- a/package-res/resources/web/pentaho/data/Cell.js
+++ b/package-res/resources/web/pentaho/data/Cell.js
@@ -236,7 +236,7 @@ define([
      * and an unspecified label,
      * getting its label returns its referent's label.
      *
-     * If a never-nully string representation of this cell is needed,
+     * If a never {@link Nully} string representation of this cell is needed,
      * use the {@link pentaho.data.Cell#toString} method instead.
      *
      * @type string

--- a/package-res/resources/web/pentaho/data/Member.js
+++ b/package-res/resources/web/pentaho/data/Member.js
@@ -142,7 +142,7 @@ define([
     /**
      * Gets or sets the value of the member.
      *
-     * Note that the value of a member cannot be `nully`.
+     * Note that the value of a member cannot be {@link Nully}.
      *
      * @type !pentaho.data.Atomic
      */

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -174,7 +174,7 @@ define([
     /**
      * Creates a value given its specification.
      *
-     * When the specification is {@link nully}, `null` is returned.
+     * When the specification is {@link Nully}, `null` is returned.
      *
      * When the specification doesn't state its type, using inline metadata,
      * and `defaultType` is specified, it is used to create a value instance,

--- a/package-res/resources/web/pentaho/type/Item.Meta.js
+++ b/package-res/resources/web/pentaho/type/Item.Meta.js
@@ -533,9 +533,9 @@ define([
      * Converts a given value to a _mesa_ instance of this _prototype_,
      * if it is not one already.
      *
-     * If a {@link nully} value is specified, `null` is returned.
+     * If a {@link Nully} value is specified, `null` is returned.
      *
-     * If a given value is not {@link nully}
+     * If a given value is not {@link Nully}
      * and not already an instance of this _prototype_
      * (checked using {@link pentaho.type.Item.Meta#is}),
      * this method delegates the creation of an instance to

--- a/package-res/resources/web/pentaho/type/Property.js
+++ b/package-res/resources/web/pentaho/type/Property.js
@@ -338,12 +338,12 @@ define([
        * If the given value is already an instance of the property's value type,
        * it is returned.
        *
-       * By default, a {@link nully} value is converted to
+       * By default, a {@link Nully} value is converted to
        * (a clone of) the property's default value,
        * {@link pentaho.type.Property.Meta#value}.
        *
        * @param {?any} valueSpec A value or value specification.
-       * @param {boolean} [noDefault=false] Indicates if {@link nully} values
+       * @param {boolean} [noDefault=false] Indicates if {@link Nully} values
        *  should _not_ be converted to the property's default value.
        *
        * @return {?pentaho.type.Value} A value.

--- a/package-res/resources/web/pentaho/type/list.js
+++ b/package-res/resources/web/pentaho/type/list.js
@@ -281,7 +281,7 @@ define([
        * given the start index and the number of elements to remove.
        *
        * If `count` is less than `1`, nothing is removed.
-       * If `count` is {@link nully} or omitted, it defaults to `1`.
+       * If `count` is {@link Nully} or omitted, it defaults to `1`.
        * If `start` is not less than the number of elements in the list, nothing is removed.
        * If `start` is negative,
        * it means to start removing that many elements from the end (`start' = length - start`).

--- a/package-res/resources/web/pentaho/type/object.js
+++ b/package-res/resources/web/pentaho/type/object.js
@@ -44,7 +44,7 @@ define([
      *
      * @description Creates an object instance.
      */
-    return Simple.extend("pentaho.type.Object", {
+    return Simple.extend("pentaho.type.Object", /** @lends "pentaho.type.Object#" */{
       constructor: function(spec) {
         this.base(spec);
 

--- a/package-res/resources/web/pentaho/type/simple.js
+++ b/package-res/resources/web/pentaho/type/simple.js
@@ -221,13 +221,13 @@ define([
          * into the value stored in a simple's {@link pentaho.type.Simple#value}
          * property.
          *
-         * The casting function is never given a {@link nully} value.
+         * The casting function is never given a {@link Nully} value.
          *
          * If the casting function returns `null`,
          * an error is then thrown, in its behalf,
          * indicating that it cannot be converted to the type.
          *
-         * Set to a nully value to reset to the default cast function.
+         * Set to a {@link Nully} value to reset to the default cast function.
          *
          * The default cast function is the identity function.
          *
@@ -263,7 +263,7 @@ define([
          * the specified set of values must be a subset of those,
          * or an error is thrown.
          *
-         * Setting to a {@link nully} value or to an empty array,
+         * Setting to a {@link Nully} value or to an empty array,
          * clears the local value and inherits the ancestor's domain.
          *
          * NOTE: This attribute can only be used successfully on

--- a/package-res/resources/web/pentaho/type/value.js
+++ b/package-res/resources/web/pentaho/type/value.js
@@ -196,9 +196,9 @@ define([
          * Performs validation on a given value and
          * returns a non-empty array of `Error` objects or `null`.
          *
-         * If a {@link nully} value is specified, `null` is returned.
+         * If a {@link Nully} value is specified, `null` is returned.
          *
-         * @param {pentaho.type.Value|nully} value The value to validate.
+         * @param {pentaho.type.Value|Nully} value The value to validate.
          * @return {?Array.<!Error>} An array of `Error` or `null`.
          */
         validate: function(value) {
@@ -216,14 +216,14 @@ define([
         /**
          * Gets a value that indicates if two given values are equal.
          *
-         * If both values are {@link nully}, `true` is returned.
-         * If only one is {@link nully}, `false` is returned.
+         * If both values are {@link Nully}, `true` is returned.
+         * If only one is {@link Nully}, `false` is returned.
          * If the values have different constructors, `false` is returned.
          * Otherwise, {@link pentaho.type.Value#equals} is called
          * on `va`, with `vb` as an argument, and its result is returned.
          *
-         * @param {pentaho.type.Value|nully} [va] The first value.
-         * @param {pentaho.type.Value|nully} [vb] The second value.
+         * @param {pentaho.type.Value|Nully} [va] The first value.
+         * @param {pentaho.type.Value|Nully} [vb] The second value.
          *
          * @return {boolean} `true` if two values are equal, `false` otherwise.
          */


### PR DESCRIPTION
* Renaming the documentation type `nully` to `Nully`,
  to avoid a JSDocs generation bug

@graimundo please review.