### PR TITLE
[BACKLOG-6049] Unit tests and API documentation on the classes pentah…

### DIFF
--- a/package-res/resources/web/pentaho/type/Item.Meta.js
+++ b/package-res/resources/web/pentaho/type/Item.Meta.js
@@ -36,13 +36,25 @@ define([
    * @class
    * @abstract
    *
-   * @classDesc The base abstract _metadata_ class of _items_, whatever their context.
+   * @classDesc The base class for _metadata_ in the Pentaho Client Metadata Model.
    *
-   * _Meta_ classes do not create instances. Instead, their constructor is used to:
-   * 1. initialize _prototype_ instances
+   * The classes that descend from {@link pentaho.type.Item} also inherit its metadata.
+   * To acomplish this, the metadata of a given type is a singleton object that is
+   * referenced on all instances of the given type.
+   *
+   * Creating a subclass `Foo` of {@link pentaho.type.Item} implicitly generates the corresponding
+   * metadata class, placing a reference to it in the static member `Foo.Meta`.
+   * Therefore, in the regular workflow of this type system, the developer should not feel the need
+   * for creating _Meta_ subclasses.
+   *
+   * The `pentaho.type.Item` and `pentaho.type.Item.Meta` classes are closely bound and
+   * must naturally reference each other.
+   * The property {@link pentaho.type.Item.Meta#mesa} points to the prototype of the class this _Meta_ class refers to.
+   * Similarly, the property {@link pentaho.type.Item#meta} points to the singleton of its _Meta_ class.
+   *
+   * Note that _Meta_ classes do not create instances. Instead, their constructor is used to:
+   * 1. initialize _prototype_ instances (metadata singletons)
    * 2. hold static members.
-   *
-   * The _mesadata_ (prototype) of this class can be accessed through {@link pentaho.type.Item.Meta#mesa}.
    *
    * @description Initializes an item metadata instance.
    */
@@ -117,7 +129,7 @@ define([
     //region proto property
     // Set on `Item._extend`
     /**
-     * Gets the closest _prototype_, possibly itself.
+     * Gets the type of the closest ancestor, possibly itself.
      *
      * @name proto
      * @memberOf pentaho.type.Item.Meta#
@@ -132,11 +144,16 @@ define([
     // `root` is generally set on direct sub-classes of Item.
     // Should be the first meaningful, non-abstract item class below `Item` along a given branch.
     /**
-     * Gets the root _prototype_ item.
+     * Gets the root type in this type hierarchy.
      *
-     * Generally, root item types are the immediate sub-types of _item_.
+     * Even though all item types derive from {@link pentaho.type.Item},
+     * the developer can mark a given node is the hierarchy as _root_,
+     * in the sense that it defines a chain of related classes with a similar
+     * behavior.
+     *
+     * Generally, root types are the immediate sub-types of {@link pentaho.type.Item}.
      * The mandatory rule is, however, that
-     * root item types are _meaningful_, concrete roots of a type tree.
+     * root types are _meaningful_, concrete roots of a type tree.
      *
      * For example, {@link pentaho.type.Value} is a root type,
      * because it is the root of the value types and there is a single tree of value types.
@@ -155,7 +172,7 @@ define([
      */
 
     /**
-     * Gets a value that indicates if the item is a tree root _prototype_.
+     * Gets a value that indicates if this type is the root of its type hierarchy.
      *
      * @type boolean
      * @readonly
@@ -167,7 +184,7 @@ define([
 
     //region ancestor property
     /**
-     * Gets the closest **ancestor** _prototype_ item of the current tree, if any, or `null`.
+     * Gets the type of the closest **ancestor** in the current type hierarchy, if any, or `null`.
      *
      * The root item returns `null`.
      *
@@ -185,7 +202,7 @@ define([
     //region mesa property
     // Set on `Item._extend`
     /**
-     * Gets the _mesadata_ _prototype_ of this item type.
+     * Gets the _prototype_ of the class that represents this type.
      *
      * @name mesa
      * @memberOf pentaho.type.Item.Meta#
@@ -203,11 +220,11 @@ define([
     _id: null,
 
     /**
-     * Gets the id of the item type.
+     * Gets the id of this type.
      *
-     * Can only be specified when extending an item type.
+     * Can only be specified when extending a type.
      *
-     * Only item types which have an associated AMD/RequireJS module have an id.
+     * The id only exists for types which have an associated AMD/RequireJS module.
      * However, note that all have a {@link pentaho.type.Item.Meta#uid}.
      *
      * This attribute is not inherited.
@@ -429,17 +446,18 @@ define([
    /**
     * Gets or sets the default view for items of this type.
     *
-    * When `undefined`, the view will be inherited from the ancestor type.
-    * When _falsy_ (like `null` or an empty string),
-    * the view will be cleared and not inherited.
+    * Setting to `undefined` causes the view to be inherited from the ancestor type.
+    * Setting to a _falsy_ value (like `null` or an empty string),
+    * clears the value of the property, ignoring any inherited value.
     *
-    * Otherwise, when a string, it is the id of the view's module.
-    * When the string starts with `/`, `xyz:` or ends with `.js`,
-    * the id is considered absolute.
-    * Otherwise, it is considered relative to the type's id folder.
+    * Setting to a string defines the id of the view's module.
+    * If the string starts with `/`, `xyz:` or ends with `.js`,
+    * the id is considered to be absolute,
+    * otherwise it is considered to be relative to the type's id folder.
     *
-    * Otherwise, it is considered to be the class or factory of the view.
-    * It'll normally be a function, but this is not ensured.
+    * Attempting to set to some other value is interpreted as the intention to set
+    * the class or factory of the view.
+    * It will normally be a function, but this is not ensured.
     *
     * @type string | Class | any
     * @readOnly
@@ -470,7 +488,7 @@ define([
     },
 
     /**
-     * Gets a promise for the default view class or `null` if no view is defined.
+     * Gets a promise for the default view class, or `null` if no view is defined.
      *
      * @type ?Promise.<!Class|!any>
      * @readOnly
@@ -508,7 +526,7 @@ define([
     },
 
     /**
-     * Creates a _mesa_ instance of this _prototype_.
+     * Creates an instance of this type.
      *
      * @param {...any} args The construction arguments.
      * @return {pentaho.type.Item} The created instance.
@@ -520,23 +538,22 @@ define([
     },
 
     /**
-     * Determines if a specified value is a _mesa_ instance of this _prototype_.
+     * Determines if a specified value is an instance of this type.
      *
      * @param {any} value The value to test.
-     * @return {boolean} `true` if if is an instance, `false` otherwise.
+     * @return {boolean} Returns `true` if the argument is an instance or `false` otherwise.
      */
     is: function(value) {
       return O_isProtoOf.call(this.mesa, value);
     },
 
     /**
-     * Converts a given value to a _mesa_ instance of this _prototype_,
+     * Converts a given value to an instance of this type,
      * if it is not one already.
      *
      * If a {@link Nully} value is specified, `null` is returned.
      *
-     * If a given value is not {@link Nully}
-     * and not already an instance of this _prototype_
+     * Otherwise, if a given value is not already an instance of this type
      * (checked using {@link pentaho.type.Item.Meta#is}),
      * this method delegates the creation of an instance to
      * {@link pentaho.type.Item.Meta#create}.
@@ -553,7 +570,8 @@ define([
   }, /** @lends pentaho.type.Item.Meta */{
 
     /**
-     * Gets the class of which this one is the metadata class.
+     * Gets the class used for _representing_ data of this type,
+     * i.e. the class that this metadata describes.
      *
      * If you're wondering were this name comes from,
      * "Mesa" is a Greek word which is opposite to "Meta".

--- a/package-res/resources/web/pentaho/type/Item.js
+++ b/package-res/resources/web/pentaho/type/Item.js
@@ -27,9 +27,49 @@ define([
    * @class
    * @abstract
    *
-   * @classDesc The abstract base class of _item_ types.
+   * @classDesc The base class of types in the Pentaho Client Metadata Model.
    *
-   * The metadata (prototype) of this class can be accessed through {@link pentaho.type.Item#meta}.
+   * The `pentaho.type.Item` class (and its descendents) embeds its own metadata,
+   * which can be accessed via the property {@link pentaho.type.Item#meta}.
+   * Because the metadata can be inherited, it is actually an instance
+   * of a metaclass stored at {@link pentaho.type.Item.Meta}.
+   *
+   * The developer is expected to subclass only the {@link pentaho.type.Item} class,
+   * as the corresponding companion class is automatically generated from the spec
+   * passed to the {@link pentaho.type.Item#meta} property.
+   *
+   * Other frameworks generally require the developer to maintain two class hierarchies
+   * (one for storing data, another for storing metadata) and ensure that the
+   * two hierarchies are properly linked together.
+   * This framework attempts to simplify the development process by automating the
+   * the generation and linking of the class that describes the metadata.
+   *
+   * @example
+   * <caption> Create a new class <code>DerivedItem</code> containing
+   * an attribute <code>greeting</code> and a method <code>doSomething</code> </caption>
+   *
+   * require(["pentaho/type/Item"], function(Item){
+   *   var DerivedItem = Item.extend({
+   *     constructor: function(label){
+   *       this.label = label;
+   *     },
+   *     meta: { // metadata spec
+   *       greeting: "Hello, ",
+   *       veryLongString: "..."
+   *     },
+   *     saySomething: function(){
+   *       console.log(this.meta.greeting + this.label + "!");
+   *     }
+   *   });
+   *
+   *   var a = new DerivedItem("Alice");
+   *   a.saySomething(); // "Hello, Alice!"
+   *   var b = new DerivedItem("Bob");
+   *   b.saySomething(); // "Hello, Bob!"
+   *
+   *   // All instances share the same _meta_:
+   *   b.meta.greeting ===  a.meta.greeting // true
+   * });
    *
    * @description Creates an instance.
    */
@@ -42,7 +82,7 @@ define([
     _meta: null,
 
     /**
-     * Gets the _metadata_ _prototype_ of this item type.
+     * Gets the singleton that describes the metadata associated with this type.
      *
      * @name meta
      * @memberOf pentaho.type.Item#
@@ -72,7 +112,7 @@ define([
 
     //region meta property
     /**
-     * Gets the _metadata_ _prototype_ of this item type.
+     * Gets the singleton that describes the metadata associated with this type.
      *
      * @type pentaho.type.Item.Meta
      * @readonly
@@ -118,7 +158,7 @@ define([
       var subMesa = Object.create(mesa);
 
       // META
-      var metaInstSpec = O["delete"](instSpec,  "meta");
+      var metaInstSpec = O["delete"](instSpec, "meta");
 
       var ka = keyArgs ? Object.create(keyArgs) : {};
       ka.mesa = subMesa;
@@ -137,11 +177,11 @@ define([
       // 1. `instSpec` may override property accessors only defined by `Complex.Meta`
       // 2. So, the Meta class must be created *before* applying instSpec and classSpec to SubMesa
       // 3. The Meta class requires Mesa to already exist, to be able to define accessors
-      var metaInstSpec  = O["delete"](instSpec,  "meta"),
-          metaClassSpec = O["delete"](classSpec, "meta"),
-          // Setting a function's name is failing on PhantomJS 1.9.8...
-          mesaName      = SubMesa.name || SubMesa.displayName,
-          metaName      = mesaName && (mesaName + ".Meta");
+      var metaInstSpec = O["delete"](instSpec, "meta"),
+        metaClassSpec = O["delete"](classSpec, "meta"),
+      // Setting a function's name is failing on PhantomJS 1.9.8...
+        mesaName = SubMesa.name || SubMesa.displayName,
+        metaName = mesaName && (mesaName + ".Meta");
 
       var ka = keyArgs ? Object.create(keyArgs) : {};
       ka.mesa = SubMesa.prototype;

--- a/package-res/resources/web/pentaho/type/Item.js
+++ b/package-res/resources/web/pentaho/type/Item.js
@@ -29,7 +29,7 @@ define([
    *
    * @classDesc The base class of types in the Pentaho Client Metadata Model.
    *
-   * The `pentaho.type.Item` class (and its descendents) embeds its own metadata,
+   * The `pentaho.type.Item` class (and its descendants) embeds its own metadata,
    * which can be accessed via the property {@link pentaho.type.Item#meta}.
    * Because the metadata can be inherited, it is actually an instance
    * of a metaclass stored at {@link pentaho.type.Item.Meta}.
@@ -141,11 +141,11 @@ define([
      * To create a _prototype_ with a constructor,
      * extend from the base constructor instead, by calling its `extend` method.
      *
-     * @param {pentaho.type.Item} [mesa] The base _mesadata_ prototype.
+     * @param {pentaho.type.Item} [mesa] The prototype of the class used for representing the data.
      *   When nully, defaults to the prototype of the constructor
      *   where this method is called.
      *
-     * @param {object} [instSpec] The sub-prototype specification.
+     * @param {object} [instSpec] The specification of the prototype that will be returned by this function.
      * @param {object} [keyArgs] Keyword arguments.
      *
      * @return {pentaho.type.Item} The created sub-prototype.
@@ -160,7 +160,7 @@ define([
       // META
       var metaInstSpec = O["delete"](instSpec, "meta");
 
-      var ka = keyArgs ? Object.create(keyArgs) : {};
+      var ka  = keyArgs ? Object.create(keyArgs) : {};
       ka.mesa = subMesa;
 
       mesa.meta._extendProto(metaInstSpec, ka);
@@ -177,13 +177,13 @@ define([
       // 1. `instSpec` may override property accessors only defined by `Complex.Meta`
       // 2. So, the Meta class must be created *before* applying instSpec and classSpec to SubMesa
       // 3. The Meta class requires Mesa to already exist, to be able to define accessors
-      var metaInstSpec = O["delete"](instSpec, "meta"),
-        metaClassSpec = O["delete"](classSpec, "meta"),
-      // Setting a function's name is failing on PhantomJS 1.9.8...
-        mesaName = SubMesa.name || SubMesa.displayName,
-        metaName = mesaName && (mesaName + ".Meta");
+      var metaInstSpec  = O["delete"](instSpec, "meta"),
+          metaClassSpec = O["delete"](classSpec, "meta"),
+          // Setting a function's name is failing on PhantomJS 1.9.8...
+          mesaName      = SubMesa.name || SubMesa.displayName,
+          metaName      = mesaName && (mesaName + ".Meta");
 
-      var ka = keyArgs ? Object.create(keyArgs) : {};
+      var ka  = keyArgs ? Object.create(keyArgs) : {};
       ka.mesa = SubMesa.prototype;
 
       this.Meta.extend(metaName, metaInstSpec, metaClassSpec, ka);

--- a/package-res/resources/web/test/karma/unit/pentaho/type/Item.Meta.Spec.js
+++ b/package-res/resources/web/test/karma/unit/pentaho/type/Item.Meta.Spec.js
@@ -139,7 +139,7 @@ define([
       it("should inherit a base function", function() {
         var FA = function() {
         };
-        var A = Item.extend({meta: {view: FA}});
+        var A  = Item.extend({meta: {view: FA}});
 
         expect(A.meta.view).toBe(FA);
 
@@ -151,15 +151,21 @@ define([
       it("should respect a specified function", function() {
         var FA = function() {
         };
-        var A = Item.extend({meta: {view: FA}});
+        var A  = Item.extend({meta: {view: FA}});
 
         expect(A.meta.view).toBe(FA);
 
         var FB = function() {
         };
-        var B = A.extend({meta: {id: "baba/dudu", view: FB}});
+        var B  = A.extend({meta: {id: "baba/dudu", view: FB}});
 
         expect(B.meta.view).toBe(FB);
+      });
+
+      it("should preserve the default value", function() {
+        Item.meta.view = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.view).toBe(null);
       });
     }); // end #view
 
@@ -179,8 +185,8 @@ define([
       it("should return a Promise, when view is a function, and resolve to it", function(done) {
         var View = function() {
         };
-        var A = Item.extend({meta: {view: View}});
-        var p = A.meta.viewClass;
+        var A    = Item.extend({meta: {view: View}});
+        var p    = A.meta.viewClass;
 
         expect(p instanceof Promise).toBe(true);
 
@@ -192,8 +198,8 @@ define([
 
       it("should return a Promise, when view is an object, and resolve to it", function(done) {
         var View = {};
-        var A = Item.extend({meta: {view: View}});
-        var p = A.meta.viewClass;
+        var A    = Item.extend({meta: {view: View}});
+        var p    = A.meta.viewClass;
 
         expect(p instanceof Promise).toBe(true);
 
@@ -276,7 +282,7 @@ define([
 
       it("should return an new Promise and resolve to the new View when the view changes", function(done) {
 
-        var ViewBar = function() {
+        var ViewBar  = function() {
         };
         var ViewDude = function() {
         };
@@ -309,6 +315,12 @@ define([
         });
       });
 
+      it("should preserve the default value", function() {
+        Item.meta.view = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.view).toBe(null);
+      });
+
     }); // end #viewClass
 
     describe("#label -", function() {
@@ -325,6 +337,21 @@ define([
           expectIt({label: null});
           expectIt({label: ""});
         });
+
+        it("should preserve the default value", function() {
+          Item.meta.label = undefined;
+          // The default value is still there (did not delete)
+          expect(Item.meta.label).toBe(null);
+        });
+
+        it("subclasses should preserve the default value", function() {
+          var FirstDerivative         = Item.extend({meta: {label: "Foo"}});
+          var SecondDerivative        = FirstDerivative.extend({meta: {label: "Bar"}});
+          SecondDerivative.meta.label = undefined;
+          // The default value is still there (did not delete)
+          expect(SecondDerivative.meta.label).toBe("Foo");
+        });
+
       }); // when `label` is falsy
 
       describe("when `label` is truthy", function() {
@@ -349,6 +376,11 @@ define([
           expectIt({id: null});
           expectIt({id: null});
         });
+        it("should preserve the default value", function() {
+          Item.meta.id = undefined;
+          // The default value is still there (did not delete)
+          expect(Item.meta.id).toBe(null);
+        });
       });
 
       describe("when `id` is truthy -", function() {
@@ -363,6 +395,13 @@ define([
     }); // #id
 
     describe("#description -", function() {
+
+      it("should preserve the default value", function() {
+        Item.meta.description = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.description).toBe(null);
+      });
+
       describe("when not specified -", function() {
         it("should inherit the base description", function() {
           function expectIt(spec) {
@@ -400,6 +439,13 @@ define([
 
     describe("#category -", function() {
       describe("when not specified -", function() {
+
+        it("should preserve the default value", function() {
+          Item.meta.category = undefined;
+          // The default value is still there (did not delete)
+          expect(Item.meta.category).toBe(null);
+        });
+
         it("should inherit the base category", function() {
           function expectIt(spec) {
             var Derived = Item.extend({meta: spec});
@@ -435,6 +481,12 @@ define([
     }); // #category
 
     describe("#helpUrl -", function() {
+      it("should preserve the default value", function() {
+        Item.meta.helpUrl = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.helpUrl).toBe(null);
+      });
+
       describe("when not specified", function() {
         it("should inherit the base helpUrl", function() {
           function expectIt(spec) {
@@ -478,7 +530,7 @@ define([
 
       it("should be unique", function() {
         var DerivedA = Item.extend(),
-          DerivedB = Item.extend();
+            DerivedB = Item.extend();
         expect(DerivedA.meta.uid).not.toBe(DerivedB.meta.uid);
         expect(DerivedA.meta.uid).not.toBe(Item.meta.uid);
       });
@@ -487,6 +539,12 @@ define([
     // TODO: ordinal, styleClass, advanced, browsable <- bring and adapt these from Property.Meta tests
 
     describe("#styleClass -", function() {
+      it("should preserve the default value", function() {
+        Item.meta.styleClass = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.styleClass).toBe(null);
+      });
+
       it("can be set on a derived class", function() {
         ["xpto", null].forEach(function(propValue) {
           var Derived = Item.extend({meta: {"styleClass": propValue}});
@@ -506,8 +564,8 @@ define([
           [[], null]
         ].forEach(function(candidateAndFinal) {
           var candidate = candidateAndFinal[0];
-          var final = candidateAndFinal[1];
-          var Derived = Item.extend({meta: {"styleClass": candidate}});
+          var final     = candidateAndFinal[1];
+          var Derived   = Item.extend({meta: {"styleClass": candidate}});
           expect(Derived.meta.styleClass).toBe(final);
 
           var item = new Derived();
@@ -517,6 +575,12 @@ define([
     }); // #styleClass
 
     describe("#advanced -", function() {
+      it("should preserve the default value", function() {
+        Item.meta.advanced = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.advanced).toBe(false);
+      });
+
       it("can be set on a derived class", function() {
         [true, false].forEach(function(bool) {
           var Derived = Item.extend({meta: {"advanced": bool}});
@@ -529,7 +593,7 @@ define([
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [true, false].forEach(function(bool) {
           [null, undefined].forEach(function(value) {
-            var FirstDerivative = Item.extend({meta: {"advanced": bool}});
+            var FirstDerivative  = Item.extend({meta: {"advanced": bool}});
             var SecondDerivative = FirstDerivative.extend({meta: {"advanced": !bool}});
 
             SecondDerivative.meta.advanced = value;
@@ -540,6 +604,11 @@ define([
     }); // #advanced
 
     describe("#browsable -", function() {
+      it("should preserve the default value", function() {
+        Item.meta.browsable = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.browsable).toBe(true);
+      });
       it("can be set on a derived class", function() {
         [true, false].forEach(function(bool) {
           var Derived = Item.extend({meta: {"browsable": bool}});
@@ -552,7 +621,7 @@ define([
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [true, false].forEach(function(bool) {
           [null, undefined].forEach(function(value) {
-            var FirstDerivative = Item.extend({meta: {"browsable": bool}});
+            var FirstDerivative  = Item.extend({meta: {"browsable": bool}});
             var SecondDerivative = FirstDerivative.extend({meta: {"browsable": !bool}});
 
             SecondDerivative.meta.browsable = value;
@@ -563,6 +632,11 @@ define([
     }); // #browsable
 
     describe("#ordinal -", function() {
+      it("should preserve the default value", function() {
+        Item.meta.ordinal = undefined;
+        // The default value is still there (did not delete)
+        expect(Item.meta.ordinal).toBe(0);
+      });
       it("can be set on a derived class", function() {
         [1].forEach(function(someValue) {
           var Derived = Item.extend({meta: {"ordinal": someValue}});
@@ -584,9 +658,9 @@ define([
           [[], 0], [[1, 2], 0]
         ].forEach(function(candidateAndFinal) {
           var candidate = candidateAndFinal[0];
-          var final = candidateAndFinal[1];
+          var final     = candidateAndFinal[1];
 
-          var FirstDerivative = Item.extend({meta: {"ordinal": 42}});
+          var FirstDerivative  = Item.extend({meta: {"ordinal": 42}});
           var SecondDerivative = FirstDerivative.extend({meta: {"ordinal": candidate}});
           expect(SecondDerivative.meta.ordinal).toBe(final);
 
@@ -597,7 +671,7 @@ define([
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [1, 20].forEach(function(someValue) {
           [null, undefined].forEach(function(resetValue) {
-            var FirstDerivative = Item.extend({meta: {"ordinal": 42}});
+            var FirstDerivative  = Item.extend({meta: {"ordinal": 42}});
             var SecondDerivative = FirstDerivative.extend({meta: {"ordinal": someValue}});
 
             SecondDerivative.meta.ordinal = resetValue;
@@ -621,8 +695,8 @@ define([
 
     describe("#ancestor -", function() {
       it("returns the immediate ancestor", function() {
-        var FirstDerivative = Item.extend({meta: {"firstDerivative": true}});
-        var FirstSibling = Item.extend({meta: {"firstSibling": true}});
+        var FirstDerivative  = Item.extend({meta: {"firstDerivative": true}});
+        var FirstSibling     = Item.extend({meta: {"firstSibling": true}});
         var SecondDerivative = FirstDerivative.extend({meta: {"secondDerivative": true}});
 
         expect(FirstDerivative.meta.ancestor).toBe(Item.meta);
@@ -641,9 +715,6 @@ define([
         expect(Derived.meta.ancestor).toBe(Item.meta);
       });
     }); // #ancestor
-
-    // TODO: create(.), is(.), to(.)
-
 
     describe("#create -", function() {
       it("returns a new instance of `pentaho.type.Item`", function() {
@@ -677,10 +748,10 @@ define([
       it("casts native data types to `pentaho.type.Item`", function() {
         [
           "",
-          0, 1, 1/0, Math.sqrt(-1),
+          0, 1, 1 / 0, Math.sqrt(-1),
           true,
           new Date(),
-          {},[]
+          {}, []
         ].forEach(function(value) {
           expect(Item.meta.to(value) instanceof Item).toBe(true);
         });

--- a/package-res/resources/web/test/karma/unit/pentaho/type/Item.Meta.Spec.js
+++ b/package-res/resources/web/test/karma/unit/pentaho/type/Item.Meta.Spec.js
@@ -1,0 +1,697 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/type/Item"
+], function(Item) {
+
+  "use strict";
+
+  /*global describe:true, it:true, expect:true, beforeEach:true*/
+
+
+  describe("pentaho/type/Item.Meta", function() {
+
+    describe("#view -", function() {
+      it("should default to `null`", function() {
+        var Derived = Item.extend({meta: {id: "fake/id"}});
+
+        expect(Derived.meta.view).toBe(null);
+      });
+
+      it("should leave absolute ids intact", function() {
+        var Derived = Item.extend({meta: {id: "fake/id", view: "/foo"}});
+
+        expect(Derived.meta.view).toBe("/foo");
+
+        // ---
+
+        Derived = Item.extend({meta: {view: "foo:"}});
+
+        expect(Derived.meta.view).toBe("foo:");
+
+        // ---
+
+        Derived = Item.extend({meta: {view: "bar.js"}});
+
+        expect(Derived.meta.view).toBe("bar.js");
+      });
+
+      it("should convert relative ids to absolute", function() {
+        var Derived = Item.extend({meta: {id: "fake/id", view: "foo"}});
+
+        expect(Derived.meta.view).toBe("fake/id/foo");
+
+        // ---
+
+        Derived = Item.extend({meta: {id: "fake/id", view: "foo/bar"}});
+
+        expect(Derived.meta.view).toBe("fake/id/foo/bar");
+
+        // ---
+
+        Derived = Item.extend({meta: {id: "fake/id", view: "./bar"}});
+
+        expect(Derived.meta.view).toBe("fake/id/./bar");
+
+        // ---
+
+        Derived = Item.extend({meta: {id: "fake/id", view: "../bar"}});
+
+        expect(Derived.meta.view).toBe("fake/id/../bar");
+
+        // ---
+        // no base folder..
+
+        Derived = Item.extend({meta: {id: "id", view: "../bar"}});
+
+        expect(Derived.meta.view).toBe("id/../bar");
+
+        // ---
+
+        Derived = Item.extend({meta: {view: "../bar"}});
+
+        expect(Derived.meta.view).toBe("../bar");
+      });
+
+      it("should inherit the base type's view, when unspecified", function() {
+        var A = Item.extend({meta: {view: "foo"}});
+
+        expect(A.meta.view).toBe("foo");
+
+        var B = A.extend();
+
+        expect(B.meta.view).toBe("foo");
+      });
+
+      it("should inherit the base type's view, when spec is undefined", function() {
+        var A = Item.extend({meta: {view: "foo"}});
+
+        expect(A.meta.view).toBe("foo");
+
+        var B = A.extend({meta: {view: undefined}});
+
+        expect(B.meta.view).toBe("foo");
+      });
+
+      it("should respect a null spec value", function() {
+        var A = Item.extend({meta: {view: "foo"}});
+
+        expect(A.meta.view).toBe("foo");
+
+        var B = A.extend({meta: {view: null}});
+
+        expect(B.meta.view).toBe(null);
+      });
+
+      it("should convert an empty string value to null", function() {
+        var A = Item.extend({meta: {view: "foo"}});
+
+        expect(A.meta.view).toBe("foo");
+
+        var B = A.extend({meta: {view: ""}});
+
+        expect(B.meta.view).toBe(null);
+      });
+
+      it("should respect a specified non-empty string", function() {
+        var A = Item.extend({meta: {view: "foo"}});
+
+        expect(A.meta.view).toBe("foo");
+
+        var B = A.extend({meta: {id: "baba/dudu", view: "bar"}});
+
+        expect(B.meta.view).toBe("baba/dudu/bar");
+      });
+
+      it("should inherit a base function", function() {
+        var FA = function() {
+        };
+        var A = Item.extend({meta: {view: FA}});
+
+        expect(A.meta.view).toBe(FA);
+
+        var B = A.extend({meta: {id: "baba/dudu"}});
+
+        expect(B.meta.view).toBe(FA);
+      });
+
+      it("should respect a specified function", function() {
+        var FA = function() {
+        };
+        var A = Item.extend({meta: {view: FA}});
+
+        expect(A.meta.view).toBe(FA);
+
+        var FB = function() {
+        };
+        var B = A.extend({meta: {id: "baba/dudu", view: FB}});
+
+        expect(B.meta.view).toBe(FB);
+      });
+    }); // end #view
+
+    describe("#viewClass -", function() {
+
+      afterEach(function() {
+        require.undef("foo/bar");
+        require.undef("foo/dude");
+      });
+
+      it("should return `null` when view is `null`", function() {
+        var A = Item.extend();
+
+        expect(A.meta.viewClass).toBe(null);
+      });
+
+      it("should return a Promise, when view is a function, and resolve to it", function(done) {
+        var View = function() {
+        };
+        var A = Item.extend({meta: {view: View}});
+        var p = A.meta.viewClass;
+
+        expect(p instanceof Promise).toBe(true);
+
+        p.then(function(V) {
+          expect(V).toBe(View);
+          done();
+        });
+      });
+
+      it("should return a Promise, when view is an object, and resolve to it", function(done) {
+        var View = {};
+        var A = Item.extend({meta: {view: View}});
+        var p = A.meta.viewClass;
+
+        expect(p instanceof Promise).toBe(true);
+
+        p.then(function(V) {
+          expect(V).toBe(View);
+          done();
+        });
+      });
+
+      it("should return a Promise, when view is a string, and resolve to that module", function(done) {
+
+        var View = function() {
+        };
+
+        define("foo/bar", function() {
+          return View;
+        });
+
+        var A = Item.extend({meta: {view: "foo/bar"}});
+
+        var p = A.meta.viewClass;
+
+        expect(p instanceof Promise).toBe(true);
+
+        p.then(function(V) {
+          expect(V).toBe(View);
+
+          done();
+        });
+      });
+
+      it("should return a Promise even if view is inherited from the base class", function(done) {
+
+        var View = function() {
+        };
+
+        define("foo/bar", function() {
+          return View;
+        });
+
+        var A = Item.extend({meta: {view: "foo/bar"}});
+
+        var B = A.extend();
+
+        var pb = B.meta.viewClass;
+
+        var pa = A.meta.viewClass;
+
+        expect(pa).toBe(pb);
+        expect(pa instanceof Promise).toBe(true);
+
+        pa.then(function(V) {
+          expect(V).toBe(View);
+
+          done();
+        });
+      });
+
+      it("should return the same Promise multiple times", function(done) {
+
+        var View = function() {
+        };
+
+        define("foo/bar", function() {
+          return View;
+        });
+
+        var A = Item.extend({meta: {view: "foo/bar"}});
+
+        var pa = A.meta.viewClass;
+
+        expect(pa).toBe(A.meta.viewClass);
+
+        pa.then(function(V) {
+          expect(V).toBe(View);
+          expect(pa).toBe(A.meta.viewClass);
+          done();
+        });
+      });
+
+      it("should return an new Promise and resolve to the new View when the view changes", function(done) {
+
+        var ViewBar = function() {
+        };
+        var ViewDude = function() {
+        };
+
+        define("foo/bar", function() {
+          return ViewBar;
+        });
+        define("foo/dude", function() {
+          return ViewDude;
+        });
+
+        var A = Item.extend({meta: {view: "foo/bar"}});
+
+        var pa = A.meta.viewClass;
+
+        A.meta.view = "foo/dude";
+
+        var pb = A.meta.viewClass;
+
+        expect(pb instanceof Promise).toBe(true);
+
+        expect(pa).not.toBe(pb);
+
+        Promise.all([pa, pb]).then(function(views) {
+
+          expect(views[0]).toBe(ViewBar);
+          expect(views[1]).toBe(ViewDude);
+
+          done();
+        });
+      });
+
+    }); // end #viewClass
+
+    describe("#label -", function() {
+
+      describe("when `label` is falsy -", function() {
+        it("should inherit `label`", function() {
+          function expectIt(derivedSpec) {
+            var Derived = Item.extend({meta: derivedSpec});
+            expect(Derived.meta.label).toBe(Item.meta.label);
+          }
+
+          expectIt({});
+          expectIt({label: undefined});
+          expectIt({label: null});
+          expectIt({label: ""});
+        });
+      }); // when `label` is falsy
+
+      describe("when `label` is truthy", function() {
+        // Can change the label
+        it("should respect the `label`", function() {
+          var Derived = Item.extend({meta: {label: "Foo"}});
+          expect(Derived.meta.label).toBe("Foo");
+        });
+      });
+    }); // #label
+
+    describe("#id -", function() {
+      describe("when `id` is falsy -", function() {
+        it("should have `null` as a default `id`", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+            expect(Derived.meta.id).toBe(null);
+          }
+
+          expectIt({});
+          expectIt({id: undefined});
+          expectIt({id: null});
+          expectIt({id: null});
+        });
+      });
+
+      describe("when `id` is truthy -", function() {
+        it("should respect it", function() {
+          var Derived = Item.extend({
+            meta: {id: "foo/bar"}
+          });
+
+          expect(Derived.meta.id).toBe("foo/bar");
+        });
+      });
+    }); // #id
+
+    describe("#description -", function() {
+      describe("when not specified -", function() {
+        it("should inherit the base description", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.description).toBe(Item.meta.description);
+          }
+
+          expectIt({});
+          expectIt({description: undefined});
+        });
+      });
+
+      describe("when specified as `null` or an empty string -", function() {
+        it("should set the description to `null`", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.description).toBe(null);
+          }
+
+          expectIt({description: null});
+          expectIt({description: ""});
+        });
+      });
+
+      describe("when specified as a non-empty string -", function() {
+        it("should respect it", function() {
+          var Derived = Item.extend({meta: {description: "Foo"}});
+
+          expect(Derived.meta.description).toBe("Foo");
+        });
+      });
+    }); // #description
+
+    describe("#category -", function() {
+      describe("when not specified -", function() {
+        it("should inherit the base category", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.category).toBe(Item.meta.category);
+          }
+
+          expectIt({});
+          expectIt({category: undefined});
+        });
+      });
+
+      describe("when specified as `null` or an empty string -", function() {
+        it("should set the category to `null`", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.category).toBe(null);
+          }
+
+          expectIt({category: null});
+          expectIt({category: ""});
+        });
+      });
+
+      describe("when specified as a non-empty string", function() {
+        it("should respect it", function() {
+          var Derived = Item.extend({meta: {category: "Foo"}});
+
+          expect(Derived.meta.category).toBe("Foo");
+        });
+      });
+    }); // #category
+
+    describe("#helpUrl -", function() {
+      describe("when not specified", function() {
+        it("should inherit the base helpUrl", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.helpUrl).toBe(Item.meta.helpUrl);
+          }
+
+          expectIt({});
+          expectIt({helpUrl: undefined});
+        });
+      });
+
+      describe("when specified as `null` or an empty string -", function() {
+        it("should set the helpUrl to `null`", function() {
+          function expectIt(spec) {
+            var Derived = Item.extend({meta: spec});
+
+            expect(Derived.meta.helpUrl).toBe(null);
+          }
+
+          expectIt({helpUrl: null});
+          expectIt({helpUrl: ""});
+        });
+      });
+
+      describe("when specified as a non-empty string -", function() {
+        it("should respect it", function() {
+          var Derived = Item.extend({meta: {helpUrl: "Foo"}});
+
+          expect(Derived.meta.helpUrl).toBe("Foo");
+        });
+      });
+    }); // #helpUrl
+
+    describe("#uid -", function() {
+      it("should not be inherited", function() {
+        var Derived = Item.extend();
+        expect(Derived.meta.uid).not.toBe(Item.meta.uid);
+      });
+
+      it("should be unique", function() {
+        var DerivedA = Item.extend(),
+          DerivedB = Item.extend();
+        expect(DerivedA.meta.uid).not.toBe(DerivedB.meta.uid);
+        expect(DerivedA.meta.uid).not.toBe(Item.meta.uid);
+      });
+    }); // #uid
+
+    // TODO: ordinal, styleClass, advanced, browsable <- bring and adapt these from Property.Meta tests
+
+    describe("#styleClass -", function() {
+      it("can be set on a derived class", function() {
+        ["xpto", null].forEach(function(propValue) {
+          var Derived = Item.extend({meta: {"styleClass": propValue}});
+          expect(Derived.meta.styleClass).toBe(propValue);
+
+          var item = new Derived();
+          expect(item.meta.styleClass).toBe(propValue);
+        });
+      });
+      it("casts to a string, or to `null` if it is nully or an object", function() {
+        [
+          [1 / 0, "Infinity"],
+          [0, "0"], [1, "1"],
+          [{}, "[object Object]"],
+          [undefined, null],
+          ["", null],
+          [[], null]
+        ].forEach(function(candidateAndFinal) {
+          var candidate = candidateAndFinal[0];
+          var final = candidateAndFinal[1];
+          var Derived = Item.extend({meta: {"styleClass": candidate}});
+          expect(Derived.meta.styleClass).toBe(final);
+
+          var item = new Derived();
+          expect(item.meta.styleClass).toBe(final);
+        });
+      });
+    }); // #styleClass
+
+    describe("#advanced -", function() {
+      it("can be set on a derived class", function() {
+        [true, false].forEach(function(bool) {
+          var Derived = Item.extend({meta: {"advanced": bool}});
+          expect(Derived.meta.advanced).toBe(bool);
+
+          var item = new Derived();
+          expect(item.meta.advanced).toBe(bool);
+        });
+      });
+      it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
+        [true, false].forEach(function(bool) {
+          [null, undefined].forEach(function(value) {
+            var FirstDerivative = Item.extend({meta: {"advanced": bool}});
+            var SecondDerivative = FirstDerivative.extend({meta: {"advanced": !bool}});
+
+            SecondDerivative.meta.advanced = value;
+            expect(SecondDerivative.meta.advanced).toBe(FirstDerivative.meta.advanced);
+          });
+        });
+      });
+    }); // #advanced
+
+    describe("#browsable -", function() {
+      it("can be set on a derived class", function() {
+        [true, false].forEach(function(bool) {
+          var Derived = Item.extend({meta: {"browsable": bool}});
+          expect(Derived.meta.browsable).toBe(bool);
+
+          var item = new Derived();
+          expect(item.meta.browsable).toBe(bool);
+        });
+      });
+      it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
+        [true, false].forEach(function(bool) {
+          [null, undefined].forEach(function(value) {
+            var FirstDerivative = Item.extend({meta: {"browsable": bool}});
+            var SecondDerivative = FirstDerivative.extend({meta: {"browsable": !bool}});
+
+            SecondDerivative.meta.browsable = value;
+            expect(SecondDerivative.meta.browsable).toBe(FirstDerivative.meta.browsable);
+          });
+        });
+      });
+    }); // #browsable
+
+    describe("#ordinal -", function() {
+      it("can be set on a derived class", function() {
+        [1].forEach(function(someValue) {
+          var Derived = Item.extend({meta: {"ordinal": someValue}});
+          expect(Derived.meta.ordinal).toBe(someValue);
+
+          var item = new Derived();
+          expect(item.meta.ordinal).toBe(someValue);
+        });
+      });
+      it("casts to an integer, using 0 as a fallback", function() {
+        [
+          [37, 37],
+          [1 / 0, Infinity],
+          [Math.sqrt(-1), 0],
+          [[1], 1],
+          ["0", 0], ["1", 1], ["3.1415", 3],
+          [{}, 0], [{"foo": "bar"}, 0],
+          ["", 0],
+          [[], 0], [[1, 2], 0]
+        ].forEach(function(candidateAndFinal) {
+          var candidate = candidateAndFinal[0];
+          var final = candidateAndFinal[1];
+
+          var FirstDerivative = Item.extend({meta: {"ordinal": 42}});
+          var SecondDerivative = FirstDerivative.extend({meta: {"ordinal": candidate}});
+          expect(SecondDerivative.meta.ordinal).toBe(final);
+
+          var item = new SecondDerivative();
+          expect(item.meta.ordinal).toBe(final);
+        });
+      });
+      it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
+        [1, 20].forEach(function(someValue) {
+          [null, undefined].forEach(function(resetValue) {
+            var FirstDerivative = Item.extend({meta: {"ordinal": 42}});
+            var SecondDerivative = FirstDerivative.extend({meta: {"ordinal": someValue}});
+
+            SecondDerivative.meta.ordinal = resetValue;
+            expect(SecondDerivative.meta.ordinal).toBe(FirstDerivative.meta.ordinal);
+          });
+        });
+      });
+    }); // #ordinal
+
+    describe("#isRoot -", function() {
+      it("can be set on a derived class", function() {
+        [true, false].forEach(function(isRoot) {
+          var Derived = Item.extend("", null, null, {isRoot: isRoot});
+          expect(Derived.meta.isRoot).toBe(isRoot);
+
+          var item = new Derived();
+          expect(item.meta.isRoot).toBe(isRoot);
+        });
+      });
+    }); // #isRoot
+
+    describe("#ancestor -", function() {
+      it("returns the immediate ancestor", function() {
+        var FirstDerivative = Item.extend({meta: {"firstDerivative": true}});
+        var FirstSibling = Item.extend({meta: {"firstSibling": true}});
+        var SecondDerivative = FirstDerivative.extend({meta: {"secondDerivative": true}});
+
+        expect(FirstDerivative.meta.ancestor).toBe(Item.meta);
+
+        expect(FirstSibling.meta.ancestor).toBe(FirstDerivative.meta.ancestor);
+
+        expect(SecondDerivative.meta.ancestor).toBe(FirstDerivative.meta);
+        expect(SecondDerivative.meta.ancestor).not.toBe(Item.meta);
+      });
+      it("does not return an ancestor if this is a root class", function() {
+        var Derived = Item.extend("", null, null, {isRoot: true});
+        expect(Derived.meta.ancestor).toBeNull();
+
+        Derived = Item.extend("", null, null, {isRoot: false});
+        expect(Derived.meta.ancestor).not.toBeNull();
+        expect(Derived.meta.ancestor).toBe(Item.meta);
+      });
+    }); // #ancestor
+
+    // TODO: create(.), is(.), to(.)
+
+
+    describe("#create -", function() {
+      it("returns a new instance of `pentaho.type.Item`", function() {
+        expect(Item.meta.create() instanceof Item).toBe(true);
+      });
+    });
+
+    describe("#is -", function() {
+      it("detects an instance of `pentaho.type.Item` correctly", function() {
+        expect(Item.meta.is(new Item())).toBe(true);
+      });
+      it("detects that simple objects aren't instances of `pentaho.type.Item`", function() {
+        [
+          true, 1, "",
+          null, undefined,
+          {}, [],
+          new Date(),
+          function() {
+            return this;
+          }()
+        ].forEach(function(obj) {
+          expect(Item.meta.is(obj)).toBe(false);
+        });
+      });
+    });
+
+    describe("#to -", function() {
+      it("casts an instance of `pentaho.type.Item` correctly", function() {
+        expect(Item.meta.to(new Item()) instanceof Item).toBe(true);
+      });
+      it("casts native data types to `pentaho.type.Item`", function() {
+        [
+          "",
+          0, 1, 1/0, Math.sqrt(-1),
+          true,
+          new Date(),
+          {},[]
+        ].forEach(function(value) {
+          expect(Item.meta.to(value) instanceof Item).toBe(true);
+        });
+      });
+      it("casts a nully into `null`", function() {
+        [null, undefined].forEach(function(value) {
+          expect(Item.meta.to(value)).toBeNull();
+        });
+      });
+    });
+
+
+  });
+});

--- a/package-res/resources/web/test/karma/unit/pentaho/type/Item.Spec.js
+++ b/package-res/resources/web/test/karma/unit/pentaho/type/Item.Spec.js
@@ -77,7 +77,7 @@ define([
           expect(item.meta.someAttribute).toBe("someValue");
         });
       });
-      it("allows overwriting a .meta property", function() {
+      it("allows setting a .meta property", function() {
         Derived.meta = {"someAttribute": "someOtherValue"};
         expect(Derived.Meta.someAttribute).toBe("someOtherValue");
       });
@@ -113,13 +113,39 @@ define([
 
 
     // TODO: extendProto
-    xdescribe("#extendProto -", function() {
-      it("some tautology", function() {
-        var Derived = Item.extend();
-        Derived.extendProto({root: true});
-        var item = new Derived();
-        expect(item.meta.isRoot).toBe(true);
+    describe("#extendProto -", function() {
+      var Derived;
+      beforeEach(function() {
+        Derived = Item.extendProto(null, {}, {});
       });
+      it("derived classes have the proper 'ancestor'", function() {
+        expect(Derived.meta).not.toBe(Item.meta)
+        expect(Derived.meta.ancestor).toBe(Item.meta)
+        expect(Derived.meta.is(Item)).toBe(false)
+      });
+      it("can be invoked without arguments", function() {
+        expect(Item.extendProto().meta.ancestor).toBe(Item.meta);
+        expect(Item.extendProto(null).meta.ancestor).toBe(Item.meta);
+        expect(Item.extendProto(null, {}).meta.ancestor).toBe(Item.meta);
+      });
+
+      it("does not return a constructor", function() {
+        expect(typeof Derived).not.toBe("function");
+        expect(Derived.prototype).toBeUndefined();
+      });
+      it("returns an instance whose constructor is the same as the extended class", function() {
+        expect(Derived.constructor).toBe(Item);
+        expect(Derived.constructor).toBe(Item.prototype.constructor);
+        expect(Derived instanceof Item).toBe(true);
+      });
+      it("accepts keyArgs", function() {
+        var Derived = Item.extendProto(null, {}, {
+          isRoot: true
+        });
+        expect(Item.meta.isRoot).toBe(false);
+        expect(Derived.meta.isRoot).toBe(true);
+      });
+
     });
 
   }); // pentaho/type/Item

--- a/package-res/resources/web/test/karma/unit/pentaho/type/Item.Spec.js
+++ b/package-res/resources/web/test/karma/unit/pentaho/type/Item.Spec.js
@@ -60,457 +60,67 @@ define([
       it("should have .meta be Derived.Meta#", function() {
         expect(Derived.meta).toBe(Derived.Meta.prototype);
       });
+
     }); // .extend({...})
 
-    describe("pentaho/type/Item.Meta", function() {
 
-      describe("#view -", function() {
-        it("should default to `null`", function() {
-          var Derived = Item.extend({meta: {id: "fake/id"}});
+    describe("get/set meta of a derived class - ", function() {
+      var Derived;
+      beforeEach(function() {
+        Derived = Item.extend({meta: {"someAttribute": "someValue"}});
+      });
 
-          expect(Derived.meta.view).toBe(null);
+      it("setting a falsy meta has no consequence", function() {
+        ["", null, undefined, false, 0, {}].forEach(function(meta) {
+          Derived.meta = meta;
+          var item = new Derived();
+          expect(item.meta.someAttribute).toBe("someValue");
         });
+      });
+      it("allows overwriting a .meta property", function() {
+        Derived.meta = {"someAttribute": "someOtherValue"};
+        expect(Derived.Meta.someAttribute).toBe("someOtherValue");
+      });
 
-        it("should leave absolute ids intact", function() {
-          var Derived = Item.extend({meta: {id: "fake/id", view: "/foo"}});
-
-          expect(Derived.meta.view).toBe("/foo");
-
-          // ---
-
-          Derived = Item.extend({meta: {view: "foo:"}});
-
-          expect(Derived.meta.view).toBe("foo:");
-
-          // ---
-
-          Derived = Item.extend({meta: {view: "bar.js"}});
-
-          expect(Derived.meta.view).toBe("bar.js");
-        });
-
-        it("should convert relative ids to absolute", function() {
-          var Derived = Item.extend({meta: {id: "fake/id", view: "foo"}});
-
-          expect(Derived.meta.view).toBe("fake/id/foo");
-
-          // ---
-
-          Derived = Item.extend({meta: {id: "fake/id", view: "foo/bar"}});
-
-          expect(Derived.meta.view).toBe("fake/id/foo/bar");
-
-          // ---
-
-          Derived = Item.extend({meta: {id: "fake/id", view: "./bar"}});
-
-          expect(Derived.meta.view).toBe("fake/id/./bar");
-
-          // ---
-
-          Derived = Item.extend({meta: {id: "fake/id", view: "../bar"}});
-
-          expect(Derived.meta.view).toBe("fake/id/../bar");
-
-          // ---
-          // no base folder..
-
-          Derived = Item.extend({meta: {id: "id", view: "../bar"}});
-
-          expect(Derived.meta.view).toBe("id/../bar");
-
-          // ---
-
-          Derived = Item.extend({meta: {view: "../bar"}});
-
-          expect(Derived.meta.view).toBe("../bar");
-        });
-
-        it("should inherit the base type's view, when unspecified", function() {
-          var A = Item.extend({meta: {view: "foo"}});
-
-          expect(A.meta.view).toBe("foo");
-
-          var B = A.extend();
-
-          expect(B.meta.view).toBe("foo");
-        });
-
-        it("should inherit the base type's view, when spec is undefined", function() {
-          var A = Item.extend({meta: {view: "foo"}});
-
-          expect(A.meta.view).toBe("foo");
-
-          var B = A.extend({meta: {view: undefined}});
-
-          expect(B.meta.view).toBe("foo");
-        });
-
-        it("should respect a null spec value", function() {
-          var A = Item.extend({meta: {view: "foo"}});
-
-          expect(A.meta.view).toBe("foo");
-
-          var B = A.extend({meta: {view: null}});
-
-          expect(B.meta.view).toBe(null);
-        });
-
-        it("should convert an empty string value to null", function() {
-          var A = Item.extend({meta: {view: "foo"}});
-
-          expect(A.meta.view).toBe("foo");
-
-          var B = A.extend({meta: {view: ""}});
-
-          expect(B.meta.view).toBe(null);
-        });
-
-        it("should respect a specified non-empty string", function() {
-          var A = Item.extend({meta: {view: "foo"}});
-
-          expect(A.meta.view).toBe("foo");
-
-          var B = A.extend({meta: {id: "baba/dudu", view: "bar"}});
-
-          expect(B.meta.view).toBe("baba/dudu/bar");
-        });
-
-        it("should inherit a base function", function() {
-          var FA = function() {};
-          var A = Item.extend({meta: {view: FA}});
-
-          expect(A.meta.view).toBe(FA);
-
-          var B = A.extend({meta: {id: "baba/dudu"}});
-
-          expect(B.meta.view).toBe(FA);
-        });
-
-        it("should respect a specified function", function() {
-          var FA = function() {};
-          var A = Item.extend({meta: {view: FA}});
-
-          expect(A.meta.view).toBe(FA);
-
-          var FB = function() {};
-          var B = A.extend({meta: {id: "baba/dudu", view: FB}});
-
-          expect(B.meta.view).toBe(FB);
-        });
-      }); // end #view
-
-      describe("#viewClass -", function() {
-
-        afterEach(function() {
-          require.undef("foo/bar");
-          require.undef("foo/dude");
-        });
-
-        it("should return `null` when view is `null`", function() {
-          var A = Item.extend();
-
-          expect(A.meta.viewClass).toBe(null);
-        });
-
-        it("should return a Promise, when view is a function, and resolve to it", function(done) {
-          var View = function() {};
-          var A = Item.extend({meta: {view: View}});
-          var p = A.meta.viewClass;
-
-          expect(p instanceof Promise).toBe(true);
-
-          p.then(function(V) {
-            expect(V).toBe(View);
-            done();
-          });
-        });
-
-        it("should return a Promise, when view is an object, and resolve to it", function(done) {
-          var View = {};
-          var A = Item.extend({meta: {view: View}});
-          var p = A.meta.viewClass;
-
-          expect(p instanceof Promise).toBe(true);
-
-          p.then(function(V) {
-            expect(V).toBe(View);
-            done();
-          });
-        });
-
-        it("should return a Promise, when view is a string, and resolve to that module", function(done) {
-
-          var View = function() {};
-
-          define("foo/bar", function() { return View; });
-
-          var A = Item.extend({meta: {view: "foo/bar"}});
-
-          var p = A.meta.viewClass;
-
-          expect(p instanceof Promise).toBe(true);
-
-          p.then(function(V) {
-            expect(V).toBe(View);
-
-            done();
-          });
-        });
-
-        it("should return a Promise even if view is inherited from the base class", function(done) {
-
-          var View = function() {};
-
-          define("foo/bar", function() { return View; });
-
-          var A = Item.extend({meta: {view: "foo/bar"}});
-
-          var B = A.extend();
-
-          var pb = B.meta.viewClass;
-
-          var pa = A.meta.viewClass;
-
-          expect(pa).toBe(pb);
-          expect(pa instanceof Promise).toBe(true);
-
-          pa.then(function(V) {
-            expect(V).toBe(View);
-
-            done();
-          });
-        });
-
-        it("should return the same Promise multiple times", function(done) {
-
-          var View = function() {};
-
-          define("foo/bar", function() { return View; });
-
-          var A = Item.extend({meta: {view: "foo/bar"}});
-
-          var pa = A.meta.viewClass;
-
-          expect(pa).toBe(A.meta.viewClass);
-
-          pa.then(function(V) {
-            expect(V).toBe(View);
-            expect(pa).toBe(A.meta.viewClass);
-            done();
-          });
-        });
-
-        it("should return an new Promise and resolve to the new View when the view changes", function(done) {
-
-          var ViewBar  = function() {};
-          var ViewDude = function() {};
-
-          define("foo/bar",  function() { return ViewBar;  });
-          define("foo/dude", function() { return ViewDude; });
-
-          var A = Item.extend({meta: {view: "foo/bar"}});
-
-          var pa = A.meta.viewClass;
-
-          A.meta.view = "foo/dude";
-
-          var pb = A.meta.viewClass;
-
-          expect(pb instanceof Promise).toBe(true);
-
-          expect(pa).not.toBe(pb);
-
-          Promise.all([pa, pb]).then(function(views) {
-
-            expect(views[0]).toBe(ViewBar);
-            expect(views[1]).toBe(ViewDude);
-
-            done();
-          });
-        });
-
-      }); // end #viewClass
-
-      describe("#label -", function() {
-
-        describe("when `label` is falsy -", function() {
-          it("should inherit `label`", function() {
-            function expectIt(derivedSpec) {
-              var Derived = Item.extend({meta: derivedSpec});
-              expect(Derived.meta.label).toBe(Item.meta.label);
-            }
-
-            expectIt({});
-            expectIt({label: undefined});
-            expectIt({label: null});
-            expectIt({label: ""});
-          });
-        }); // when `label` is falsy
-
-        describe("when `label` is truthy", function() {
-          // Can change the label
-          it("should respect the `label`", function() {
-            var Derived = Item.extend({meta: {label: "Foo"}});
-            expect(Derived.meta.label).toBe("Foo");
-          });
-        });
-      }); // #label
-
-      describe("#id -", function() {
-        describe("when `id` is falsy -", function() {
-          it("should have `null` as a default `id`", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-              expect(Derived.meta.id).toBe(null);
-            }
-
-            expectIt({});
-            expectIt({id: undefined});
-            expectIt({id: null});
-            expectIt({id: null});
-          });
-        });
-
-        describe("when `id` is truthy -", function() {
-          it("should respect it", function() {
-            var Derived = Item.extend({
-              meta: {id: "foo/bar"}
-            });
-
-            expect(Derived.meta.id).toBe("foo/bar");
-          });
-        });
-      }); // #id
-
-      describe("#description -", function() {
-        describe("when not specified -", function() {
-          it("should inherit the base description", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.description).toBe(Item.meta.description);
-            }
-
-            expectIt({});
-            expectIt({description: undefined});
-          });
-        });
-
-        describe("when specified as `null` or an empty string -", function() {
-          it("should set the description to `null`", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.description).toBe(null);
-            }
-
-            expectIt({description: null});
-            expectIt({description: ""});
-          });
-        });
-
-        describe("when specified as a non-empty string -", function() {
-          it("should respect it", function() {
-            var Derived = Item.extend({meta: {description: "Foo"}});
-
-            expect(Derived.meta.description).toBe("Foo");
-          });
-        });
-      }); // #description
-
-      describe("#category -", function() {
-        describe("when not specified -", function() {
-          it("should inherit the base category", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.category).toBe(Item.meta.category);
-            }
-
-            expectIt({});
-            expectIt({category: undefined});
-          });
-        });
-
-        describe("when specified as `null` or an empty string -", function() {
-          it("should set the category to `null`", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.category).toBe(null);
-            }
-
-            expectIt({category: null});
-            expectIt({category: ""});
-          });
-        });
-
-        describe("when specified as a non-empty string", function() {
-          it("should respect it", function() {
-            var Derived = Item.extend({meta: {category: "Foo"}});
-
-            expect(Derived.meta.category).toBe("Foo");
-          });
-        });
-      }); // #category
-
-      describe("#helpUrl -", function() {
-        describe("when not specified", function() {
-          it("should inherit the base helpUrl", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.helpUrl).toBe(Item.meta.helpUrl);
-            }
-
-            expectIt({});
-            expectIt({helpUrl: undefined});
-          });
-        });
-
-        describe("when specified as `null` or an empty string -", function() {
-          it("should set the helpUrl to `null`", function() {
-            function expectIt(spec) {
-              var Derived = Item.extend({meta: spec});
-
-              expect(Derived.meta.helpUrl).toBe(null);
-            }
-
-            expectIt({helpUrl: null});
-            expectIt({helpUrl: ""});
-          });
-        });
-
-        describe("when specified as a non-empty string -", function() {
-          it("should respect it", function() {
-            var Derived = Item.extend({meta: {helpUrl: "Foo"}});
-
-            expect(Derived.meta.helpUrl).toBe("Foo");
-          });
-        });
-      }); // #helpUrl
-
-      describe("#uid -", function() {
-        it("should not be inherited", function() {
-          var Derived = Item.extend();
-          expect(Derived.meta.uid).not.toBe(Item.meta.uid);
-        });
-
-        it("should be unique", function() {
-          var DerivedA = Item.extend(),
-              DerivedB = Item.extend();
-          expect(DerivedA.meta.uid).not.toBe(DerivedB.meta.uid);
-          expect(DerivedA.meta.uid).not.toBe(Item.meta.uid);
-        });
-      }); // #uid
-
-      // TODO: ordinal, styleClass, advanced, browsable <- bring and adapt these from Property.Meta tests
-      // TODO: isRoot, ancestor
-      // TODO: create(.), is(.), to(.)
     });
 
+    describe("get/set meta of an instance - ", function() {
+      var item;
+      beforeEach(function() {
+        item = new Item();
+      });
+
+      it("sets/gets some meta attribute correctly", function() {
+        expect(item.meta.someAttribute).toBeUndefined();
+        item.meta = {someAttribute: "someValue"};
+        expect(item.meta.someAttribute).toBe("someValue");
+      });
+
+      it("setting meta to a falsy value has no consequence", function() {
+        ["", null, undefined, false, 0].forEach(function(value) {
+          item.meta = value;
+          expect(item.meta).not.toBeFalsy();
+        });
+      });
+
+      it("setting meta to an empty object has no consequence", function() {
+        var id = item.meta.id;
+        item.meta = {};
+        expect(item.meta).not.toBeFalsy();
+        expect(item.meta.id).toBe(id);
+      });
+    });
+
+
     // TODO: extendProto
+    xdescribe("#extendProto -", function() {
+      it("some tautology", function() {
+        var Derived = Item.extend();
+        Derived.extendProto({root: true});
+        var item = new Derived();
+        expect(item.meta.isRoot).toBe(true);
+      });
+    });
 
   }); // pentaho/type/Item
 });


### PR DESCRIPTION
…o.type.Item (and pentaho.type.Item.Meta)

@scottyaslan @dcleao Please review. Note that the static method pentaho.type.Item.extendProto was not yet addressed.
Here's a short list of the changes.
- Provided a short rationale to justify the merging of Mesa/Meta classes.
- Attempted to minimize the references to the mesa/meta concept.
- Simplified descriptions by avoiding references to deeply abstract concepts like prototype, constructor, mesadata, metadata.