### PR TITLE
[DOC] Upgrade AMD tag for common-ui use cases and updated the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ eclipse-bin/
 doc-js
 build-res/pentaho-js-build/
 build-res/module-scripts/
+build-res/pentaho-js-build.zip
 build-res/requireCfg-raw.js
 build-res/requireCfg.js
 test-res/data/sampledata.log

--- a/build-res/jsdoc-template/static/styles/jsdoc-overrides.css
+++ b/build-res/jsdoc-template/static/styles/jsdoc-overrides.css
@@ -1,11 +1,18 @@
-
 h3 {
   font-size: 22px;
 }
 
-.amd-module {
-	font-size: 120%;
+#main {
+  overflow-x: hidden;
+}
+
+.amd-type, .amd-module h5 {
+  font-size: 120%;
   line-height: 140%;
   margin-bottom: 1em;
   margin-top: 1em
+}
+
+.amd-module pre {
+  min-width: 700px;
 }

--- a/build-res/jsdoc-template/tmpl/amd.tmpl
+++ b/build-res/jsdoc-template/tmpl/amd.tmpl
@@ -2,8 +2,30 @@
 var data = obj;
 var self = this;
 ?>
-<?js if(data.amd != null) { ?>
-	<div class="amd-tag">
-	<h5>AMD Require:</h5> <pre class="prettyprint"><code>require("<?js= data.amd.value ?>", function(<?js= data.name ?>){ /* code goes here */ });</code></pre>
+<?js
+	if(data.amd != null) {
+		var value = data.amd.value;
+?>
+	<div class="amd-module">
+		<h5>AMD Require:</h5>
+		<?js
+			var type = value.type;
+			if(type != null) {
+		?>
+			<span class="amd-type">Type:<?js= self.partial('type.tmpl', type.names) ?></span>
+		<?js
+			}
+		?>
+		<pre class="prettyprint"><code>require("[<?js= value.name ?>]", function(<?js= data.name ?>){ /* code goes here */ });</code></pre>
+		<?js
+			var description = value.description;
+			if(description != null) {
+		?>
+			<p><?js= description ?></p>
+		<?js
+			}
+		?>
 	</div>
-<?js } ?>
+<?js
+	}
+?>

--- a/config/customPlugins/amd.js
+++ b/config/customPlugins/amd.js
@@ -15,6 +15,8 @@ exports.defineTags = function (dictionary) {
    */
   dictionary.defineTag('amd', {
 
+    canHaveType: true,
+    canHaveName: true,
     /**
      * A callback function executed when the tag is found
      * @param  {Object} doclet Doclet where the tag was "tagged"

--- a/package-res/resources/web/pentaho/data/AbstractTable.js
+++ b/package-res/resources/web/pentaho/data/AbstractTable.js
@@ -31,11 +31,6 @@ define([
    * @classdesc The `AbstractTable` class is the abstract base class of
    * classes that represent a tabular dataset.
    *
-   * ### AMD
-   *
-   * To obtain the constructor of this class,
-   * require the module `"pentaho/data/AbstractTable"`.
-   *
    * ### Remarks
    *
    * The following derived classes are not abstract and can be used directly:

--- a/package-res/resources/web/pentaho/lang/Collection.js
+++ b/package-res/resources/web/pentaho/lang/Collection.js
@@ -22,11 +22,6 @@ define([
     /**
      * @classdesc The `Collection` class is an abstract base class for typed ordered maps.
      *
-     * ### AMD
-     *
-     * To obtain the constructor of this class,
-     * require the module `"pentaho/lang/Collection"`.
-     *
      * ### Remarks
      *
      * A collection is a list whose elements can only be contained in one position.
@@ -38,6 +33,7 @@ define([
      * Elements of a collection must implement the {@link pentaho.lang.ICollectionElement} interface.
      *
      * @class
+     * @amd pentaho/lang/Collection
      * @name Collection
      * @memberOf pentaho.lang
      * @abstract

--- a/package-res/resources/web/pentaho/lang/List.js
+++ b/package-res/resources/web/pentaho/lang/List.js
@@ -25,11 +25,6 @@ define([
      *
      * Elements of a list must implement the {@link pentaho.lang.IListElement} interface.
      *
-     * ### AMD
-     *
-     * To obtain the constructor of this class,
-     * require the module `"pentaho/lang/List"`.
-     *
      * @description Initializes a list instance.
      *
      * Note that because a `List` is a sub-class of `Array`,
@@ -44,6 +39,7 @@ define([
      * to help in their construction.
      *
      * @class
+     * @amd pentaho/lang/List
      * @abstract
      * @name List
      * @memberOf pentaho.lang

--- a/package-res/resources/web/pentaho/type/boolean.js
+++ b/package-res/resources/web/pentaho/type/boolean.js
@@ -29,16 +29,9 @@ define([
      * @name pentaho.type.Boolean
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/boolean
+     * @amd {pentaho.type.Factory<pentaho.type.Boolean>} pentaho/type/boolean
      *
      * @classDesc The class of boolean values.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/boolean`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Boolean>}.
      *
      * @description Creates a boolean instance.
      */

--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -51,16 +51,9 @@ define([
      * @name pentaho.type.Complex
      * @class
      * @extends pentaho.type.Element
-     * @amd pentaho/type/complex
+     * @amd {pentaho.type.Factory<pentaho.type.Complex>} pentaho/type/complex
      *
      * @classDesc The base class of complex types.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/complex`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Complex>}.
      *
      * Example complex type:
      * ```javascript

--- a/package-res/resources/web/pentaho/type/date.js
+++ b/package-res/resources/web/pentaho/type/date.js
@@ -29,16 +29,9 @@ define([
      * @name pentaho.type.Date
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/date
+     * @amd {pentaho.type.Factory<pentaho.type.Date>} pentaho/type/date
      *
      * @classDesc The class of a date value.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/date`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Date>}.
      *
      * @description Creates a date instance.
      */

--- a/package-res/resources/web/pentaho/type/element.js
+++ b/package-res/resources/web/pentaho/type/element.js
@@ -43,16 +43,7 @@ define([
      * @name pentaho.type.Element
      * @class
      * @extends pentaho.type.Value
-     * @amd pentaho/type/element
-     *
-     * @classDesc
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/element`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Element>}.
+     * @amd {pentaho.type.Factory<pentaho.type.Element>} pentaho/type/element
      *
      * @description Creates an element instance.
      */

--- a/package-res/resources/web/pentaho/type/function.js
+++ b/package-res/resources/web/pentaho/type/function.js
@@ -31,16 +31,9 @@ define([
      * @name pentaho.type.Function
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/function
+     * @amd {pentaho.type.Factory<pentaho.type.Function>} pentaho/type/function
      *
      * @classDesc A primitive JavaScript function type.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/function`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Function>}.
      *
      * @description Creates a function instance.
      */

--- a/package-res/resources/web/pentaho/type/number.js
+++ b/package-res/resources/web/pentaho/type/number.js
@@ -29,16 +29,9 @@ define([
      * @name pentaho.type.Number
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/number
+     * @amd {pentaho.type.Factory<pentaho.type.Number>} pentaho/type/number
      *
      * @classDesc The base class of numeric values.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/number`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Number>}.
      *
      * @description Creates a number instance.
      */

--- a/package-res/resources/web/pentaho/type/object.js
+++ b/package-res/resources/web/pentaho/type/object.js
@@ -31,16 +31,9 @@ define([
      * @name pentaho.type.Object
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/object
+     * @amd {pentaho.type.Factory<pentaho.type.Object>} pentaho/type/object
      *
      * @classDesc A primitive JavaScript object type.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/object`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Object>}.
      *
      * @description Creates an object instance.
      */

--- a/package-res/resources/web/pentaho/type/simple.js
+++ b/package-res/resources/web/pentaho/type/simple.js
@@ -38,14 +38,9 @@ define([
      * @name pentaho.type.Simple
      * @class
      * @extends pentaho.type.Element
-     * @amd pentaho/type/simple
+     * @amd {pentaho.type.Factory<pentaho.type.Simple>} pentaho/type/simple
      *
      * @classDesc The base abstract class of un-structured, indivisible values.
-     *
-     * ### AMD
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Simple>}.
      *
      * Module Id: `pentaho/type/simple`
      *

--- a/package-res/resources/web/pentaho/type/string.js
+++ b/package-res/resources/web/pentaho/type/string.js
@@ -29,16 +29,9 @@ define([
      * @name pentaho.type.String
      * @class
      * @extends pentaho.type.Simple
-     * @amd pentaho/type/string
+     * @amd {pentaho.type.Factory<pentaho.type.String>} pentaho/type/string
      *
      * @classDesc A textual type.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/string`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.String>}.
      *
      * @description Creates a string instance.
      */

--- a/package-res/resources/web/pentaho/type/value.js
+++ b/package-res/resources/web/pentaho/type/value.js
@@ -48,18 +48,10 @@ define([
      * @abstract
      * @class
      * @extends pentaho.type.Item
-     * @amd pentaho/type/value
+     * @amd {pentaho.type.Factory<pentaho.type.Value>} pentaho/type/value
      *
      * @classDesc A Value is an abstract class used as a base implementation and unifying type. </br>
      * A Value has a key that uniquely identifies the entity it represents.
-     *
-     * ### AMD
-     *
-     * Module Id: `pentaho/type/value`
-     *
-     * The AMD module returns the type's factory, a
-     * {@link pentaho.type.Factory<pentaho.type.Value>}.
-     *
      */
     var Value = Item.extend("pentaho.type.Value", /** @lends pentaho.type.Value# */{
 


### PR DESCRIPTION
@dcleao @graimundo please review

This is the output:

![amd-tag](https://cloud.githubusercontent.com/assets/6906072/12814198/1e3055a6-cb35-11e5-9eb4-d53fcb0923cf.png)
