### PR TITLE
[BACKLOG-6289] DEV: Create unit tests and documentation for /pentaho/util/error.js

### DIFF
--- a/config/jsdoc-vizapi.json
+++ b/config/jsdoc-vizapi.json
@@ -8,6 +8,7 @@
       "package-res/resources/web/pentaho/service.js",
       "package-res/resources/web/pentaho/_doc",
       "package-res/resources/web/pentaho/lang",
+      "package-res/resources/web/pentaho/util",
       "package-res/resources/web/pentaho/type",
       "package-res/resources/web/pentaho/visual/_doc/_namespace.jsdoc",
       "package-res/resources/web/pentaho/visual/base"

--- a/package-res/resources/web/pentaho/data/_WithCellTupleBase.js
+++ b/package-res/resources/web/pentaho/data/_WithCellTupleBase.js
@@ -33,7 +33,7 @@ define([
         return cellSpecs;
 
       if(!(cellSpecs instanceof Array))
-        throw error.argNotArray("cellSpecs");
+        throw error.argInvalidType("cellSpecs", "Array");
 
       var cellTuple = O.setPrototypeOf(cellSpecs, this.cellTupleBase);
       CellTuple.call(cellTuple, keyArgs);

--- a/package-res/resources/web/pentaho/data/_cross/Table.js
+++ b/package-res/resources/web/pentaho/data/_cross/Table.js
@@ -310,7 +310,7 @@ define([
       // Get measure attribute name.
       var meaAttrName;
       if(xC) {
-        if(typeof colSpec !== "object") throw error.argNotObject("cols[" + j + "]");
+        if(typeof colSpec !== "object") throw error.argInvalidType("cols[" + j + "]", "object");
 
         meaAttrName = colSpec.attr;
       } else {

--- a/package-res/resources/web/pentaho/data/_trends.js
+++ b/package-res/resources/web/pentaho/data/_trends.js
@@ -71,7 +71,7 @@ define([
         var xIndex = arg.required(trendArgs, "x", "trendArgs");
 
         xIndex = +xIndex; // toNumber
-        if(isNaN(xIndex)) throw error.argNotNumber("trendArgs.x");
+        if(isNaN(xIndex)) throw error.argInvalidType("trendArgs.x", "number");
 
         if(xIndex < 0 || xIndex >= colCount) throw error.argOutOfRange("trendArgs.x");
 
@@ -82,7 +82,7 @@ define([
         var yIndex = arg.required(trendArgs, "y", "trendArgs");
 
         yIndex = +yIndex; // toNumber
-        if(isNaN(yIndex)) throw error.argNotNumber("trendArgs.y");
+        if(isNaN(yIndex)) throw error.argInvalidType("trendArgs.y", "number");
 
         if(yIndex < 0 || yIndex >= colCount) throw error.argOutOfRange("trendArgs.y");
 
@@ -198,7 +198,7 @@ define([
     // ----
 
     var model = arg.required(spec, "model", "spec");
-    if(typeof model !== 'function') throw error.argNotFunction("spec.model");
+    if(typeof model !== 'function') throw error.argInvalidType("spec.model", "function");
 
     // ----
 

--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -462,7 +462,7 @@ define([
           }
 
           var p = this._get(name);
-          if(!p && !lenient) throw error.operInvalid("A property with the name '" + (name.name || name) + "' is not defined.");
+          if(!p && !lenient) throw error.argInvalid("name", "A property with the name '" + (name.name || name) + "' is not defined.");
           return p;
         },
 

--- a/package-res/resources/web/pentaho/type/i18n/types.properties
+++ b/package-res/resources/web/pentaho/type/i18n/types.properties
@@ -36,7 +36,6 @@ function.description=A JS function value.
 ## REFINEMENT TYPES
 errors.refinement.domain.notSubsetOfBase=Must be a subset of the base domain.
 errors.refinement.cannotExtendInstance=Refinement types cannot extend the instance interface.
-errors.refinement.invalidRefinementFacet=Not a refinement facet class.
 ## PROPERTY VALIDATION
 errors.property.isRequired=The property '{0}' is required.
 errors.property.countOutOfRange=The count of '{0}' is not within the expected range. Expected count is between {2} and {3}.

--- a/package-res/resources/web/pentaho/type/refinement.js
+++ b/package-res/resources/web/pentaho/type/refinement.js
@@ -333,9 +333,7 @@ define([
             }
 
             if(!F.is(Facet) || !(Facet.prototype instanceof RefinementFacet))
-              throw error.argInvalidType(
-                  "facets",
-                  bundle.structured.errors.refinement.invalidRefinementFacet);
+              throw error.argInvalidType("facets", "pentaho/type/facets/Refinement");
 
             if(facets.indexOf(Facet) < 0) {
               facets.push(Facet);
@@ -375,7 +373,7 @@ define([
           // Value returns refinement === undefined...
           var ofMeta = this.context.get(value).meta;
           if(ofMeta.refinement !== false)
-            throw error.argInvalidType("of", "Not a representation type.");
+            throw error.argInvalidType("of", ["pentaho/type/element", "pentaho/type/list"]);
 
           // Throws when set again with a different value.
           O.setConst(this, "_of", ofMeta);

--- a/package-res/resources/web/pentaho/util/error.js
+++ b/package-res/resources/web/pentaho/util/error.js
@@ -16,52 +16,303 @@
 define(function() {
   "use strict";
 
-  var error = {
+  /**
+   * The `error` namespace contains factory functions for
+   * creating `Error` instances for common error conditions
+   * that arise in API design.
+   *
+   * @namespace
+   * @memberOf pentaho.util
+   * @amd pentaho/util/error
+   * @ignore
+   */
+  var error = /** @lends pentaho.util.error */ {
+    /**
+     * Creates an `Error` object for a case where a required
+     * function argument was not specified or was specified _nully_ or empty.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * Also, it is up to the caller to define what exactly "required" mean;
+     * that an argument must be:
+     * * specified - `if(arguments.length < 1) ...`
+     * * truthy - `if(!value) ...`
+     * * not nully - `if(value == null) ...`
+     * * not nully or an empty string - `if(value == null || value === "") ...`
+     * * ...
+     *
+     * @example
+     *
+     * define(["pentaho/util/error"], function(error) {
+     *
+     *   function add(member) {
+     *
+     *     // Member cannot be null or undefined
+     *     if(member == null) {
+     *       throw error.argRequired("member");
+     *     }
+     *
+     *     // Safe to add member
+     *     this._members.push(member);
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @param {string} name The name of the argument.
+     * @param {?string} [text] Optional text further explaining the reason why the argument is required.
+     * Can be useful when "being required" is a dynamic rule.
+     *
+     * @return {!Error} The created `Error` object.
+     */
     argRequired: function(name, text) {
-      return new Error("Argument required: '" + name + "'." + (text ? (" " + text) : ""));
+      return new Error(andSentence("Argument required: '" + name + "'.", text));
     },
 
-    argEmpty: function(name, text) {
-      return new Error("Argument cannot be empty: '" + name + "'." + (text ? (" " + text) : ""));
+    /**
+     * Creates an `Error` object for a case where a function argument
+     * has been specified, albeit with an invalid value.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * An argument's value can be considered **invalid** because:
+     * * it is not of one of the supported, documented types -
+     *   use [argInvalidType]{@link pentaho.util.error.argInvalidType} instead
+     * * the specific value is not supported, or is out of range -
+     *   use [argOutOfRange]{@link pentaho.util.error.argOutOfRange} instead
+     * * the value is not in an acceptable state
+     * * the value refers to something which does not exist (like a dictionary _key_ which is undefined)
+     * * ...
+     *
+     * You should use this error if none of the other more specific
+     * invalid argument errors applies.
+     *
+     * @example
+     *
+     * define(["pentaho/util/error"], function(error) {
+     *
+     *   function connect(channel) {
+     *
+     *     if(channel && channel.isOpened) {
+     *       throw error.argInvalid("channel", "Channel not free to use.");
+     *     }
+     *
+     *     var handle = channel.open();
+     *     // ...
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @param {string} name The name of the argument.
+     * @param {string} reason Text that explains the reason why the argument is considered invalid.
+     * @return {!Error} The created `Error` object.
+     */
+    argInvalid: function(name, reason) {
+      return new Error(andSentence("Argument invalid: '" + name + "'.", reason));
     },
 
-    argInvalid: function(name, text) {
-      return new Error("Argument invalid: '" + name + "'." + (text ? (" " + text) : ""));
+    /**
+     * Creates an `Error` object for a case where a function argument
+     * has been specified, albeit with a value of an unsupported type,
+     * according to the documented contract.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * Types can be:
+     * * one of the possible results of the `typeof` operator,
+     *   like `"number"`, `"string"`, `"boolean"`, `"function"`, ...
+     * * the name of global classes/constructors,
+     *   that would be testable by use of the `instanceof` operator or
+     *   by accessing the `constructor` property,
+     *   like `"Array"`, `"Object"`, or `"HTMLElement"`
+     * * the id of an AMD module that returns a constructor or factory, like `"pentaho/type/complex"`.
+     *
+     * @example
+     *
+     * define(["pentaho/util/error"], function(error) {
+     *
+     *   function createInstance(type, args) {
+     *     var TypeCtor;
+     *
+     *     switch(typeof type) {
+     *       case "string":
+     *         TypeCtor = window[type];
+     *         break;
+     *
+     *       case "function":
+     *         TypeCtor = type;
+     *         break;
+     *
+     *       default:
+     *         throw error.argInvalidType("type", ["string", "function"], typeof type);
+     *     }
+     *
+     *     // ...
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @param {string} name The name of the argument.
+     * @param {string|string[]} expectedType The name or names of the expected types.
+     * @param {string} [gotType] The name of the received type, when known.
+     * @return {!Error} The created `Error` object.
+     */
+    argInvalidType: function(name, expectedType, gotType) {
+      var typesMsg = "Expected type to be ";
+
+      if(Array.isArray(expectedType)) {
+        if(expectedType.length > 1) {
+          var lastExpectedType = expectedType.pop();
+          typesMsg += "one of " + expectedType.join(", ") + " or " + lastExpectedType;
+        } else {
+          // If should have at least one entry...
+          typesMsg += expectedType[0];
+        }
+      } else {
+        typesMsg += expectedType;
+      }
+
+      typesMsg += gotType ? (", but got " + gotType + ".") : ".";
+
+      return error.argInvalid(name, typesMsg);
     },
 
-    argInvalidType: function(name, text) {
-      return error.argInvalid(name, "Invalid type." + (text ? (" " + text) : ""));
-    },
-
-    argNotArray: function(name) {
-      return error.argInvalid(name, "Not an array.");
-    },
-
-    argNotNumber: function(name) {
-      return error.argInvalid(name, "Not a number.");
-    },
-
-    argNotFunction: function(name) {
-      return error.argInvalid(name, "Not a function.");
-    },
-
-    argNotObject: function(name) {
-      return error.argInvalid(name, "Not an object.");
-    },
-
+    /**
+     * Creates an `Error` object for a case where a function argument
+     * was specified with a value of one of the expected types,
+     * albeit not within the expected range.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.index"`.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * @example
+     *
+     * define(["pentaho/util/error"], function(error) {
+     *
+     *   function insertAt(element, index) {
+     *
+     *     if(index < 0 || index > this.length) {
+     *       throw error.argOutOfRange("index");
+     *     }
+     *
+     *     // Safe to insert at index
+     *     this._elements.splice(index, 0, element);
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @param {string} name The name of the argument.
+     * @return {!Error} The created `Error` object.
+     */
     argOutOfRange: function(name) {
       return error.argInvalid(name, "Out of range.");
     },
 
-    operInvalid: function(text) {
-      return new Error("Operation invalid." + (text ? (" " + text) : ""));
+    /**
+     * Creates an `Error` object for a case where performing an operation is considered invalid.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * Performing an operation can be considered **invalid** when:
+     * * the object in which it is executed is not in a state that allows the operation to be performed,
+     *   like it is _locked_, _busy_ or _disposed_.
+     * * it cannot be performed on a certain type of object
+     * * ...
+     *
+     * @example
+     *
+     * define(["pentaho/util/error"], function(error) {
+     *
+     *   function Cell(value) {
+     *     this._value = value;
+     *     this._locked = false;
+     *   }
+     *
+     *   Cell.prototype = {
+     *     lock: function() {
+     *       this._locked = true;
+     *     },
+     *
+     *     get value() {
+     *       return this._value;
+     *     },
+     *
+     *     set value(v) {
+     *       if(this._locked) {
+     *         throw error.operInvalid("Cell is locked.");
+     *       }
+     *
+     *       this._value = v;
+     *     }
+     *   };
+     *
+     *   // ...
+     * });
+     *
+     * @param {string} reason Text that explains the reason why performing the operation is considered invalid.
+     * @return {!Error} The created `Error` object.
+     */
+    operInvalid: function(reason) {
+      return new Error(andSentence("Operation invalid.", reason));
     },
 
-    notImplemented: function(text){
-      return new Error("Not Implemented." + (text ? (" " + text) : ""));
+    /**
+     * Creates an `Error` object for a case where an _abstract_ method has not been implemented/overridden
+     * and is being called.
+     *
+     * It is up to the caller to actually `throw` the returned `Error` object.
+     * This makes flow control be clearly visible at the call site.
+     *
+     * @param {string} text Complementary text.
+     * @return {!Error} The created `Error` object.
+     */
+    notImplemented: function(text) {
+      return new Error(andSentence("Not Implemented.", text));
     }
   };
 
-
   return error;
+
+  /**
+   * Appends a sentence to another,
+   * making sure that the appended sentence ends with a period or is, otherwise,
+   * terminated by a punctuation character.
+   *
+   * @param {string} text The initial sentence.
+   * @param {?string} [sentence] A sentence to append to `text`, that can not be properly terminated.
+   * @return {string} A new, terminated sentence.
+   */
+  function andSentence(text, sentence) {
+    return text + (sentence ? (" " + withPeriod(sentence)) : "");
+  }
+
+  /**
+   * Ensures a sentence is terminated with a period or another punctuation character,
+   * like `;`, `?` or `!`.
+   *
+   * @param {string} sentence A possibly unterminated sentence.
+   * @return {string} A new, terminated sentence.
+   */
+  function withPeriod(sentence) {
+    return sentence && !/[.;!?]/.test(sentence[sentence.length - 1]) ? (sentence + ".") : sentence;
+  }
 });

--- a/package-res/resources/web/pentaho/visual/type/helper.js
+++ b/package-res/resources/web/pentaho/visual/type/helper.js
@@ -172,7 +172,7 @@ define([
             .then(haveVisual);
 
         case "function": break;
-        default: throw error.argInvalidType("createOptions.type.factory");
+        default: throw error.argInvalidType("createOptions.type.factory", ["string", "function"], typeof factory);
       }
     } else if((classPath = type['class'])) {
       factory = createClassFactory(classPath);

--- a/test-js/unit/pentaho/type/complex.Spec.js
+++ b/test-js/unit/pentaho/type/complex.Spec.js
@@ -641,7 +641,7 @@ define([
 
         expect(function() {
           derived.get("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should throw when given the name of an undefined property and lenient is false", function() {
@@ -653,7 +653,7 @@ define([
 
         expect(function() {
           derived.get("y", false);
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should return null when not given the name of a property and lenient is true", function() {
@@ -760,7 +760,7 @@ define([
 
         expect(function() {
           derived.set("y", "1");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
     });
 
@@ -829,7 +829,7 @@ define([
 
         expect(function() {
           derived.getv("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
     });
 
@@ -887,7 +887,7 @@ define([
 
         expect(function() {
           derived.getf("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
     });
 
@@ -933,7 +933,7 @@ define([
 
         expect(function() {
           derived.applicable("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should throw when given the metadata not owned by the complex, even if of same name as an existing one", function() {
@@ -947,7 +947,7 @@ define([
 
         expect(function() {
           derived.applicable(Other.meta.get("x"));
-        }).toThrowError(error.operInvalid("A property with the name 'x' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'x' is not defined.").message);
       });
     }); // end applicable
 
@@ -993,7 +993,7 @@ define([
 
         expect(function() {
           derived.readOnly("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should throw when given the metadata not owned by the complex, even if of same name as an existing one", function() {
@@ -1007,7 +1007,7 @@ define([
 
         expect(function() {
           derived.readOnly(Other.meta.get("x"));
-        }).toThrowError(error.operInvalid("A property with the name 'x' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'x' is not defined.").message);
       });
     }); // end readOnly
 
@@ -1053,7 +1053,7 @@ define([
 
         expect(function() {
           derived.required("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should throw when given the metadata not owned by the complex, even if of same name as an existing one", function() {
@@ -1067,7 +1067,7 @@ define([
 
         expect(function() {
           derived.required(Other.meta.get("x"));
-        }).toThrowError(error.operInvalid("A property with the name 'x' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'x' is not defined.").message);
       });
     }); // end required
 
@@ -1115,7 +1115,7 @@ define([
 
         expect(function() {
           derived.countRange("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
 
       it("should throw when the given metadata is not owned by the complex, even if of an existing name", function() {
@@ -1129,7 +1129,7 @@ define([
 
         expect(function() {
           derived.countRange(Other.meta.get("x"));
-        }).toThrowError(error.operInvalid("A property with the name 'x' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'x' is not defined.").message);
       });
     }); // end countRange
 
@@ -1179,7 +1179,7 @@ define([
 
         expect(function() {
           derived.count("y");
-        }).toThrowError(error.operInvalid("A property with the name 'y' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'y' is not defined.").message);
       });
     }); // end count
 
@@ -1298,7 +1298,7 @@ define([
 
         expect(function() {
           derived.path("x", "z", 1);
-        }).toThrowError(error.operInvalid("A property with the name 'z' is not defined.").message);
+        }).toThrowError(error.argInvalid("name", "A property with the name 'z' is not defined.").message);
 
       });
     }); // end path

--- a/test-js/unit/pentaho/type/refinement.Spec.js
+++ b/test-js/unit/pentaho/type/refinement.Spec.js
@@ -75,7 +75,7 @@ define([
               facets: [Facet]
             }
           });
-        }).toThrowError(error.argInvalidType("of", "Not a representation type.").message);
+        }).toThrowError(error.argInvalidType("of", ["pentaho/type/element", "pentaho/type/list"]).message);
       });
 
       it("should not throw if given an `of` which is a representation type", function() {
@@ -265,7 +265,7 @@ define([
                 }
               });
             }).toThrowError(
-                error.argInvalidType("facets", bundle.structured.errors.refinement.invalidRefinementFacet).message);
+                error.argInvalidType("facets", "pentaho/type/facets/Refinement").message);
           }
 
           expectIt([{}]); // Not a function

--- a/test-js/unit/pentaho/util/error.Spec.js
+++ b/test-js/unit/pentaho/util/error.Spec.js
@@ -1,0 +1,106 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(["pentaho/util/error"], function(error) {
+
+  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, spyOn:false, JSON:false*/
+
+  describe("pentaho.util.error -", function() {
+    it("is defined", function() {
+      expect(error instanceof Object).toBe(true);
+    });
+
+    function itShouldHaveMessage(methodName, withArgs, message) {
+      it("should have message «" + message + "» when called with arguments " + JSON.stringify(withArgs), function() {
+
+        var result = error[methodName].apply(error, withArgs);
+
+        expect(result instanceof Error).toBe(true);
+        expect(result.message).toBe(message);
+      });
+    }
+
+    describe("argRequired(name, (text)) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.argRequired).toBe("function");
+      });
+
+      itShouldHaveMessage("argRequired", ["foo"       ], "Argument required: 'foo'.");
+      itShouldHaveMessage("argRequired", ["foo", "bar"], "Argument required: 'foo'. bar.");
+    });
+
+    describe("argInvalid(name, (reason)) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.argInvalid).toBe("function");
+      });
+
+      itShouldHaveMessage("argInvalid", ["foo"       ], "Argument invalid: 'foo'.");
+      itShouldHaveMessage("argInvalid", ["foo", "bar"], "Argument invalid: 'foo'. bar.");
+    });
+
+    describe("argInvalidType(name, [expectedType], (gotType)) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.argInvalidType).toBe("function");
+      });
+
+      itShouldHaveMessage("argInvalidType", ["foo", "string"],
+          "Argument invalid: 'foo'. Expected type to be string.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", ["string"]],
+          "Argument invalid: 'foo'. Expected type to be string.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", "string", "boolean"],
+          "Argument invalid: 'foo'. Expected type to be string, but got boolean.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", ["string"], "boolean"],
+          "Argument invalid: 'foo'. Expected type to be string, but got boolean.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", ["string", "function"], "boolean"],
+          "Argument invalid: 'foo'. Expected type to be one of string or function, but got boolean.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", ["string", "function"]],
+          "Argument invalid: 'foo'. Expected type to be one of string or function.");
+
+      itShouldHaveMessage("argInvalidType", ["foo", ["string", "function", "Array"], "boolean"],
+          "Argument invalid: 'foo'. Expected type to be one of string, function or Array, but got boolean.");
+    });
+
+    describe("argOutOfRange(name) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.argOutOfRange).toBe("function");
+      });
+
+      itShouldHaveMessage("argOutOfRange", ["foo"], "Argument invalid: 'foo'. Out of range.");
+    });
+
+    describe("operInvalid((text)) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.operInvalid).toBe("function");
+      });
+
+      itShouldHaveMessage("operInvalid", [], "Operation invalid.");
+      itShouldHaveMessage("operInvalid", ["Invalid state."], "Operation invalid. Invalid state.");
+    });
+
+    describe("notImplemented((text)) -", function() {
+      it("should be a function", function() {
+        expect(typeof error.notImplemented).toBe("function");
+      });
+
+      itShouldHaveMessage("notImplemented", [], "Not Implemented.");
+      itShouldHaveMessage("notImplemented", ["Don't be lazy!"], "Not Implemented. Don't be lazy!");
+    });
+  });
+});


### PR DESCRIPTION
* Added lots of documentation
* Removed unused error.argEmpty
* Removed error.{argNotArray, argNotNumber, argNotFunction, argNotObject},
  in favor of a generalization of the `argInvalidType` method

@pentaho/millenniumfalcon please review.