### PR TITLE
[BACKLOG-6289] DEV: Create unit tests and documentation for /pentaho/util/error.js

### DIFF
--- a/config/nodojo.karma.conf.js
+++ b/config/nodojo.karma.conf.js
@@ -15,8 +15,8 @@ module.exports = function (config) {
       "config/context-begin.js",
 
       // SOURCE files
-      {pattern: "build-res/module-scripts/**/{*.js,*.html,*.xml}", included: false},
-      {pattern: "package-res/resources/web/**/{*.js,*.html,*.xml,*.properties}", included: false},
+      {pattern: "build-res/module-scripts/**/*.+(js|html|xml)", included: false},
+      {pattern: "package-res/resources/web/**/*.+(js|html|xml|properties)", included: false},
 
       // AMD configuration
       "build-res/requireCfg-raw.js",

--- a/package-res/resources/web/pentaho/util/error.js
+++ b/package-res/resources/web/pentaho/util/error.js
@@ -50,6 +50,9 @@ define([
      * * not nully or an empty string - `if(value == null || value === "") ...`
      * * ...
      *
+     * The `name` property of the returned error object has the value `"ArgumentRequiredError"`.
+     * Additionally, the `argument` property has the name of the argument.
+     *
      * @example
      *
      * define(["pentaho/util/error"], function(error) {
@@ -103,6 +106,9 @@ define([
      * You should use this error if none of the other more specific
      * invalid argument errors applies.
      *
+     * The `name` property of the returned error object has the value `"ArgumentInvalidError"`.
+     * Additionally, the `argument` property has the name of the argument.
+     *
      * @example
      *
      * define(["pentaho/util/error"], function(error) {
@@ -150,6 +156,11 @@ define([
      *   by accessing the `constructor` property,
      *   like `"Array"`, `"Object"`, or `"HTMLElement"`
      * * the id of an AMD module that returns a constructor or factory, like `"pentaho/type/complex"`.
+     *
+     * The `name` property of the returned error object has the value `"ArgumentInvalidTypeError"`.
+     * Additionally, the `argument` property has the name of the argument.
+     * Property `expectedTypes` contains an array of the expected type names, and,
+     * property `actualType`, the name of the actual type, if specified, or `undefined`.
      *
      * @example
      *
@@ -220,6 +231,9 @@ define([
      * It is up to the caller to actually `throw` the returned `RangeError` object.
      * This makes flow control be clearly visible at the call site.
      *
+     * The `name` property of the returned error object has the value `"ArgumentOutOfRangeError"`.
+     * Additionally, the `argument` property has the name of the argument.
+     *
      * @example
      *
      * define(["pentaho/util/error"], function(error) {
@@ -258,6 +272,8 @@ define([
      *   like it is _locked_, _busy_ or _disposed_.
      * * it cannot be performed on a certain type of object
      * * ...
+     *
+     * The `name` property of the returned error object has the value `"OperationInvalidError"`.
      *
      * @example
      *
@@ -305,6 +321,8 @@ define([
      *
      * It is up to the caller to actually `throw` the returned `Error` object.
      * This makes flow control be clearly visible at the call site.
+     *
+     * The `name` property of the returned error object has the value `"NotImplementedError"`.
      *
      * @param {?string} [text] Complementary text.
      * @return {!Error} The created `Error` object.

--- a/package-res/resources/web/pentaho/util/error.js
+++ b/package-res/resources/web/pentaho/util/error.js
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(function() {
+define([
+  "./object"
+], function(O) {
+
   "use strict";
+
+  /*global TypeError:false, RangeError:false*/
 
   /**
    * The `error` namespace contains factory functions for
@@ -70,7 +75,10 @@ define(function() {
      * @return {!Error} The created `Error` object.
      */
     argRequired: function(name, text) {
-      return new Error(andSentence("Argument required: '" + name + "'.", text));
+      return createError(
+          Error,
+          andSentence("Argument " + name + " is required.", text),
+          {name: "ArgumentRequiredError", argument: name});
     },
 
     /**
@@ -117,18 +125,21 @@ define(function() {
      * @return {!Error} The created `Error` object.
      */
     argInvalid: function(name, reason) {
-      return new Error(andSentence("Argument invalid: '" + name + "'.", reason));
+      return createError(
+          Error,
+          andSentence("Argument " + name + " is invalid.", reason),
+          {name: "ArgumentInvalidError", argument: name});
     },
 
     /**
-     * Creates an `Error` object for a case where a function argument
+     * Creates a `TypeError` object for a case where a function argument
      * has been specified, albeit with a value of an unsupported type,
      * according to the documented contract.
      *
      * The name of the argument can be that of a nested property,
      * like, for example, `"keyArgs.description"`.
      *
-     * It is up to the caller to actually `throw` the returned `Error` object.
+     * It is up to the caller to actually `throw` the returned `TypeError` object.
      * This makes flow control be clearly visible at the call site.
      *
      * Types can be:
@@ -168,38 +179,45 @@ define(function() {
      *
      * @param {string} name The name of the argument.
      * @param {string|string[]} expectedType The name or names of the expected types.
-     * @param {string} [gotType] The name of the received type, when known.
-     * @return {!Error} The created `Error` object.
+     * @param {string} [actualType] The name of the received type, when known.
+     * @return {!TypeError} The created `TypeError` object.
      */
-    argInvalidType: function(name, expectedType, gotType) {
+    argInvalidType: function(name, expectedType, actualType) {
       var typesMsg = "Expected type to be ";
 
-      if(Array.isArray(expectedType)) {
-        if(expectedType.length > 1) {
-          var lastExpectedType = expectedType.pop();
-          typesMsg += "one of " + expectedType.join(", ") + " or " + lastExpectedType;
-        } else {
-          // If should have at least one entry...
-          typesMsg += expectedType[0];
-        }
+      if(!Array.isArray(expectedType)) expectedType = [expectedType];
+
+      if(expectedType.length > 1) {
+        var expectedTypesClone = expectedType.slice();
+        var lastExpectedType = expectedTypesClone.pop();
+        typesMsg += "one of " + expectedTypesClone.join(", ") + " or " + lastExpectedType;
       } else {
-        typesMsg += expectedType;
+        // If should have at least one entry...
+        typesMsg += expectedType[0];
       }
 
-      typesMsg += gotType ? (", but got " + gotType + ".") : ".";
+      typesMsg += actualType ? (", but got " + actualType + ".") : ".";
 
-      return error.argInvalid(name, typesMsg);
+      return createError(
+          TypeError,
+          andSentence("Argument " + name + " is invalid.", typesMsg),
+          {
+            name: "ArgumentInvalidTypeError",
+            argument: name,
+            actualType: actualType,
+            expectedTypes: expectedType
+          });
     },
 
     /**
-     * Creates an `Error` object for a case where a function argument
+     * Creates an `RangeError` object for a case where a function argument
      * was specified with a value of one of the expected types,
      * albeit not within the expected range.
      *
      * The name of the argument can be that of a nested property,
      * like, for example, `"keyArgs.index"`.
      *
-     * It is up to the caller to actually `throw` the returned `Error` object.
+     * It is up to the caller to actually `throw` the returned `RangeError` object.
      * This makes flow control be clearly visible at the call site.
      *
      * @example
@@ -220,10 +238,13 @@ define(function() {
      * });
      *
      * @param {string} name The name of the argument.
-     * @return {!Error} The created `Error` object.
+     * @return {!RangeError} The created `RangeError` object.
      */
     argOutOfRange: function(name) {
-      return error.argInvalid(name, "Out of range.");
+      return createError(
+          RangeError,
+          "Argument " + name + " is out of range.",
+          {name: "ArgumentOutOfRangeError", argument: name});
     },
 
     /**
@@ -272,7 +293,10 @@ define(function() {
      * @return {!Error} The created `Error` object.
      */
     operInvalid: function(reason) {
-      return new Error(andSentence("Operation invalid.", reason));
+      return createError(
+          Error,
+          andSentence("Operation invalid.", reason),
+          {name: "OperationInvalidError"});
     },
 
     /**
@@ -282,15 +306,31 @@ define(function() {
      * It is up to the caller to actually `throw` the returned `Error` object.
      * This makes flow control be clearly visible at the call site.
      *
-     * @param {string} text Complementary text.
+     * @param {?string} [text] Complementary text.
      * @return {!Error} The created `Error` object.
      */
     notImplemented: function(text) {
-      return new Error(andSentence("Not Implemented.", text));
+      return createError(
+          Error,
+          andSentence("Not Implemented.", text),
+          {name: "NotImplementedError"});
     }
   };
 
   return error;
+
+  /**
+   * Creates an error object of a given type and with a given message and properties.
+   *
+   * @param {Class.<Error>} ErrorCtor The error constructor.
+   * @param {string} message The error message.
+   * @param {?Object} [props] A map of properties to extend the error object with.
+   *
+   * @return {Error} The created error object.
+   */
+  function createError(ErrorCtor, message, props) {
+    return O.assignOwn(new ErrorCtor(message), props);
+  }
 
   /**
    * Appends a sentence to another,

--- a/test-js/unit/pentaho/util/error.Match.js
+++ b/test-js/unit/pentaho/util/error.Match.js
@@ -1,0 +1,156 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function() {
+
+  "use strict";
+
+  // Basic class inheritance routine
+  function inherits(Sub, Base, props) {
+    if(Base) {
+      Sub.super = Base.prototype;
+      Sub.prototype = Object.create(Sub.super);
+      Sub.prototype.constructor = Sub;
+    }
+
+    for(var p in props)
+      if(props.hasOwnProperty(p))
+        Sub.prototype[p] = props[p];
+
+    return Sub;
+  }
+
+  //region Error
+  function ErrorMatcher() {
+  }
+
+  inherits(ErrorMatcher, null, {
+
+    Type: Error,
+
+    asymmetricMatch: function(actual) {
+      return (actual instanceof this.Type) &&
+             (actual.name === this.constructor.name);
+    }
+  });
+  //endregion
+
+  //region ArgumentError
+  function ArgumentError(argName) {
+    this.argument = argName;
+  }
+
+  inherits(ArgumentError, ErrorMatcher, {
+    asymmetricMatch: function(actual) {
+      return ArgumentError.super.asymmetricMatch.call(this, actual) &&
+             (actual.argument === this.argument);
+    }
+  });
+  //endregion
+
+  //region ArgumentRequiredError
+  // The function name is matched against the actual error.name property
+  // Also, this makes jasmine print this nicely as the expected outcome, when unmatched.
+  function ArgumentRequiredError(argName) {
+    this.argument = argName;
+  }
+
+  inherits(ArgumentRequiredError, ArgumentError);
+  //endregion
+
+  //region ArgumentInvalidError
+  function ArgumentInvalidError(argName) {
+    this.argument = argName;
+  }
+
+  inherits(ArgumentInvalidError, ArgumentError);
+  //endregion
+
+  //region ArgumentInvalidTypeError
+  function ArgumentInvalidTypeError(argName, expectedType, actualType) {
+    this.argument = argName;
+    this.expectedTypes = Array.isArray(expectedType) ? expectedType : [expectedType];
+    this.actualType = actualType;
+  }
+
+  inherits(ArgumentInvalidTypeError, ArgumentError, {
+    Type: TypeError,
+
+    asymmetricMatch: function(actual) {
+      if(!ArgumentInvalidTypeError.super.asymmetricMatch.call(this, actual)) return false;
+
+      // Same expected types?
+      var i = this.expectedTypes.length;
+      if(!actual.expectedTypes || actual.expectedTypes.length !== i) return false;
+      while(i--) if(this.expectedTypes[i] !== actual.expectedTypes[i]) return false;
+
+      // Same actual type?
+      if((this.actualType || actual.actualType) && (this.actualType !== actual.actualType)) return false;
+
+      return true;
+    }
+  });
+  //endregion
+
+  //region ArgumentOutOfRangeError
+  function ArgumentOutOfRangeError(argName) {
+    this.argument = argName;
+  }
+
+  inherits(ArgumentOutOfRangeError, ArgumentError, {
+    Type: RangeError
+  });
+  //endregion
+
+  //region OperationInvalidError
+  function OperationInvalidError() {
+  }
+
+  inherits(OperationInvalidError, ErrorMatcher);
+  //endregion
+
+  //region NotImplementedError
+  function NotImplementedError() {
+  }
+
+  inherits(NotImplementedError, ErrorMatcher);
+  //endregion
+
+  return {
+    argRequired: function(name) {
+      return new ArgumentRequiredError(name);
+    },
+
+    argInvalid: function(name) {
+      return new ArgumentInvalidError(name);
+    },
+
+    argInvalidType: function(name, expectedType, actualType) {
+      return new ArgumentInvalidTypeError(name, expectedType, actualType);
+    },
+
+    argOutOfRange: function(name) {
+      return new ArgumentOutOfRangeError(name);
+    },
+
+    operInvalid: function() {
+      return new OperationInvalidError();
+    },
+
+    notImplemented: function() {
+      return new NotImplementedError();
+    }
+  };
+});

--- a/test-js/unit/pentaho/util/error.Spec.js
+++ b/test-js/unit/pentaho/util/error.Spec.js
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(["pentaho/util/error"], function(error) {
+define([
+  "pentaho/util/error",
+  "./error.Match"
+], function(error, errorMatch) {
 
-  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, spyOn:false, JSON:false*/
+  "use strict";
+
+  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, spyOn:false,
+           JSON:false, TypeError:false, RangeError:false, jasmine:false*/
 
   describe("pentaho.util.error -", function() {
     it("is defined", function() {
@@ -27,7 +33,9 @@ define(["pentaho/util/error"], function(error) {
 
         var result = error[methodName].apply(error, withArgs);
 
-        expect(result instanceof Error).toBe(true);
+        // Call and test (with) the error matcher
+        expect(result).toEqual(errorMatch[methodName].apply(errorMatch, withArgs));
+
         expect(result.message).toBe(message);
       });
     }
@@ -37,8 +45,8 @@ define(["pentaho/util/error"], function(error) {
         expect(typeof error.argRequired).toBe("function");
       });
 
-      itShouldHaveMessage("argRequired", ["foo"       ], "Argument required: 'foo'.");
-      itShouldHaveMessage("argRequired", ["foo", "bar"], "Argument required: 'foo'. bar.");
+      itShouldHaveMessage("argRequired", ["foo"       ], "Argument foo is required.");
+      itShouldHaveMessage("argRequired", ["foo", "bar"], "Argument foo is required. bar.");
     });
 
     describe("argInvalid(name, (reason)) -", function() {
@@ -46,8 +54,8 @@ define(["pentaho/util/error"], function(error) {
         expect(typeof error.argInvalid).toBe("function");
       });
 
-      itShouldHaveMessage("argInvalid", ["foo"       ], "Argument invalid: 'foo'.");
-      itShouldHaveMessage("argInvalid", ["foo", "bar"], "Argument invalid: 'foo'. bar.");
+      itShouldHaveMessage("argInvalid", ["foo"       ], "Argument foo is invalid.");
+      itShouldHaveMessage("argInvalid", ["foo", "bar"], "Argument foo is invalid. bar.");
     });
 
     describe("argInvalidType(name, [expectedType], (gotType)) -", function() {
@@ -56,25 +64,25 @@ define(["pentaho/util/error"], function(error) {
       });
 
       itShouldHaveMessage("argInvalidType", ["foo", "string"],
-          "Argument invalid: 'foo'. Expected type to be string.");
+          "Argument foo is invalid. Expected type to be string.");
 
       itShouldHaveMessage("argInvalidType", ["foo", ["string"]],
-          "Argument invalid: 'foo'. Expected type to be string.");
+          "Argument foo is invalid. Expected type to be string.");
 
       itShouldHaveMessage("argInvalidType", ["foo", "string", "boolean"],
-          "Argument invalid: 'foo'. Expected type to be string, but got boolean.");
+          "Argument foo is invalid. Expected type to be string, but got boolean.");
 
       itShouldHaveMessage("argInvalidType", ["foo", ["string"], "boolean"],
-          "Argument invalid: 'foo'. Expected type to be string, but got boolean.");
+          "Argument foo is invalid. Expected type to be string, but got boolean.");
 
       itShouldHaveMessage("argInvalidType", ["foo", ["string", "function"], "boolean"],
-          "Argument invalid: 'foo'. Expected type to be one of string or function, but got boolean.");
+          "Argument foo is invalid. Expected type to be one of string or function, but got boolean.");
 
       itShouldHaveMessage("argInvalidType", ["foo", ["string", "function"]],
-          "Argument invalid: 'foo'. Expected type to be one of string or function.");
+          "Argument foo is invalid. Expected type to be one of string or function.");
 
       itShouldHaveMessage("argInvalidType", ["foo", ["string", "function", "Array"], "boolean"],
-          "Argument invalid: 'foo'. Expected type to be one of string, function or Array, but got boolean.");
+          "Argument foo is invalid. Expected type to be one of string, function or Array, but got boolean.");
     });
 
     describe("argOutOfRange(name) -", function() {
@@ -82,7 +90,7 @@ define(["pentaho/util/error"], function(error) {
         expect(typeof error.argOutOfRange).toBe("function");
       });
 
-      itShouldHaveMessage("argOutOfRange", ["foo"], "Argument invalid: 'foo'. Out of range.");
+      itShouldHaveMessage("argOutOfRange", ["foo"], "Argument foo is out of range.");
     });
 
     describe("operInvalid((text)) -", function() {

--- a/test-js/unit/pentaho/util/error.Spec.js
+++ b/test-js/unit/pentaho/util/error.Spec.js
@@ -15,7 +15,7 @@
  */
 define([
   "pentaho/util/error",
-  "./error.Match"
+  "./errorMatch"
 ], function(error, errorMatch) {
 
   "use strict";

--- a/test-js/unit/pentaho/util/errorMatch.js
+++ b/test-js/unit/pentaho/util/errorMatch.js
@@ -17,6 +17,49 @@ define(function() {
 
   "use strict";
 
+  /**
+   * The `errorMatch` namespace contains factory functions
+   * that create jasmine _asymmetric match_ objects that can be compared to the
+   * real error objects returned by the same named factory functions of
+   * the {@link pentaho.util.error} namespace.
+   *
+   * The match objects can be passed to the jasmine matchers, like `toEqual` and `toThrow`.
+   * Note that the `toThrowError` matcher does not accept these match objects.
+   *
+   * For more information on this jasmine's feature, see
+   * [asymmetric equality testers](http://jasmine.github.io/edge/introduction.html#section-Custom_asymmetric_equality_tester).
+   *
+   * Each factory function accepts the same arguments as the corresponding real version,
+   * except that the free, natural text arguments, like `reason` and `text` are ignored.
+   *
+   * @example
+   *
+   * define([
+   *   "pentaho/some/api",  // <-- the module being tested
+   *   "tests/pentaho/util/errorMatch" // <- include errorMatch module
+   * ], function(someApi, errorMatch) {
+   *
+   *   describe("someApi.doWithNumber", function() {
+   *
+   *     it("should throw an argument invalid type error when given a string", function() {
+   *
+   *       expect(function() {
+   *
+   *         someApi.doWithNumber("NaN");
+   *
+   *       }).toThrow(errorMatch.argInvalidType("count", "number", "string"));
+   *     });
+   *
+   *   });
+   * });
+   *
+   *
+   * @namespace
+   * @name pentaho.util.errorMatch
+   * @amd tests/pentaho/util/errorMatch
+   * @ignore
+   */
+
   // Basic class inheritance routine
   function inherits(Sub, Base, props) {
     if(Base) {

--- a/test-js/unit/pentaho/visual/data/AttributeSpec.js
+++ b/test-js/unit/pentaho/visual/data/AttributeSpec.js
@@ -16,8 +16,9 @@
 define([
   "pentaho/data/Model",
   "pentaho/data/Attribute",
-  "pentaho/data/Member"
-], function(Model, Attribute, Member) {
+  "pentaho/data/Member",
+  "tests/pentaho/util/errorMatch"
+], function(Model, Attribute, Member, errorMatch) {
 
   function expectAttribute(attrSpec) {
     var model = new Model([attrSpec]);
@@ -287,11 +288,11 @@ define([
       it("should throw if the attribute name is empty", function() {
         expect(function() {
           expectAttribute({attr: ""});
-        }).toThrowError("Argument required: 'spec.name'.");
+        }).toThrow(errorMatch.argRequired("spec.name"));
 
         expect(function() {
           expectAttribute("");
-        }).toThrowError("Argument required: 'spec.name'.");
+        }).toThrow(errorMatch.argRequired("spec.name"));
       });
     });
   });

--- a/test-js/unit/pentaho/visual/data/MemberSpec.js
+++ b/test-js/unit/pentaho/visual/data/MemberSpec.js
@@ -16,8 +16,9 @@
 define([
   "pentaho/data/Model",
   "pentaho/data/Attribute",
-  "pentaho/data/Member"
-], function(Model, Attribute, Member) {
+  "pentaho/data/Member",
+  "tests/pentaho/util/errorMatch"
+], function(Model, Attribute, Member, errorMatch) {
 
   function expectMember(memberSpec) {
     var model = new Model([{name: "test", type: "string", members: [memberSpec]}]);
@@ -60,11 +61,11 @@ define([
       it("should throw if the specified `v` is null or undefined", function() {
         expect(function() {
           expectMember({v: undefined});
-        }).toThrowError("Argument invalid: 'value'. Cannot be nully.");
+        }).toThrow(errorMatch.argInvalid("value"));
 
         expect(function() {
           expectMember({v: null});
-        }).toThrowError("Argument invalid: 'value'. Cannot be nully.");
+        }).toThrow(errorMatch.argInvalid("value"));
       });
     });
 

--- a/test-js/unit/pentaho/visual/data/TableSpec.js
+++ b/test-js/unit/pentaho/visual/data/TableSpec.js
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 define([
-  "pentaho/data/Table",
-  "pentaho/data/Attribute"
-], function(DataTable, Attribute, Column) {
+  "pentaho/data/Table"
+], function(DataTable) {
 
   function getDatasetCDA1() {
     return {

--- a/test-js/unit/pentaho/visual/data/_cross/TableSpec.js
+++ b/test-js/unit/pentaho/visual/data/_cross/TableSpec.js
@@ -21,8 +21,8 @@ define([
   "pentaho/data/_cross/Table",
   "pentaho/data/_cross/Axis",
   "pentaho/data/_cross/MeasureCellSet",
-  "pentaho/util/error"
-], function(Model, Attribute, Structure, CellTuple, Table, Axis, MeasureCellSet, error) {
+  "tests/pentaho/util/errorMatch"
+], function(Model, Attribute, Structure, CellTuple, Table, Axis, MeasureCellSet, errorMatch) {
 
   function createModel1() {
     return new Model([
@@ -37,9 +37,6 @@ define([
 
   var UNDEFINED_ATTRIBUTE_FOO_ERROR = "A attribute with name 'foo' is not defined.";
   var MISMATCHED_COL_ATTR_D3_ERROR = "Invalid cross-table - attribute mismatch: 'D3'. Expected: 'D2'.";
-  var INVALID_COL_2_ATTR_ERROR = "Argument invalid: 'cols[2].attr'. Required when there is more than one measure.";
-  var INVALID_COL_3_ATTR_ERROR = "Argument invalid: 'cols[3].attr'. Required when there is more than one measure.";
-  var INVALID_COL_4_DUP_ERROR = "Argument invalid: 'cols[4]'. Duplicate column cell tuple and measure attribute.";
 
   var NOT_MEASURE_ATTR_N2_ERROR = "A structure position with name 'N2' is not defined.";
   var NOT_MEASURE_ATTR_D1_ERROR = "A structure position with name 'D1' is not defined.";
@@ -61,7 +58,7 @@ define([
       it("should throw when `keyArgs.model` is not specified", function() {
         expect(function() {
           new Table({});
-        }).toThrowError(error.argRequired("keyArgs.model").message);
+        }).toThrow(errorMatch.argRequired("keyArgs.model"));
       });
 
       it("should create empty cols and rows axes and measures list when all these are empty or nully in `spec.layout`", function() {
@@ -224,7 +221,7 @@ define([
             }, {
               model: model
             });
-          }).toThrowError(INVALID_COL_2_ATTR_ERROR);
+          }).toThrow(errorMatch.argInvalid("cols[2].attr"));
         });
 
         it("should throw if a COL column specifies an attribute that is not one of the measure attributes", function() {
@@ -612,9 +609,6 @@ define([
       });
 
       describe("when `spec.cols` is not specified -", function() {
-        var REQUIRED_COLS_ERROR =
-            "Argument invalid: 'spec.cols'. " +
-            "As many columns as row attributes are required when there are measure and/or column attributes.";
 
         it("should not throw if there are only row attributes", function() {
           new Table({
@@ -645,7 +639,7 @@ define([
                 ["d1_2", "d2_1"]
               ]
             }, {model: model});
-          }).toThrowError(REQUIRED_COLS_ERROR);
+          }).toThrow(errorMatch.argInvalid("spec.cols"));
         });
 
         it("should throw if there are measure attributes", function() {
@@ -662,7 +656,7 @@ define([
                 ["d1_2", "d2_1"]
               ]
             }, {model: model});
-          }).toThrowError(REQUIRED_COLS_ERROR);
+          }).toThrow(errorMatch.argInvalid("spec.cols"));
         });
       });
 
@@ -683,7 +677,7 @@ define([
             }, {
               model: model
             });
-          }).toThrowError("Argument invalid: 'rows[1].c'. Duplicate row tuple.");
+          }).toThrow(errorMatch.argInvalid("rows[1].c"));
         });
       });
     });
@@ -943,7 +937,7 @@ define([
 
         expect(function() {
           table.addColumn({c: ["d3_1"], attr: "N1"});
-        }).toThrowError(INVALID_COL_4_DUP_ERROR);
+        }).toThrow(errorMatch.argInvalid("cols[4]"));
       });
 
       it("should add when table has no column attributes and spec has a MIC-unbound measure", function() {
@@ -1009,7 +1003,7 @@ define([
 
         expect(function() {
           table.addColumn({attr: "N1"});
-        }).toThrowError(INVALID_COL_4_DUP_ERROR);
+        }).toThrow(errorMatch.argInvalid("cols[4]"));
       });
 
       describe("when measure attribute is unspecified ", function() {
@@ -1066,7 +1060,7 @@ define([
 
               table.addColumn({c: ["d3_2"]});
 
-            }).toThrowError(INVALID_COL_3_ATTR_ERROR);
+            }).toThrow(errorMatch.argInvalid("cols[3].attr"));
           });
         });
       });


### PR DESCRIPTION
* `argInvalidType` now returns a standard JavaScript `TypeError`
* `argOutOfRange` now returns a standard JavaScript `RangeError`
* all errors now have an overridden `Error#name` property that shows up
  by standard behavior when errors converted toString; this now carries a string
  that denotes the error type, like: "ArgumentRequiredError", "OperationInvalidError", ...
* all error instances now have extra metadata properties like `argument` to contain the
  argument name of an `argXYZ` method, and `expectedTypes` that contains the array of
  expected type names of an `argInvalidType` error
* Added a kind of an error mock for use in specs — error.Match.js
  * Replaces direct use of `error` methods to test errors thrown by other code
  * `errorMatch` has one method per original `error` method, like
    `errorMatch.argRequired("foo")`
  * The methods, however, do not include arguments that are purely textual (like `reason`),
    as those are not matched against
  * The matcher works by creating a fake error instance that knows how to compare itself to
    real Errors, by using jasmine's `asymmetricMatch` [feature](http://jasmine.github.io/edge/introduction.html#section-Custom_asymmetric_equality_tester).
    Can be used as the value of matchers like `toEqual(.)` and `toThrow(.)`
    (but not `toThrowError`...)
  * We can take this technique further and apply it to the validation errors we have,
    to avoid having to include bundles to have proper error testing
  * On the downside, for each original error method, there's a corresponding error matcher class...
* Fixing paths in nodojo.karma.conf.js for the nth time...

@pentaho/millenniumfalcon what do you think of this as an alternative to direct use of the error factories (and, possibly, message bundles) for asserting errors?