### PR TITLE
[BACKLOG-6291] pentaho/util/object.js:

### DIFF
--- a/package-res/resources/web/pentaho/util/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/util/_doc/_namespace.jsdoc
@@ -16,7 +16,7 @@
 
 /**
  * The `util` namespace contains a minimal set of supporting modules
- * used by other Pentaho Web Platform classes.
+ * used by other Pentaho Metadata Model classes.
  *
  * @name pentaho.util
  * @namespace

--- a/package-res/resources/web/pentaho/util/object.js
+++ b/package-res/resources/web/pentaho/util/object.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,28 @@ define(function() {
       A_empty  = [],
       setProtoOf = Object.setPrototypeOf || ({}.__proto__ ? setProtoProp : setProtoCopy);
 
+  /**
+   * The `object` namespace contains functions for
+   * common tasks dealing with the manipulation of the internal state of objects.
+   *
+   * @name object
+   * @namespace
+   * @memberOf pentaho.util
+   * @amd pentaho/util/object
+   *
+   */
   return /** @lends pentaho.util.object */{
+    /**
+     * Deletes an enumerable property in an object, even if it is not a direct/own property.
+     * Constant properties cannot be deleted.
+     *
+     * @param {object} object
+     * @param {string} property - Property to be deleted
+     * @param {any} defaultValue - Default value of the property.
+     * @return {any} Returns the value of the deleted property.
+     * If the property did not exist, `defaultValue` is returned instead.
+     * @throws {TypeError} Cannot delete a constant property.
+     */
     "delete": function(o, p, dv) {
       var v = dv;
       if(o && (p in o)) {
@@ -30,18 +51,60 @@ define(function() {
       return v;
     },
 
+    /**
+     * Determines if the property is a direct property of the object.
+     * This method does not check down the object's prototype chain.
+     *
+     * @param {?object} object - Object to be tested.
+     * @param {string} property - Name of the property to be tested.
+     * @return {boolean} Returns `true` if this is a direct/own property, or `false` otherwise.
+     */
     hasOwn: function(o, p) {
       return !!o && O_hasOwn.call(o, p);
     },
 
+    /**
+     * Returns the value of a direct property, or the default value.
+     * This method does not check down the object's prototype chain.
+     *
+     * @param {?object} object - Object to be tested.
+     * @param {string} property - Name of the property to be retrieved.
+     * @param {any} defaultValue - Default value of the property.
+     * @return {boolean} Returns the value of the property if it exists in the object and is an own property,
+     * otherwise returns `defaultValue`.
+     */
     getOwn: function(o, p, dv) {
       return o && O_hasOwn.call(o, p) ? o[p] : dv;
     },
 
+    /**
+     * Creates an immutable (constant) property in an object with a given value.
+     * The created property can neither be overwritten nor deleted.
+     *
+     * @param {!object} object - Object to be tested.
+     * @param {string} property - Name of the property to be created.
+     * @param {any} value - Value to be assigned to the property.
+     */
     setConst: function(o, p, v) {
       Object.defineProperty(o, p, {value: v});
     },
 
+    /**
+     * Interates over all **direct enumerable** properties of an object,
+     * yielding each in turn to an iteratee function.
+     * The iteratee is bound to the context object, if one is passed,
+     * otherwise it is bound to the iterated object.
+     * Each invocation of iteratee is called with two arguments: (propertyValue, propertyName).
+     * If the iteratee function returns `false`, the iteration loop is broken out.
+     *
+     * @param {!object} object - Object containing the properties to be iterated
+     * @param {function} iteratee - Function that will be iterated
+     * @param {?object} context - Object which will provide the execution context of the iteratee function.
+     * If nully, the iteratee will run with the context of the iterated object.
+     *
+     * @return {boolean} Returns `true` when the iteration completed regularly,
+     * or `false` if the iteration was forcefully terminated.
+     */
     eachOwn: function(o, fun, ctx) {
       for(var p in o)
         if(O_hasOwn.call(o, p) && fun.call(ctx || o, o[p], p) === false)
@@ -50,35 +113,42 @@ define(function() {
       return true;
     },
 
-    eachOwnDefined: function(o, fun, ctx) {
-      var v;
-      for(var p in o)
-        if(O_hasOwn.call(o, p) &&
-           (v = o[p]) !== undefined &&
-           fun.call(ctx || o, v, p) === false)
-          return false;
-
-      return true;
-    },
-
-    assignOwnDefined: assignOwnDefined,
-    assignOwn: assignOwn,
-
-    copyOneDefined: copyOneDefined,
-
-    copyOwnDefined: function(to, from) {
-      if(from) {
-        var keys = Object.keys(from),
-            i = -1,
-            L = keys.length;
-        while(++i < L)
-          copyOneDefined(to, from, keys[i]);
-
-      }
-
+    /**
+     * Iterates over the own properties of a source object and assigns them to a target object.
+     *
+     * @param {!object} to - Target object.
+     * @param {!object} from - Source object.
+     * @return {object} Returns the target object.
+     */
+    assignOwn: function(to, from) {
+      for(var p in from)
+        if(O_hasOwn.call(from, p))
+          to[p] = from[p];
       return to;
     },
 
+    /**
+     * Iterates over the own properties of a source object,
+     * checks if their values are defined, and if so, assigns them to a target object.
+     *
+     * @param {!object} to - Target object.
+     * @param {!object} from - Source object.
+     * @return {object} Returns the target object.
+     * @method
+     * @see pentaho.util.object.assignOwn
+     */
+    assignOwnDefined: assignOwnDefined,
+
+    /**
+     * Creates a shallow clone of a plain object or array.
+     * Undefined properties are ignored.
+     * If `from` is an instance of a class, or a simple value (e.g. string, number),
+     * no clone is created and the original object is returned instead.
+     *
+     * @param {object|Array|any} from - Source object.
+     * @return {any} Returns shallow copy of object,
+     * or the object itself if it is neither a plain object nor an array.
+     */
     cloneShallow: function(v) {
       if(v && typeof v === "object") {
         if(v instanceof Array)
@@ -89,30 +159,63 @@ define(function() {
       return v;
     },
 
+    /**
+     * Retrieves an object that describes a property, traversing the inheritance chain if necessary.
+     *
+     * @param {!object} object - Object that contains the property.
+     * @param {!string} property - Name of property.
+     * @return {object|null} Returns the
+     * [property descriptor]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty}.
+     * @method
+     */
+    //only used by pentaho.lang.Base
     getPropertyDescriptor: getPropertyDescriptor,
 
     /**
      * Constructs an instance of a class,
-     * from a an array of arguments.
+     * from an array of arguments.
      *
-     * @param {function} Ctor The constructor function.
-     * @param {Array} [args] The array of arguments, or arguments object.
-     * @return {*} The constructed instance.
+     * @param {function} Ctor - The constructor function of the class to be instantiated.
+     * @param {Array} [args] - The array of arguments, or arguments object, which will be passed to the constructor.
+     * @return {object} Returns the constructed instance.
      */
+    //only used by pentaho.lang.Base
     make: function(Ctor, args) {
-      var inst = Object.create(Ctor.prototype);
       switch(args.length) {
+        case 0: return new Ctor();
         case 1: return new Ctor(args[0]);
         case 2: return new Ctor(args[0], args[1]);
-        case 0: return new Ctor();
         case 3: return new Ctor(args[0], args[1], args[2]);
       }
-
+      // generic implementation, possibly slower
+      var inst = Object.create(Ctor.prototype);
       return Ctor.apply(inst, args || A_empty) || inst;
     },
 
+    /**
+     * Sets the _prototype_ (i.e., the internal `prototype` property) of a specified object
+     * to another object.
+     *
+     * Setting the _prototype_ to `null` breaks the object's inheritance.
+     *
+     * Delegates to the native implementation of `Object.setPrototypeOf`, if supported.
+     *
+     * @param {object} obj - The object which is to have its prototype set.
+     * @param {?object} prototype - The object's new prototype.
+     * @return {object} Returns `object`.
+     */
     setPrototypeOf: setProtoOf,
 
+    /**
+     * Mutates an object so that it becomes an instance of a given class, if not already.
+     * In particular, the _prototype_ and _constructor_ properties of a given object are replaced, if necessary.
+     *
+     * @param {!object} inst - Object to be mutated.
+     * @param {function} Class - Constructor of the class to be applied to the object.
+     * @param {?Array} args - Array of arguments to be passed to the constructor of the class.
+     * @return {object} Returns the mutated object.
+     */
+    //only used by pentaho.lang.Base
     applyClass: function(inst, Class, args) {
       var proto = Class.prototype;
       if(proto === inst || proto.isPrototypeOf(inst))
@@ -140,13 +243,16 @@ define(function() {
     return to;
   }
 
-  function assignOwn(to, from) {
-    for(var p in from)
-      if(O_hasOwn.call(from, p))
-        to[p] = from[p];
-    return to;
-  }
-
+  /**
+   * Copies a single property from a source object to a target object, provided it is defined.
+   * A property is defined if either its value, getter or setter are defined.
+   *
+   * @param {!object} to - Target object.
+   * @param {!object} from - Source object.
+   * @param {string} p - Name of the property to be copied.
+   * @return {object} Returns the target object.
+   * @method
+   */
   function copyOneDefined(to, from, p) {
     var pd = getPropertyDescriptor(from, p);
     if(pd && pd.get || pd.set || pd.value !== undefined)

--- a/package-res/resources/web/pentaho/util/object.js
+++ b/package-res/resources/web/pentaho/util/object.js
@@ -38,7 +38,7 @@ define(function() {
      * @param {object} object
      * @param {string} property - Property to be deleted
      * @param {any} defaultValue - Default value of the property.
-     * @return {any} Returns the value of the deleted property.
+     * @return {any} The value of the deleted property.
      * If the property did not exist, `defaultValue` is returned instead.
      * @throws {TypeError} Cannot delete a constant property.
      */
@@ -57,7 +57,7 @@ define(function() {
      *
      * @param {?object} object - Object to be tested.
      * @param {string} property - Name of the property to be tested.
-     * @return {boolean} Returns `true` if this is a direct/own property, or `false` otherwise.
+     * @return {boolean} `true` if this is a direct/own property, or `false` otherwise.
      */
     hasOwn: function(o, p) {
       return !!o && O_hasOwn.call(o, p);
@@ -70,7 +70,7 @@ define(function() {
      * @param {?object} object - Object to be tested.
      * @param {string} property - Name of the property to be retrieved.
      * @param {any} defaultValue - Default value of the property.
-     * @return {boolean} Returns the value of the property if it exists in the object and is an own property,
+     * @return {boolean} The value of the property if it exists in the object and is an own property,
      * otherwise returns `defaultValue`.
      */
     getOwn: function(o, p, dv) {
@@ -102,7 +102,7 @@ define(function() {
      * @param {?object} context - Object which will provide the execution context of the iteratee function.
      * If nully, the iteratee will run with the context of the iterated object.
      *
-     * @return {boolean} Returns `true` when the iteration completed regularly,
+     * @return {boolean} `true` when the iteration completed regularly,
      * or `false` if the iteration was forcefully terminated.
      */
     eachOwn: function(o, fun, ctx) {
@@ -118,7 +118,7 @@ define(function() {
      *
      * @param {!object} to - Target object.
      * @param {!object} from - Source object.
-     * @return {object} Returns the target object.
+     * @return {object} The target object.
      */
     assignOwn: function(to, from) {
       for(var p in from)
@@ -133,7 +133,7 @@ define(function() {
      *
      * @param {!object} to - Target object.
      * @param {!object} from - Source object.
-     * @return {object} Returns the target object.
+     * @return {object} The target object.
      * @method
      * @see pentaho.util.object.assignOwn
      */
@@ -146,7 +146,7 @@ define(function() {
      * no clone is created and the original object is returned instead.
      *
      * @param {object|Array|any} from - Source object.
-     * @return {any} Returns shallow copy of object,
+     * @return {any} A shallow copy of the object,
      * or the object itself if it is neither a plain object nor an array.
      */
     cloneShallow: function(v) {
@@ -164,7 +164,7 @@ define(function() {
      *
      * @param {!object} object - Object that contains the property.
      * @param {!string} property - Name of property.
-     * @return {object|null} Returns the
+     * @return {object|null} The
      * [property descriptor]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty}.
      * @method
      */
@@ -177,7 +177,7 @@ define(function() {
      *
      * @param {function} Ctor - The constructor function of the class to be instantiated.
      * @param {Array} [args] - The array of arguments, or arguments object, which will be passed to the constructor.
-     * @return {object} Returns the constructed instance.
+     * @return {object} The constructed instance.
      */
     //only used by pentaho.lang.Base
     make: function(Ctor, args) {
@@ -202,7 +202,7 @@ define(function() {
      *
      * @param {object} obj - The object which is to have its prototype set.
      * @param {?object} prototype - The object's new prototype.
-     * @return {object} Returns `object`.
+     * @return {object} The `object`.
      */
     setPrototypeOf: setProtoOf,
 
@@ -213,7 +213,7 @@ define(function() {
      * @param {!object} inst - Object to be mutated.
      * @param {function} Class - Constructor of the class to be applied to the object.
      * @param {?Array} args - Array of arguments to be passed to the constructor of the class.
-     * @return {object} Returns the mutated object.
+     * @return {object} The mutated object.
      */
     //only used by pentaho.lang.Base
     applyClass: function(inst, Class, args) {

--- a/package-res/resources/web/pentaho/visual/spec/helper.js
+++ b/package-res/resources/web/pentaho/visual/spec/helper.js
@@ -149,7 +149,9 @@ define([
    * @return {boolean} `true` if iteration was not cancelled, `false` otherwise.
    */
   function eachProperties(spec, fun, ctx) {
-    return O.eachOwnDefined(spec, function(v, p) {
+    return O.eachOwn(spec, function(v, p) {
+      if(v === undefined)
+        return;
       if(!isStandardProperty(p))
         return fun.call(ctx, v, p); // maybe stop
     });

--- a/test-js/unit/pentaho/util/object.Spec.js
+++ b/test-js/unit/pentaho/util/object.Spec.js
@@ -1,0 +1,581 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/util/object"
+], function(O) {
+
+  "use strict";
+
+  /*global describe:true, it:true, expect:true, beforeEach:true, Object:true*/
+
+  describe("pentaho.util.object -", function() {
+    it("is an object containing the advertised functions", function() {
+      expect(typeof O).toBe("object");
+      [
+        "delete",
+        "hasOwn", "getOwn",
+        "setConst",
+        "eachOwn",
+        "assignOwn", "assignOwnDefined",
+        "cloneShallow", "getPropertyDescriptor",
+        "make", "setPrototypeOf", "applyClass"
+      ].forEach(function(f) {
+        expect(f in O).toBe(true);
+      });
+    });
+
+    function getFoo() {
+      var Foo = function() {
+        this.bar = "bar";
+      };
+      Foo.prototype = new function() {
+      };
+      Foo.prototype.spam = "spam";
+      Object.defineProperty(Foo.prototype, "eggs", {enumerable: false, value: "eggs"});
+
+      var foo = new Foo();
+      foo.parrot = "parrot";
+      Object.defineProperty(foo, "gumby", {value: "gumby"});
+      Object.defineProperty(foo, "cheese", {enumerable: false, value: "cheese"});
+      Object.defineProperty(foo, "minister", {
+        enumerable: false,
+        value: "minister",
+        configurable: true
+      });
+      Object.defineProperty(foo, "lumberjack", {
+        enumerable: true,
+        get: function() {
+          return "lumberjack";
+        }
+      });
+      Object.defineProperty(foo, "inspector", {
+        enumerable: false,
+        set: function() {
+        }
+      });
+      return foo;
+    }
+
+    describe("`delete` -", function() {
+
+      function canDelete(foo, prop) {
+        expect(prop in foo).toBe(true);
+        O["delete"](foo, prop);
+        expect(prop in foo).toBe(false);
+      }
+
+      function cannotDelete(foo, prop) {
+        expect(prop in foo).toBe(true);
+        O["delete"](foo, prop);
+        expect(prop in foo).toBe(true);
+      }
+
+      describe("removes properties", function() {
+        var foo;
+        beforeEach(function() {
+          foo = getFoo();
+        });
+
+        it("should remove an enumerable own property", function() {
+          canDelete(foo, "bar");
+
+          canDelete({
+            bar: "bar"
+          }, "bar");
+
+        });
+
+        it("should remove non-enumerable own properties", function() {
+          canDelete(foo, "minister");
+        });
+
+        it("should not remove inherited properties", function() {
+          cannotDelete(foo, "spam");
+          cannotDelete(foo, "eggs");
+        });
+
+        it("should throw when attempting to remove a constant property", function() {
+          expect(function() {
+            O["delete"](foo, "gumby");
+          }).toThrowError(TypeError);
+        });
+
+      });
+
+      describe("returns values", function() {
+        it("should return the value of the deleted property", function() {
+          expect(O["delete"]({bar: "spam"}, "bar", "foo")).toBe("spam");
+        });
+
+        it("should return the default value if the property does not exist", function() {
+          expect(O["delete"]({spam: "eggs"}, "bar", "foo")).toBe("foo");
+        });
+      });
+
+    }); // delete
+
+    describe("`hasOwn` -", function() {
+      var foo;
+
+      beforeEach(function() {
+        foo = getFoo();
+      });
+
+      it("returns `true` on own properties, regardless if they are enumerable", function() {
+        expect(O.hasOwn(foo, "bar")).toBe(true);
+        expect(O.hasOwn(foo, "parrot")).toBe(true);
+        expect(O.hasOwn(foo, "gumby")).toBe(true);
+        expect(O.hasOwn(foo, "cheese")).toBe(true);
+        expect(O.hasOwn(foo, "minister")).toBe(true);
+      });
+
+      it("returns `false` on inherited properties", function() {
+        expect(O.hasOwn(foo, "spam")).toBe(false);
+        expect(O.hasOwn(foo, "eggs")).toBe(false);
+      });
+
+      it("returns `false` on non-existent properties", function() {
+        expect(O.hasOwn(foo, "twit")).toBe(false);
+      });
+
+    }); // hasOwn
+
+    describe("`getOwn` -", function() {
+      var foo;
+
+      beforeEach(function() {
+        foo = getFoo();
+      });
+
+      it("returns an own property, regardless if it is enumerable", function() {
+        expect(O.getOwn(foo, "bar", "ni!")).toBe("bar");
+        expect(O.getOwn(foo, "parrot", "ni!")).toBe("parrot");
+        expect(O.getOwn(foo, "gumby", "ni!")).toBe("gumby");
+        expect(O.getOwn(foo, "cheese", "ni!")).toBe("cheese");
+        expect(O.getOwn(foo, "minister", "ni!")).toBe("minister");
+      });
+
+      it("returns the default value on inherited properties", function() {
+        expect(O.getOwn(foo, "spam", "ni!")).toBe("ni!");
+        expect(O.getOwn(foo, "spam")).toBeUndefined();
+        expect(O.getOwn(foo, "eggs", "ni!")).toBe("ni!");
+        expect(O.getOwn(foo, "eggs")).toBeUndefined();
+      });
+
+      it("returns the default value  on non-existent properties", function() {
+        expect(O.getOwn(foo, "twit", "ni!")).toBe("ni!");
+        expect(O.getOwn(foo, "twit")).toBeUndefined();
+      });
+
+    }); // getOwn
+
+    describe("`setConst` -", function() {
+      var foo;
+      beforeEach(function() {
+        foo = {};
+        O.setConst(foo, "bar", "bar");
+      });
+
+      it("a property created with `setConst` should be readable", function() {
+        expect(foo.bar).toBe("bar");
+      });
+      it("attempting to write over a property created with `setConst` throws a TypeError", function() {
+        expect(function() {
+          foo.bar = "twit";
+        }).toThrowError(TypeError);
+      });
+      it("attempting to delete a property created with `setConst` throws a TypeError", function() {
+        expect(function() {
+          delete foo.bar;
+        }).toThrowError(TypeError);
+      });
+    }); //setConst
+
+    describe("`eachOwn` -", function() {
+      var foo;
+
+      beforeEach(function() {
+        foo = getFoo();
+      });
+
+      it("iterates over all direct enumerable properties of an object", function() {
+        foo.xpto = "xpto";
+        Object.defineProperty(foo, "goose", {enumerable: true})
+        var ownProps = ["bar", "parrot", "lumberjack", "xpto", "goose"];
+        var count = 0;
+        O.eachOwn(foo, function(value, key) {
+          expect(ownProps.indexOf(key) >= -1).toBe(true);
+          count++;
+        });
+        expect(count).toBe(ownProps.length);
+      });
+
+
+      it("iterates over all direct enumerable properties of an object (POJO variant)", function() {
+        foo = {
+          "bar": 0,
+          "parrot": 1,
+          "xpto": 2
+        };
+        var ownProps = ["bar", "parrot", "xpto"];
+        var count = 0;
+        O.eachOwn(foo, function(value, key) {
+          expect(ownProps.indexOf(key) >= -1).toBe(true);
+          count++;
+        });
+        expect(count).toBe(ownProps.length);
+      });
+
+      it("returns `true` after iterating over all own properties of an object", function() {
+        var result = O.eachOwn(foo, function(value, key) {
+        });
+        expect(result).toBe(true);
+      });
+
+      it("breaks out of the loop if the iteratee returns `false`", function() {
+        var count = 0;
+        O.eachOwn(foo, function(value, key) {
+          count++;
+          return false;
+        });
+        expect(count).toBe(1);
+      });
+
+      it("returns `false` if the iteratee returns `false`", function() {
+        var result = O.eachOwn(foo, function(value, key) {
+          return false;
+        });
+        expect(result).toBe(false);
+      });
+
+    }); // eachOwn
+
+    describe("`assignOwn` -", function() {
+      var foo;
+
+      beforeEach(function() {
+        foo = getFoo();
+      });
+
+      it("returns the target object", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"]
+        };
+        var target = {};
+        var result = O.assignOwn(target, source);
+        expect(result).toBe(target);
+      });
+
+      it("assigns a property from one object to another", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"]
+        };
+        var target = O.assignOwn({}, source);
+        expect(target.ingredients[2]).toBe("cheese");
+        source.ingredients[2] = "lard";
+        expect(target.ingredients[2]).toBe("lard");
+      });
+
+      it("assigns all direct enumerable properties of an object to another", function() {
+        foo.xpto = "xpto";
+        Object.defineProperty(foo, "goose", {enumerable: true}); //value: undefined
+        var ownProps = ["bar", "parrot", "lumberjack", "xpto", "goose"];
+        var target = O.assignOwn({}, foo);
+        expect(Object.keys(target).length).toBe(ownProps.length);
+        expect(target.spam).toBeUndefined(); //inherited property
+      });
+
+      it("assigns all direct enumerable properties of an object to another (POJO variant)", function() {
+        foo = {
+          "bar": 0,
+          "parrot": 1,
+          "xpto": 2
+        };
+        var ownProps = ["bar", "parrot", "xpto"];
+        var target = O.assignOwn({}, foo);
+        expect(Object.keys(target).length).toBe(ownProps.length);
+      });
+
+    }); // assignOwn
+
+    describe("`assignOwnDefined` -", function() {
+      var foo;
+
+      beforeEach(function() {
+        foo = getFoo();
+      });
+
+      it("returns the target object", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"]
+        };
+        var target = {};
+        var result = O.assignOwnDefined(target, source);
+        expect(result).toBe(target);
+      });
+
+      it("assigns a defined property from one object to another", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"],
+          recipe: undefined
+        };
+        var target = O.assignOwnDefined({}, source);
+        expect(target.ingredients[2]).toBe("cheese");
+        source.ingredients[2] = "lard";
+        source.recipe = "mix vigorously";
+        expect(target.ingredients[2]).toBe("lard");
+        expect(target.recipe).toBeUndefined();
+      });
+
+      it("assigns all defined direct enumerable properties of an object to another", function() {
+        foo.xpto = "xpto";
+        Object.defineProperty(foo, "goose", {enumerable: true}); //value: undefined
+        var ownProps = ["bar", "parrot", "lumberjack", "xpto"];
+        var target = O.assignOwnDefined({}, foo);
+        expect(Object.keys(target).length).toBe(ownProps.length);
+        expect(target.spam).toBeUndefined(); //inherited property
+      });
+
+      it("assigns all defined direct enumerable properties of an object to another (POJO variant)", function() {
+        foo = {
+          "bar": 0,
+          "parrot": 1,
+          "xpto": undefined
+        };
+        var ownProps = ["bar", "parrot"];
+        var target = O.assignOwnDefined({}, foo);
+        expect(Object.keys(target).length).toBe(ownProps.length);
+      });
+
+    }); // assignOwnDefined
+
+    describe("`cloneShallow` -", function() {
+
+      it("should return a different object for plain objects or arrays", function() {
+        [
+          {}, {foo: "bar"},
+          [], [1, 2, 3]
+        ].forEach(function(src) {
+          var clone = O.cloneShallow(src);
+          expect(clone).not.toBe(src);
+        });
+      });
+
+      it("should return an object containing the same properties", function() {
+        [
+          {}, {foo: "bar"},
+          [], [1, 2, 3]
+        ].forEach(function(src) {
+          var clone = O.cloneShallow(src);
+          for(var prop in src) {
+            expect(clone[prop]).toBe(src[prop]);
+          }
+        });
+      });
+
+      it("should act as an identity function for simple data types or instances", function() {
+        [
+          1, true, null, undefined, "foo",
+          new Date(),
+          getFoo()
+        ].forEach(function(value) {
+          expect(O.cloneShallow(value)).toBe(value);
+        });
+      });
+
+    }); //cloneShallow
+
+    describe("`getPropertyDescriptor` -", function() {
+
+      function expectDescriptor(obj, property) {
+        var result = O.getPropertyDescriptor(obj, property);
+        expect(typeof result).toBe("object");
+        var attrs = ["configurable", "enumerable", "get", "set", "value", "writable"];
+        Object.keys(result).forEach(function(prop) {
+          expect(attrs).toContain(prop);
+        });
+      }
+
+      it("should return an object", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"]
+        };
+        var result = O.getPropertyDescriptor(source, "ingredients");
+        expect(typeof result).toBe("object");
+      });
+
+      it("should return `null` if the property does not exist", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"]
+        };
+        var result = O.getPropertyDescriptor(source, "recipe");
+        expect(result).toBeNull();
+
+        var foo = getFoo();
+        expect(O.getPropertyDescriptor(foo, "recipe")).toBeNull();
+      });
+
+      it("should return the descriptor of an own property", function() {
+        var source = {
+          ingredients: ["spam", "eggs", "cheese"],
+          recipe: undefined
+        };
+        var foo = getFoo();
+        expectDescriptor(source, "ingredients");
+        expectDescriptor(source, "recipe"); //property is defined, its value is not
+        expectDescriptor(foo, "bar");
+        expectDescriptor(foo, "parrot");
+        expectDescriptor(foo, "cheese");
+        expectDescriptor(foo, "minister");
+        expectDescriptor(foo, "lumberjack");
+      });
+
+      it("should return the descriptor of an inherited property", function() {
+        var foo = getFoo();
+        expectDescriptor(foo, "spam");
+        expectDescriptor(foo, "eggs");
+      });
+
+    }); // getPropertyDescriptor
+
+    describe("`setPrototypeOf` -", function() {
+      var Spam, protoEggs, parrot;
+      beforeEach(function() {
+        Spam = function() {
+          this.bar = "bar";
+        };
+        Spam.prototype = new function() {
+          this.spam = "spam";
+        };
+        parrot = new Spam();
+
+        var myProto = function() {
+          this.spam = "eggs";
+        };
+        protoEggs = new myProto();
+      });
+
+      it("should return the input object, if the desired prototype is an object", function() {
+        expect(O.setPrototypeOf(parrot, protoEggs)).toBe(parrot);
+      });
+
+      it("should return the input object, if the desired prototype is `null` ", function() {
+        expect(O.setPrototypeOf(parrot, null)).toBe(parrot);
+      });
+
+      it("should replace the `prototype` of an object, if the desired prototype is an object", function() {
+        expect(parrot.spam).toBe("spam");
+        O.setPrototypeOf(parrot, protoEggs);
+        expect(parrot.spam).toBe("eggs");
+      });
+
+      it("should clear the object's prototype, if the desired prototype is `null`", function() {
+        expect(parrot.spam).toBe("spam");
+        var deadParrot = O.setPrototypeOf(parrot, null);
+        expect(deadParrot.spam).toBeUndefined();
+      });
+
+      it("should throw an error if the desired prototype is neither an extensible object nor `null`", function() {
+        [
+          1, "foo", undefined
+        ].forEach(function(protoFoo) {
+          var parrot = new Spam();
+          expect(function() {
+            O.setPrototypeOf(parrot, protoFoo);
+          }).toThrowError(TypeError);
+        });
+      });
+
+      it("should throw an error if the object is not extensible", function() {
+        [
+          Object.seal(new Spam()),
+          Object.freeze(new Spam()),
+          Object.preventExtensions(new Spam())
+        ].forEach(function(parrot) {
+          expect(function() {
+            O.setPrototypeOf(parrot, protoEggs);
+          }).toThrowError(TypeError);
+        });
+      });
+
+    }); // setPrototypeOf
+
+    describe("`make` -", function() {
+
+      it("should return an instance of the same class of the constructor", function() {
+        var Spam = function() {
+          this.input = arguments;
+        };
+        var spam = O.make(Spam, []);
+        expect(spam instanceof Spam).toBe(true);
+      });
+
+      it("should pass the array of arguments to the constructor", function() {
+        var Spam = function() {
+          this.input = arguments;
+        };
+        [
+          [],
+          [1], [1, 2], [1, 2, 3],
+          [1, "2", 3, "4", 5, 6, 7, "8", 9, 10]
+        ].forEach(function(args) {
+          var spam = O.make(Spam, args);
+          expect(spam.input.length).toBe(args.length);
+          for(var arg in spam.input) {
+            expect(args.indexOf(spam.input[arg])).toBeGreaterThan(-1);
+          }
+        });
+      });
+
+    }); // make
+
+    describe("`applyClass` -", function() {
+      var spam, Spam, Eggs;
+      beforeEach(function() {
+        Spam = function() {
+          this.input = arguments;
+          this.spam = "spam";
+        };
+        Spam.prototype = new (function() {
+          this.spam = "ham";
+        })();
+        spam = new Spam();
+        spam.spam = "bacon";
+
+        Eggs = function() {
+          this.eggs = "eggs";
+        };
+        Eggs.prototype = new (function() {
+          this.cheese = "cheese";
+        })();
+
+      });
+
+      it("should not invoke the constructor of the class if the instance already has the same prototype", function() {
+        var mutatedSpam = O.applyClass(spam, Spam);
+        expect(mutatedSpam.spam).toBe("bacon");
+      });
+
+      it("should invoke the constructor of the class if the instance does not have the same prototype", function() {
+        var mutatedSpam = O.applyClass(spam, Eggs);
+        expect(mutatedSpam.spam).toBe("bacon");
+        expect(mutatedSpam.eggs).toBe("eggs");
+      });
+
+    }); //applyClass
+
+  }); // pentaho.util.object
+});


### PR DESCRIPTION
- Added unit tests and documentation
- Removed functions eachOwnDefined, copyOwnDefined, copyOneDefined