### PR TITLE
[CLEANUP] Create pentaho.lang.XyzError classes

### DIFF
--- a/package-res/resources/web/pentaho/data/_trends.js
+++ b/package-res/resources/web/pentaho/data/_trends.js
@@ -73,7 +73,7 @@ define([
         xIndex = +xIndex; // toNumber
         if(isNaN(xIndex)) throw error.argInvalidType("trendArgs.x", "number");
 
-        if(xIndex < 0 || xIndex >= colCount) throw error.argOutOfRange("trendArgs.x");
+        if(xIndex < 0 || xIndex >= colCount) throw error.argRange("trendArgs.x");
 
         // can be numeric or string
 
@@ -84,7 +84,7 @@ define([
         yIndex = +yIndex; // toNumber
         if(isNaN(yIndex)) throw error.argInvalidType("trendArgs.y", "number");
 
-        if(yIndex < 0 || yIndex >= colCount) throw error.argOutOfRange("trendArgs.y");
+        if(yIndex < 0 || yIndex >= colCount) throw error.argRange("trendArgs.y");
 
         if(this.getColumnType(yIndex) !== 'number')
           throw error.argInvalid("trendArgs.y", "Must be a numeric column.");

--- a/package-res/resources/web/pentaho/lang/ArgumentError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentError.js
@@ -1,0 +1,60 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./Base"
+], function(Base) {
+
+  "use strict";
+
+  return Base.Error.extend("pentaho.lang.ArgumentError", /** @lends pentaho.lang.ArgumentError# */{
+    /**
+     * @classDesc The `ArgumentError` class is the base class of error objects associated with a function argument.
+     *
+     * The {@link pentaho.lang.ArgumentError#argument} property contains the name of the associated argument.
+     *
+     * @name ArgumentError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.Base.Error
+     *
+     * @description Creates an argument error object.
+     * @constructor
+     * @param {string} name The name of the argument.
+     * @param {string} message The error message.
+     */
+    constructor: function(name, message) {
+
+      this.base(message);
+
+      /**
+       * The name of the associated argument.
+       * @type {string}
+       * @readonly
+       */
+      this.argument = name;
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "ArgumentError"
+     */
+    name: "ArgumentError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/ArgumentInvalidError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentInvalidError.js
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./ArgumentError",
+  "../util/text"
+], function(ArgumentError, textUtil) {
+
+  "use strict";
+
+  return ArgumentError.extend("pentaho.lang.ArgumentInvalidError", /** @lends pentaho.lang.ArgumentInvalidError# */{
+    /**
+     * @classDesc The `ArgumentInvalidError` class is the class of errors that
+     * signals that a function argument has been specified, albeit with an invalid value.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * An argument's value can be considered **invalid** because:
+     * * it is not of one of the supported, documented types -
+     *   use {@link pentaho.lang.ArgumentInvalidTypeError} instead
+     * * the specific value is not supported, or is out of range -
+     *   use {@link pentaho.lang.ArgumentRangeError} instead
+     * * the value is not in an acceptable state
+     * * the value refers to something which does not exist (like a dictionary _key_ which is undefined)
+     * * ...
+     *
+     * You should use this error if none of the other more specific
+     * invalid argument errors applies.
+     *
+     * @name ArgumentInvalidError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.ArgumentError
+     *
+     * @description Creates an invalid argument error object.
+     * @constructor
+     * @param {string} name The name of the argument.
+     * @param {string} reason Text that explains the reason why the argument is considered invalid.
+     * Can be useful when "being required" is a dynamic rule.
+     */
+    constructor: function(name, reason) {
+      this.base(name, textUtil.andSentence("Argument " + name + " is invalid.", reason));
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "ArgumentInvalidError"
+     */
+    name: "ArgumentInvalidError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/ArgumentInvalidTypeError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentInvalidTypeError.js
@@ -1,0 +1,121 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./ArgumentError",
+  "../util/text"
+], function(ArgumentError, textUtil) {
+
+  "use strict";
+
+  return ArgumentError.extend("pentaho.lang.ArgumentInvalidTypeError", /** @lends pentaho.lang.ArgumentInvalidTypeError# */{
+    /**
+     * @classDesc The `ArgumentInvalidTypeError` class is the class of errors that
+     * signals that a function argument has been specified, albeit with a value of an unsupported type,
+     * according to the documented contract.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * Types can be:
+     * * one of the possible results of the `typeof` operator,
+     *   like `"number"`, `"string"`, `"boolean"`, `"function"`, ...
+     * * the name of global classes/constructors,
+     *   that would be testable by use of the `instanceof` operator or
+     *   by accessing the `constructor` property,
+     *   like `"Array"`, `"Object"`, or `"HTMLElement"`
+     * * the id of an AMD module that returns a constructor or factory, like `"pentaho/type/complex"`.
+     *
+     * @example
+     *
+     * define(["pentaho/lang/ArgumentInvalidTypeError"], function(ArgumentInvalidTypeError) {
+     *
+     *   function createInstance(type, args) {
+     *     var TypeCtor;
+     *
+     *     switch(typeof type) {
+     *       case "string":
+     *         TypeCtor = window[type];
+     *         break;
+     *
+     *       case "function":
+     *         TypeCtor = type;
+     *         break;
+     *
+     *       default:
+     *         throw new ArgumentInvalidTypeError("type", ["string", "function"], typeof type);
+     *     }
+     *
+     *     // ...
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @name ArgumentInvalidTypeError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.ArgumentError
+     *
+     * @description Creates an invalid argument type error object.
+     * @constructor
+     * @param {string} name The name of the argument.
+     * @param {string|string[]} expectedType The name or names of the expected types.
+     * @param {string} [actualType] The name of the received type, when known.
+     */
+    constructor: function(name, expectedType, actualType) {
+      var typesMsg = "Expected type to be ";
+
+      if(!Array.isArray(expectedType)) expectedType = [expectedType];
+
+      if(expectedType.length > 1) {
+        var expectedTypesClone = expectedType.slice();
+        var lastExpectedType = expectedTypesClone.pop();
+        typesMsg += "one of " + expectedTypesClone.join(", ") + " or " + lastExpectedType;
+      } else {
+        // If should have at least one entry...
+        typesMsg += expectedType[0];
+      }
+
+      typesMsg += actualType ? (", but got " + actualType + ".") : ".";
+
+      this.base(name, textUtil.andSentence("Argument " + name + " is invalid.", typesMsg));
+
+      /**
+       * The name of the received type, when known.
+       * @type {?nonEmptyString}
+       * @readonly
+       */
+      this.actualType = actualType || null;
+
+      /**
+       * The names of the expected types.
+       * @type {nonEmptyString[]}
+       * @readonly
+       */
+      this.expectedTypes = expectedType;
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "ArgumentInvalidTypeError"
+     */
+    name: "ArgumentInvalidTypeError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/ArgumentRangeError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentRangeError.js
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./ArgumentError"
+], function(ArgumentError) {
+
+  "use strict";
+
+  return ArgumentError.extend("pentaho.lang.ArgumentRangeError", /** @lends pentaho.lang.ArgumentRangeError# */{
+    /**
+     * @classDesc The `ArgumentRangeError` class is the class of errors that
+     * signals that a function argument was specified with a value of one of the expected types,
+     * albeit not within the expected range.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * @example
+     *
+     * define(["pentaho/lang/ArgumentRangeError"], function(ArgumentRangeError) {
+     *
+     *   function insertAt(element, index) {
+     *
+     *     if(index < 0 || index > this.length) {
+     *       throw new ArgumentRangeError("index");
+     *     }
+     *
+     *     // Safe to insert at index
+     *     this._elements.splice(index, 0, element);
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @name ArgumentRangeError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.ArgumentError
+     *
+     * @description Creates an out of range argument error object.
+     * @constructor
+     * @param {string} name The name of the argument.
+     */
+    constructor: function(name) {
+      this.base(name, "Argument " + name + " is out of range.");
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "ArgumentRangeError"
+     */
+    name: "ArgumentRangeError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/ArgumentRequiredError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentRequiredError.js
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./ArgumentError",
+  "../util/text"
+], function(ArgumentError, textUtil) {
+
+  "use strict";
+
+  return ArgumentError.extend("pentaho.lang.ArgumentRequiredError", /** @lends pentaho.lang.ArgumentRequiredError# */{
+    /**
+     * @classDesc The `ArgumentRequiredError` class is the class of errors that
+     * signals that a required function argument was not specified,
+     * or was specified _nully_ or empty.
+     *
+     * The name of the argument can be that of a nested property,
+     * like, for example, `"keyArgs.description"`.
+     *
+     * An argument being "required" may mean that an argument must be:
+     * * specified - `if(arguments.length < 1) ...`
+     * * truthy - `if(!value) ...`
+     * * not nully - `if(value == null) ...`
+     * * not nully or an empty string - `if(value == null || value === "") ...`
+     * * ...
+     *
+     * @example
+     *
+     * define(["pentaho/lang/ArgumentRequiredError"], function(ArgumentRequiredError) {
+     *
+     *   function connect(channel) {
+     *
+     *     if(channel && channel.isOpened) {
+     *       throw new ArgumentRequiredError("channel", "Channel not free to use.");
+     *     }
+     *
+     *     var handle = channel.open();
+     *     // ...
+     *   }
+     *
+     *   // ...
+     * });
+     *
+     * @name ArgumentRequiredError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.ArgumentError
+     *
+     * @description Creates a required argument error object.
+     * @constructor
+     * @param {string} name The name of the argument.
+     * @param {?string} [text] Optional text further explaining the reason why the argument is required.
+     * Can be useful when "being required" is a dynamic rule.
+     */
+    constructor: function(name, text) {
+      this.base(name, textUtil.andSentence("Argument " + name + " is required.", text));
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "ArgumentRequiredError"
+     */
+    name: "ArgumentRequiredError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/Base.js
+++ b/package-res/resources/web/pentaho/lang/Base.js
@@ -76,7 +76,27 @@ define([
    * @returns {Class.<pentaho.lang.Base>}
    */
   function base_create() {
-    var Base = base_root(Object, {}, "Base.Object");
+    /**
+     * @classdesc `Base` Class for JavaScript Inheritance.
+     * Based on Base.js by Dean Edwards, and later edited by Kenneth Powers.
+     *
+     * @class
+     * @name Base
+     * @memberOf pentaho.lang
+     * @amd pentaho/lang/Base
+     *
+     * @description Creates a new object of `Base` class.
+     *
+     * If provided, extends the created instance with the spec in `source` parameter.
+     *
+     * @constructor
+     * @param {Object} [source] An instance specification.
+     */
+    function BaseObject(source) {
+      this.extend(source);
+    }
+
+    var Base = base_root(Object, {}, "Base.Object", BaseObject);
     Base.version = "2.0";
 
     /**
@@ -97,12 +117,11 @@ define([
     /**
      * The `Base.Array` root class is the base class for `Array` classes.
      *
-     * @name Array
+     * @alias Array
      * @memberOf pentaho.lang.Base
      *
      * @class
      * @extends Array
-     *
      *
      * @borrows pentaho.lang.Base.ancestor as ancestor
      * @borrows pentaho.lang.Base.extend as extend
@@ -112,21 +131,31 @@ define([
      * @borrows pentaho.lang.Base.implementStatic as implementStatic
      * @borrows pentaho.lang.Base#base as #base
      * @borrows pentaho.lang.Base#extend as #extend
+     *
+     * @description Initializes a new array of `Base.Array` class.
+     *
+     * If provided, extends the created instance with the spec in `source` parameter.
+     *
+     * To "create" an instance of `Base.Array`,
+     * use {@link pentaho.lang.Base.Array.to},
+     * to convert an existing array instance.
+     *
+     * @constructor
+     * @param {Array} [source] An instance specification.
      */
-    Base.Array = base_root(Array, [], "Base.Array");
+    function BaseArray(source) {
+      this.extend(source);
+    }
+
+    Base.Array = base_root(Array, [], "Base.Array", BaseArray);
     Base.Array.to = class_array_to;
 
     // ---
 
-    var baseErrorConstructor = function(message) {
-      this.message = message;
-      this.stack = (new Error()).stack;
-    };
-
     /**
      * The `Base.Error` root class is the base class for `Error` classes.
      *
-     * @name Error
+     * @alias Error
      * @memberOf pentaho.lang.Base
      *
      * @class
@@ -144,7 +173,12 @@ define([
      * @borrows pentaho.lang.Base#base as #base
      * @borrows pentaho.lang.Base#extend as #extend
      */
-    Base.Error = base_root(Error, Object.create(Error.prototype), "Base.Error", baseErrorConstructor);
+    function BaseError(message) {
+      this.message = message;
+      this.stack = (new Error()).stack;
+    }
+
+    Base.Error = base_root(Error, Object.create(Error.prototype), "Base.Error", BaseError);
 
     return Base;
   }
@@ -186,32 +220,8 @@ define([
 
     // ---
 
-    if(!baseConstructor) {
-      baseConstructor = function() {
-        this.extend(arguments[0]);
-      };
-    }
-
-    // ---
-
     var BaseRoot = BaseBoot.extend({
-      /**
-       * Creates a new object of `Base` class.
-       *
-       * If provided extends the created instance with the spec in `source` parameter.
-       *
-       * @param {Object} [source] A instance spec. Optional parameter.
-       *
-       * @classdesc `Base` Class for JavaScript Inheritance.
-       * Based on Base.js by Dean Edwards, and later edited by Kenneth Powers.
-       *
-       * @amd pentaho/lang/Base
-       *
-       * @class
-       * @name Base
-       * @memberOf pentaho.lang
-       */
-      constructor: baseConstructor,
+      constructor: baseConstructor
     }, {
       /**
        * This class ancestor.

--- a/package-res/resources/web/pentaho/lang/Base.js
+++ b/package-res/resources/web/pentaho/lang/Base.js
@@ -116,6 +116,36 @@ define([
     Base.Array = base_root(Array, [], "Base.Array");
     Base.Array.to = class_array_to;
 
+    // ---
+
+    var baseErrorConstructor = function(message) {
+      this.message = message;
+      this.stack = (new Error()).stack;
+    };
+
+    /**
+     * The `Base.Error` root class is the base class for `Error` classes.
+     *
+     * @name Error
+     * @memberOf pentaho.lang.Base
+     *
+     * @class
+     * @extends Error
+     *
+     * @constructor
+     * @param {string} [message] The error message.
+     *
+     * @borrows pentaho.lang.Base.ancestor as ancestor
+     * @borrows pentaho.lang.Base.extend as extend
+     * @borrows pentaho.lang.Base._extend as _extend
+     * @borrows pentaho.lang.Base.mix as mix
+     * @borrows pentaho.lang.Base.implement as implement
+     * @borrows pentaho.lang.Base.implementStatic as implementStatic
+     * @borrows pentaho.lang.Base#base as #base
+     * @borrows pentaho.lang.Base#extend as #extend
+     */
+    Base.Error = base_root(Error, Object.create(Error.prototype), "Base.Error", baseErrorConstructor);
+
     return Base;
   }
 
@@ -127,10 +157,10 @@ define([
    * @param {Class} NativeBase The native base constructor that this _Base_ root is rooted on.
    * @param {object} bootProto The prototype of the _boot_ constructor.
    * @param {string} baseRootName The name of the _root_ constructor.
-   *
+   * @param {?function} [baseConstructor] The base constructor.
    * @returns {Class.<pentaho.lang.Base>} The new `Base` root class.
    */
-  function base_root(NativeBase, bootProto, baseRootName) {
+  function base_root(NativeBase, bootProto, baseRootName, baseConstructor) {
     // Bootstrapping "Base" class.
     // Does not have the full "Base" class interface,
     // but only enough properties set to trick `class_extend`.
@@ -153,6 +183,15 @@ define([
 
     // Used by BaseBoot.extend, just below
     BaseBoot.prototype.extend = inst_extend;
+
+    // ---
+
+    if(!baseConstructor) {
+      baseConstructor = function() {
+        this.extend(arguments[0]);
+      };
+    }
+
     // ---
 
     var BaseRoot = BaseBoot.extend({
@@ -172,9 +211,7 @@ define([
        * @name Base
        * @memberOf pentaho.lang
        */
-      constructor: function() {
-        this.extend(arguments[0]);
-      },
+      constructor: baseConstructor,
     }, {
       /**
        * This class ancestor.

--- a/package-res/resources/web/pentaho/lang/NotImplementedError.js
+++ b/package-res/resources/web/pentaho/lang/NotImplementedError.js
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./Base",
+  "../util/text"
+], function(Base, textUtil) {
+
+  "use strict";
+
+  return Base.Error.extend("pentaho.lang.NotImplementedError", /** @lends pentaho.lang.NotImplementedError# */{
+    /**
+     * @classDesc The `NotImplementedError` class is the class of errors
+     * that signals that a method that is either
+     * abstract and has not been overridden, or
+     * is not abstract but has not been implemented,
+     * and is being called.
+     *
+     * @name NotImplementedError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.Base.Error
+     *
+     * @description Creates a not implemented error object.
+     * @constructor
+     * @param {?string} [text] Complementary text.
+     */
+    constructor: function(text) {
+      this.base(textUtil.andSentence("Not Implemented.", text));
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "NotImplementedError"
+     */
+    name: "NotImplementedError"
+  });
+});

--- a/package-res/resources/web/pentaho/lang/OperationInvalidError.js
+++ b/package-res/resources/web/pentaho/lang/OperationInvalidError.js
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "./Base",
+  "../util/text"
+], function(Base, textUtil) {
+
+  "use strict";
+
+  return Base.Error.extend("pentaho.lang.OperationInvalidError", /** @lends pentaho.lang.OperationInvalidError# */{
+    /**
+     * @classDesc The `OperationInvalidError` class is the class of errors
+     * that signals that performing an operation is considered invalid.
+     *
+     * Performing an operation can be considered **invalid** when:
+     * * the object in which it is executed is not in a state that allows the operation to be performed,
+     *   like it is _locked_, _busy_ or _disposed_.
+     * * it cannot be performed on a certain type of object
+     * * ...
+     *
+     * @example
+     *
+     * define(["pentaho/lang/OperationInvalid"], function(OperationInvalid) {
+     *
+     *   function Cell(value) {
+     *     this._value = value;
+     *     this._locked = false;
+     *   }
+     *
+     *   Cell.prototype = {
+     *     lock: function() {
+     *       this._locked = true;
+     *     },
+     *
+     *     get value() {
+     *       return this._value;
+     *     },
+     *
+     *     set value(v) {
+     *       if(this._locked) {
+     *         throw new OperationInvalid("Cell is locked.");
+     *       }
+     *
+     *       this._value = v;
+     *     }
+     *   };
+     *
+     *   // ...
+     * });
+     *
+     * @name OperationInvalidError
+     * @memberOf pentaho.lang
+     * @class
+     * @extends pentaho.lang.Base.Error
+     *
+     * @description Creates an invalid operation error object.
+     * @constructor
+     * @param {string} reason Text that explains the reason why performing the operation is considered invalid.
+     */
+    constructor: function(reason) {
+      this.base(textUtil.andSentence("Operation invalid.", reason));
+    },
+
+    /**
+     * The name of the type of error.
+     *
+     * @type {string}
+     * @readonly
+     * @default "OperationInvalidError"
+     */
+    name: "OperationInvalidError"
+  });
+});

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -248,26 +248,7 @@ define([
      * the asynchronous method version, [getAsync]{@link pentaho.type.Context#getAsync},
      * should be used instead.
      *
-     * An error is thrown when:
-     *
-     * * the argument `typeRef` is of an unsupported JavaScript type: not a string, function, array or object
-     *
-     * * the argument `typeRef` is a value type's constructor (e.g. [Value.Meta]{@link pentaho.type.Value.Meta})
-     *
-     * * the argument `typeRef` is a value instance
-     *
-     * * the id of a type is not defined as a module in the AMD module system
-     *   (specified directly in `typeRef`, or present in an generic type specification)
-     *
-     * * the id of a **non-standard type** is from a module that the AMD module system hasn't loaded yet
-     *   (specified directly in `typeRef`, or present in an generic type specification)
-     *
-     * * the value returned by a factory function is not a instance constructor of a subtype of _Value_
-     *   (specified directly in `typeRef`, or obtained indirectly by loading a type's module given its id)
-     *
-     * * an instance constructor is from a different [context]{@link pentaho.type.Value.Meta#context}
-     *   (directly specified in `typeRef`,
-     *    or obtained indirectly by loading a type's module given its id, or from a factory function)
+     * @see pentaho.type.Context#getAsync
      *
      * @example
      * <caption>
@@ -297,40 +278,46 @@ define([
      *
      * @return {!Class.<pentaho.type.Value>} The instance constructor.
      *
-     * @see pentaho.type.Context#getAsync
+     * @throws {pentaho.lang.ArgumentInvalidError} When `typeRef` is of an unsupported JavaScript type:
+     * not a string, function, array or object.
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When `typeRef` is a value type's constructor
+     * (e.g. [Value.Meta]{@link pentaho.type.Value.Meta})
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When `typeRef` is a value instance.
+     *
+     * @throws {Error} When the id of a type is not defined as a module in the AMD module system
+     * (specified directly in `typeRef`, or present in an generic type specification).
+     *
+     * @throws {Error} When the id of a **non-standard type** is from a module that the AMD module system
+     * hasn't loaded yet (specified directly in `typeRef`, or present in an generic type specification)
+     *
+     * @throws {pentaho.lang.OperationInvalidError} When the value returned by a factory function is not
+     * an instance constructor of a subtype of _Value_
+     * (specified directly in `typeRef`, or obtained indirectly by loading a type's module given its id).
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When an instance constructor is
+     * from a different [context]{@link pentaho.type.Value.Meta#context}
+     * (directly specified in `typeRef`,
+     * or obtained indirectly by loading a type's module given its id, or from a factory function).
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When `typeRef` is, or contains, an array-shorthand,
+     * list type specification that has more than one child element type specification.
      */
     get: function(typeRef) {
       return this._get(typeRef, true);
     },
 
     /**
-     * Gets, asynchronously, the **configured instance constructor** instance constructor of a type.
+     * Gets, asynchronously, the **configured instance constructor** of a type.
      *
      * For more information on the `typeRef` argument,
      * please see [UTypeReference]{@link pentaho.type.spec.UTypeReference}.
      *
-     * This method can be used even if a generic type metadata specification references
-     * non-standard types whose modules have not yet been loaded by the AMD module system.
+     * This method can be used even if a generic type metadata specification references non-standard types
+     * whose modules have not yet been loaded by the AMD module system.
      *
-     * The returned promise gets rejected with an error when:
-     *
-     * * the argument `typeRef` is of an unsupported JavaScript type: not a string, function, array or object
-     *
-     * * the argument `typeRef` is a value type's constructor (e.g. [Value.Meta]{@link pentaho.type.Value.Meta})
-     *
-     * * the argument `typeRef` is a value instance.
-     *
-     * * the id of a type is not defined as a module in the AMD module system
-     *   (specified directly in `typeRef`, or present in an generic type specification)
-     *
-     * * the value returned by a factory function is not a instance constructor of a subtype of _Value_
-     *   (specified directly in `typeRef`, or obtained indirectly by loading a type's module given its id)
-     *
-     * * an instance constructor is from a different [context]{@link pentaho.type.Value.Meta#context}
-     *   (directly specified in `typeRef`,
-     *    or obtained indirectly by loading a type's module given its id, or from a factory function)
-     *
-     * * any other, unexpected error occurs.
+     * @see pentaho.type.Context#get
      *
      * @example
      * <caption>
@@ -361,7 +348,30 @@ define([
      *
      * @return {!Promise.<!Class.<pentaho.type.Value>>} A promise for the instance constructor.
      *
-     * @see pentaho.type.Context#get
+     * @rejects {pentaho.lang.ArgumentInvalidError} When `typeRef` is of an unsupported JavaScript type:
+     * not a string, function, array or object.
+     *
+     * @rejects {pentaho.lang.ArgumentInvalidError} When `typeRef` is a value type's constructor
+     * (e.g. [Value.Meta]{@link pentaho.type.Value.Meta})
+     *
+     * @rejects {pentaho.lang.ArgumentInvalidError} When `typeRef` is a value instance.
+     *
+     * @rejects {Error} When the id of a type is not defined as a module in the AMD module system
+     * (specified directly in `typeRef`, or present in an generic type specification).
+     *
+     * @rejects {pentaho.lang.OperationInvalidError} When the value returned by a factory function is not
+     * an instance constructor of a subtype of _Value_
+     * (specified directly in `typeRef`, or obtained indirectly by loading a type's module given its id).
+     *
+     * @rejects {pentaho.lang.ArgumentInvalidError} When an instance constructor is
+     * from a different [context]{@link pentaho.type.Value.Meta#context}
+     * (directly specified in `typeRef`,
+     * or obtained indirectly by loading a type's module given its id, or from a factory function).
+     *
+     * @rejects {pentaho.lang.ArgumentInvalidError} When `typeRef` is, or contains, an array-shorthand,
+     * list type specification that has more than one child element type specification.
+     *
+     * @rejects {Error} Any other, unexpected error occurs.
      */
     getAsync: function(typeRef) {
       try {
@@ -439,12 +449,15 @@ define([
      * Main dispatcher according to the type and class of `typeRef`:
      * string, function or array or object.
      *
-     * @param {?pentaho.type.spec.UTypeReference} [typeRef] A type reference.
+     * @param {?pentaho.type.spec.UTypeReference} typeRef A type reference.
      * Defaults to type `"pentaho/type/string"`.
      *
      * @param {boolean} [sync=false] Whether to perform a synchronous get.
      * @return {!Promise.<!Class.<pentaho.type.Value>>|!Class.<pentaho.type.Value>} When sync,
      *   returns the instance constructor, while, when async, returns a promise for it.
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When `typeRef` is of an unsupported JavaScript type:
+     * not a string, function, array or object.
      *
      * @private
      * @ignore
@@ -526,6 +539,12 @@ define([
      * @return {!Promise.<!Class.<pentaho.type.Value>>|!Class.<pentaho.type.Value>} When sync,
      *   returns the instance constructor, while, when async, returns a promise for it.
      *
+     * @throws {pentaho.lang.ArgumentInvalidError} When `fun` is a value type's constructor
+     * (e.g. [Value.Meta]{@link pentaho.type.Value.Meta}).
+     *
+     * @throws {Error} Other errors,
+     * thrown by {@link pentaho.type.Context#_getByType} and {@link pentaho.type.Context#_getByFactory}.
+     *
      * @private
      * @ignore
      */
@@ -546,21 +565,12 @@ define([
      * Gets a configured instance constructor of a type,
      * given the instance constructor of that type.
      *
-     * An error is thrown if, for the given instance constructor,
-     * {@link pentaho.type.Value.Meta#context} is not `this` -
-     * the instance constructor must have been created by a factory called with this context,
-     * and have captured the context as the value of its `context` property,
-     * or, have been extended from a type that had this context.
-     *
      * This method works for anonymous types as well -
      * that have no [id]{@link pentaho.type.Value.Meta#id} -
      * cause it uses the types' [uid]{@link pentaho.type.Value.Meta#uid}
      * to identify types.
      *
      * A map of already configured types is kept in `_byTypeUid`.
-     *
-     * An error is thrown in the pathological case of a different instance constructor,
-     * with the same `uid` is already registered.
      *
      * If the type not yet in the map, and it is not anonymous,
      * configuration is requested for it, and, if any exists,
@@ -576,6 +586,14 @@ define([
      *
      * @return {!Promise.<!Class.<pentaho.type.Value>>|!Class.<pentaho.type.Value>} When sync,
      *   returns the instance constructor, while, when async, returns a promise for it.
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When the [context]{@link pentaho.type.Value.Meta#context}
+     * of `Type` is not `this` - the instance constructor must have been created by a factory called with this context,
+     * and have captured the context as the value of its `context` property,
+     * or, have been extended from a type that had this context.
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When, pathologically, an instance constructor with
+     * the same `uid` is already registered.
      *
      * @private
      * @ignore
@@ -629,9 +647,6 @@ define([
      *
      * Otherwise the factory function is evaluated being passed this context as argument.
      *
-     * An error is thrown if the factory function does not return an instance constructor
-     * derived from `Value`.
-     *
      * The returned instance constructor is passed to `_getType`,
      * for registration and configuration,
      * and then returned immediately (module sync).
@@ -640,7 +655,10 @@ define([
      * @param {boolean} [sync=false] Whether to perform a synchronous get.
      *
      * @return {!Promise.<!Class.<pentaho.type.Value>>|!Class.<pentaho.type.Value>} When sync,
-     *   returns the instance constructor, while, when async, returns a promise for it.
+     * returns the instance constructor, while, when async, returns a promise for it.
+     *
+     * @throws {pentaho.lang.OperationInvalidError} When the value returned by the factory function
+     * is not a instance constructor of a subtype of _Value_.
      *
      * @private
      * @ignore
@@ -698,7 +716,7 @@ define([
     _getByListSpec: function(typeSpec, sync) {
       if(typeSpec.length > 1)
         return this._error(
-            error.argInvalid("typeSpec", "List type specification should have at most one child element type spec."),
+            error.argInvalid("typeRef", "List type specification should have at most one child element type spec."),
             sync);
 
       // Expand compact list type spec syntax and delegate to the generic handler.

--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -269,7 +269,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When `lenient` is `false` and
        * a property with name `name` is not defined.
        *
-       * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is `false` and
+       * @throws {pentaho.lang.ArgumentRangeError} When `lenient` is `false` and
        * the specified or implied `index` is out of range.
        */
       get1: function(name, index, lenient) {
@@ -288,7 +288,7 @@ define([
           }
 
           if(!lenient) {
-            throw error.argOutOfRange("index");
+            throw error.argRange("index");
           }
         }
         // => lenient
@@ -375,7 +375,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When `lenient` is `false` and
        * a property with name `name` is not defined.
        *
-       * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is `false` and
+       * @throws {pentaho.lang.ArgumentRangeError} When `lenient` is `false` and
        * the specified or implied `index` is out of range.
        */
       getv: function(name, index, lenient) {
@@ -406,7 +406,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When `lenient` is `false` and
        * a property with name `name` is not defined.
        *
-       * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is `false` and
+       * @throws {pentaho.lang.ArgumentRangeError} When `lenient` is `false` and
        * the specified or implied `index` is out of range.
        */
       getf: function(name, index, lenient) {
@@ -566,7 +566,7 @@ define([
          * @return {?pentaho.type.Property.Meta} The property metadata, or `null`.
          *
          * @throws {pentaho.lang.ArgumentRequiredError} When `lenient` is `false` and `index` is not specified.
-         * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is `false` and
+         * @throws {pentaho.lang.ArgumentRangeError} When `lenient` is `false` and
          *   the specified `index` is out of range.
          */
         at: function(index, lenient) {
@@ -577,7 +577,7 @@ define([
 
           var pMeta = this._getProps()[index] || null;
           if(!pMeta && !lenient)
-            throw error.argOutOfRange("index");
+            throw error.argRange("index");
 
           return pMeta;
         },

--- a/package-res/resources/web/pentaho/type/facets/DiscreteDomain.js
+++ b/package-res/resources/web/pentaho/type/facets/DiscreteDomain.js
@@ -50,8 +50,7 @@ define([
      * {@link pentaho.type.Refinement.Meta#of}.
      *
      * If the ancestor refinement type has `domain` set,
-     * the specified set of values must be a subset of those,
-     * or an error is thrown.
+     * the specified set of values must be a subset of those.
      *
      * Setting to a {@link Nully} value,
      * clears the local value and inherits the ancestor's domain.
@@ -60,6 +59,9 @@ define([
      *
      * @type {?pentaho.type.List}
      * @readonly
+     *
+     * @throws {pentaho.lang.ArgumentInvalidError} When the specified values are not a subset of those
+     * of the ancestor refinement type.
      */
     get domain() {
       return this._domain;

--- a/package-res/resources/web/pentaho/type/list.js
+++ b/package-res/resources/web/pentaho/type/list.js
@@ -167,7 +167,7 @@ define([
        *
        * @return {?pentaho.type.Element} The element value or `null`.
        *
-       * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is falsy and the specified `index`
+       * @throws {pentaho.lang.ArgumentRangeError} When `lenient` is falsy and the specified `index`
        * is out of range.
        */
       at: function(index, lenient) {
@@ -182,11 +182,11 @@ define([
        * Throws an out of range error for a given index.
        *
        * @param {number} index The index that is out of range.
-       * @throws {pentaho.lang.ArgumentOutOfRangeError} Always.
+       * @throws {pentaho.lang.ArgumentRangeError} Always.
        * @private
        */
       _throwOutOfRange: function(index) {
-        throw error.argOutOfRange("index");
+        throw error.argRange("index");
       },
 
       /**

--- a/package-res/resources/web/pentaho/type/list.js
+++ b/package-res/resources/web/pentaho/type/list.js
@@ -161,14 +161,32 @@ define([
       /**
        * Gets the element at a specified index.
        *
-       * If the index is out of range, `null` is returned.
-       *
        * @param {number} index The desired index.
+       * @param {boolean} [lenient=false] Indicates if `null` is returned
+       *   when the specified index is unspecified or out of range, or if, instead, an error is thrown.
        *
        * @return {?pentaho.type.Element} The element value or `null`.
+       *
+       * @throws {pentaho.lang.ArgumentOutOfRangeError} When `lenient` is falsy and the specified `index`
+       * is out of range.
        */
-      at: function(index) {
-        return this._elems[index] || null;
+      at: function(index, lenient) {
+        if(index == null) {
+          if(lenient) return null;
+          throw error.argRequired("index");
+        }
+        return this._elems[index] || (lenient ? null : this._throwOutOfRange(index));
+      },
+
+      /**
+       * Throws an out of range error for a given index.
+       *
+       * @param {number} index The index that is out of range.
+       * @throws {pentaho.lang.ArgumentOutOfRangeError} Always.
+       * @private
+       */
+      _throwOutOfRange: function(index) {
+        throw error.argOutOfRange("index");
       },
 
       /**
@@ -370,7 +388,7 @@ define([
             L = changes.length,
             change = L ? changes[L - 1] : null;
 
-        if(change && change.type === type && change.at + change.elems.length === index)
+        if(change && (change.type === type) && (change.at + change.elems.length === index))
           return change;
 
         changes.push((change = {type: type, at: index, elems: []}));

--- a/package-res/resources/web/pentaho/type/refinement.js
+++ b/package-res/resources/web/pentaho/type/refinement.js
@@ -29,9 +29,7 @@ define([
 
   return function(context) {
 
-    var Value   = context.get("pentaho/type/value"),
-        Element = context.get("pentaho/type/element"),
-        List    = context.get("pentaho/type/list"),
+    var Value = context.get("pentaho/type/value"),
         _refinementMeta;
 
     /**

--- a/package-res/resources/web/pentaho/util/error.js
+++ b/package-res/resources/web/pentaho/util/error.js
@@ -14,251 +14,88 @@
  * limitations under the License.
  */
 define([
-  "./object"
-], function(O) {
+  "../lang/ArgumentRequiredError",
+  "../lang/ArgumentInvalidError",
+  "../lang/ArgumentInvalidTypeError",
+  "../lang/ArgumentRangeError",
+  "../lang/OperationInvalidError",
+  "../lang/NotImplementedError"
+], function(ArgumentRequiredError, ArgumentInvalidError, ArgumentInvalidTypeError,
+    ArgumentRangeError, OperationInvalidError, NotImplementedError) {
 
   "use strict";
-
-  /*global TypeError:false, RangeError:false*/
 
   /**
    * The `error` namespace contains factory functions for
    * creating `Error` instances for common error conditions
    * that arise in API design.
    *
-   * @namespace
+   * @name error
    * @memberOf pentaho.util
+   * @namespace
    * @amd pentaho/util/error
    * @ignore
    */
-  var error = /** @lends pentaho.util.error */ {
+  return /** @lends pentaho.util.error */ {
     /**
-     * Creates an `Error` object for a case where a required
+     * Creates an error for a case where a required
      * function argument was not specified or was specified _nully_ or empty.
      *
-     * The name of the argument can be that of a nested property,
-     * like, for example, `"keyArgs.description"`.
-     *
-     * It is up to the caller to actually `throw` the returned `Error` object.
+     * It is up to the caller to actually `throw` the returned error object.
      * This makes flow control be clearly visible at the call site.
-     *
-     * Also, it is up to the caller to define what exactly "required" mean;
-     * that an argument must be:
-     * * specified - `if(arguments.length < 1) ...`
-     * * truthy - `if(!value) ...`
-     * * not nully - `if(value == null) ...`
-     * * not nully or an empty string - `if(value == null || value === "") ...`
-     * * ...
-     *
-     * The `name` property of the returned error object has the value `"ArgumentRequiredError"`.
-     * Additionally, the `argument` property has the name of the argument.
-     *
-     * @example
-     *
-     * define(["pentaho/util/error"], function(error) {
-     *
-     *   function add(member) {
-     *
-     *     // Member cannot be null or undefined
-     *     if(member == null) {
-     *       throw error.argRequired("member");
-     *     }
-     *
-     *     // Safe to add member
-     *     this._members.push(member);
-     *   }
-     *
-     *   // ...
-     * });
      *
      * @param {string} name The name of the argument.
      * @param {?string} [text] Optional text further explaining the reason why the argument is required.
      * Can be useful when "being required" is a dynamic rule.
      *
-     * @return {!Error} The created `Error` object.
+     * @return {!pentaho.lang.ArgumentRequiredError} The created `Error` object.
      */
     argRequired: function(name, text) {
-      return createError(
-          Error,
-          andSentence("Argument " + name + " is required.", text),
-          {name: "ArgumentRequiredError", argument: name});
+      return new ArgumentRequiredError(name, text);
     },
 
     /**
-     * Creates an `Error` object for a case where a function argument
+     * Creates an error object for a case where a function argument
      * has been specified, albeit with an invalid value.
-     *
-     * The name of the argument can be that of a nested property,
-     * like, for example, `"keyArgs.description"`.
-     *
-     * It is up to the caller to actually `throw` the returned `Error` object.
-     * This makes flow control be clearly visible at the call site.
-     *
-     * An argument's value can be considered **invalid** because:
-     * * it is not of one of the supported, documented types -
-     *   use [argInvalidType]{@link pentaho.util.error.argInvalidType} instead
-     * * the specific value is not supported, or is out of range -
-     *   use [argOutOfRange]{@link pentaho.util.error.argOutOfRange} instead
-     * * the value is not in an acceptable state
-     * * the value refers to something which does not exist (like a dictionary _key_ which is undefined)
-     * * ...
-     *
-     * You should use this error if none of the other more specific
-     * invalid argument errors applies.
-     *
-     * The `name` property of the returned error object has the value `"ArgumentInvalidError"`.
-     * Additionally, the `argument` property has the name of the argument.
-     *
-     * @example
-     *
-     * define(["pentaho/util/error"], function(error) {
-     *
-     *   function connect(channel) {
-     *
-     *     if(channel && channel.isOpened) {
-     *       throw error.argInvalid("channel", "Channel not free to use.");
-     *     }
-     *
-     *     var handle = channel.open();
-     *     // ...
-     *   }
-     *
-     *   // ...
-     * });
      *
      * @param {string} name The name of the argument.
      * @param {string} reason Text that explains the reason why the argument is considered invalid.
-     * @return {!Error} The created `Error` object.
+     * @return {!ArgumentInvalidError} The created error object.
      */
     argInvalid: function(name, reason) {
-      return createError(
-          Error,
-          andSentence("Argument " + name + " is invalid.", reason),
-          {name: "ArgumentInvalidError", argument: name});
+      return new ArgumentInvalidError(name, reason);
     },
 
     /**
-     * Creates a `TypeError` object for a case where a function argument
+     * Creates an error object for a case where a function argument
      * has been specified, albeit with a value of an unsupported type,
      * according to the documented contract.
-     *
-     * The name of the argument can be that of a nested property,
-     * like, for example, `"keyArgs.description"`.
      *
      * It is up to the caller to actually `throw` the returned `TypeError` object.
      * This makes flow control be clearly visible at the call site.
      *
-     * Types can be:
-     * * one of the possible results of the `typeof` operator,
-     *   like `"number"`, `"string"`, `"boolean"`, `"function"`, ...
-     * * the name of global classes/constructors,
-     *   that would be testable by use of the `instanceof` operator or
-     *   by accessing the `constructor` property,
-     *   like `"Array"`, `"Object"`, or `"HTMLElement"`
-     * * the id of an AMD module that returns a constructor or factory, like `"pentaho/type/complex"`.
-     *
-     * The `name` property of the returned error object has the value `"ArgumentInvalidTypeError"`.
-     * Additionally, the `argument` property has the name of the argument.
-     * Property `expectedTypes` contains an array of the expected type names, and,
-     * property `actualType`, the name of the actual type, if specified, or `undefined`.
-     *
-     * @example
-     *
-     * define(["pentaho/util/error"], function(error) {
-     *
-     *   function createInstance(type, args) {
-     *     var TypeCtor;
-     *
-     *     switch(typeof type) {
-     *       case "string":
-     *         TypeCtor = window[type];
-     *         break;
-     *
-     *       case "function":
-     *         TypeCtor = type;
-     *         break;
-     *
-     *       default:
-     *         throw error.argInvalidType("type", ["string", "function"], typeof type);
-     *     }
-     *
-     *     // ...
-     *   }
-     *
-     *   // ...
-     * });
-     *
      * @param {string} name The name of the argument.
      * @param {string|string[]} expectedType The name or names of the expected types.
      * @param {string} [actualType] The name of the received type, when known.
-     * @return {!TypeError} The created `TypeError` object.
+     * @return {!ArgumentInvalidTypeError} The created error object.
      */
     argInvalidType: function(name, expectedType, actualType) {
-      var typesMsg = "Expected type to be ";
-
-      if(!Array.isArray(expectedType)) expectedType = [expectedType];
-
-      if(expectedType.length > 1) {
-        var expectedTypesClone = expectedType.slice();
-        var lastExpectedType = expectedTypesClone.pop();
-        typesMsg += "one of " + expectedTypesClone.join(", ") + " or " + lastExpectedType;
-      } else {
-        // If should have at least one entry...
-        typesMsg += expectedType[0];
-      }
-
-      typesMsg += actualType ? (", but got " + actualType + ".") : ".";
-
-      return createError(
-          TypeError,
-          andSentence("Argument " + name + " is invalid.", typesMsg),
-          {
-            name: "ArgumentInvalidTypeError",
-            argument: name,
-            actualType: actualType,
-            expectedTypes: expectedType
-          });
+      return new ArgumentInvalidTypeError(name, expectedType, actualType);
     },
 
     /**
-     * Creates an `RangeError` object for a case where a function argument
+     * Creates an error object for a case where a function argument
      * was specified with a value of one of the expected types,
      * albeit not within the expected range.
-     *
-     * The name of the argument can be that of a nested property,
-     * like, for example, `"keyArgs.index"`.
      *
      * It is up to the caller to actually `throw` the returned `RangeError` object.
      * This makes flow control be clearly visible at the call site.
      *
-     * The `name` property of the returned error object has the value `"ArgumentOutOfRangeError"`.
-     * Additionally, the `argument` property has the name of the argument.
-     *
-     * @example
-     *
-     * define(["pentaho/util/error"], function(error) {
-     *
-     *   function insertAt(element, index) {
-     *
-     *     if(index < 0 || index > this.length) {
-     *       throw error.argOutOfRange("index");
-     *     }
-     *
-     *     // Safe to insert at index
-     *     this._elements.splice(index, 0, element);
-     *   }
-     *
-     *   // ...
-     * });
-     *
-     * @param {string} name The name of the argument.
-     * @return {!RangeError} The created `RangeError` object.
+     * @param {string} name The name of the argument.§1§
+     * @return {!pentaho.lang.ArgumentRangeError} The created error object.
      */
-    argOutOfRange: function(name) {
-      return createError(
-          RangeError,
-          "Argument " + name + " is out of range.",
-          {name: "ArgumentOutOfRangeError", argument: name});
+    argRange: function(name) {
+      return new ArgumentRangeError(name);
     },
 
     /**
@@ -267,110 +104,22 @@ define([
      * It is up to the caller to actually `throw` the returned `Error` object.
      * This makes flow control be clearly visible at the call site.
      *
-     * Performing an operation can be considered **invalid** when:
-     * * the object in which it is executed is not in a state that allows the operation to be performed,
-     *   like it is _locked_, _busy_ or _disposed_.
-     * * it cannot be performed on a certain type of object
-     * * ...
-     *
-     * The `name` property of the returned error object has the value `"OperationInvalidError"`.
-     *
-     * @example
-     *
-     * define(["pentaho/util/error"], function(error) {
-     *
-     *   function Cell(value) {
-     *     this._value = value;
-     *     this._locked = false;
-     *   }
-     *
-     *   Cell.prototype = {
-     *     lock: function() {
-     *       this._locked = true;
-     *     },
-     *
-     *     get value() {
-     *       return this._value;
-     *     },
-     *
-     *     set value(v) {
-     *       if(this._locked) {
-     *         throw error.operInvalid("Cell is locked.");
-     *       }
-     *
-     *       this._value = v;
-     *     }
-     *   };
-     *
-     *   // ...
-     * });
-     *
      * @param {string} reason Text that explains the reason why performing the operation is considered invalid.
-     * @return {!Error} The created `Error` object.
+     * @return {!pentaho.lang.OperationInvalidError} The created `Error` object.
      */
     operInvalid: function(reason) {
-      return createError(
-          Error,
-          andSentence("Operation invalid.", reason),
-          {name: "OperationInvalidError"});
+      return new OperationInvalidError(reason);
     },
 
     /**
      * Creates an `Error` object for a case where an _abstract_ method has not been implemented/overridden
      * and is being called.
      *
-     * It is up to the caller to actually `throw` the returned `Error` object.
-     * This makes flow control be clearly visible at the call site.
-     *
-     * The `name` property of the returned error object has the value `"NotImplementedError"`.
-     *
      * @param {?string} [text] Complementary text.
      * @return {!Error} The created `Error` object.
      */
     notImplemented: function(text) {
-      return createError(
-          Error,
-          andSentence("Not Implemented.", text),
-          {name: "NotImplementedError"});
+      return new NotImplementedError(text);
     }
   };
-
-  return error;
-
-  /**
-   * Creates an error object of a given type and with a given message and properties.
-   *
-   * @param {Class.<Error>} ErrorCtor The error constructor.
-   * @param {string} message The error message.
-   * @param {?Object} [props] A map of properties to extend the error object with.
-   *
-   * @return {Error} The created error object.
-   */
-  function createError(ErrorCtor, message, props) {
-    return O.assignOwn(new ErrorCtor(message), props);
-  }
-
-  /**
-   * Appends a sentence to another,
-   * making sure that the appended sentence ends with a period or is, otherwise,
-   * terminated by a punctuation character.
-   *
-   * @param {string} text The initial sentence.
-   * @param {?string} [sentence] A sentence to append to `text`, that can not be properly terminated.
-   * @return {string} A new, terminated sentence.
-   */
-  function andSentence(text, sentence) {
-    return text + (sentence ? (" " + withPeriod(sentence)) : "");
-  }
-
-  /**
-   * Ensures a sentence is terminated with a period or another punctuation character,
-   * like `;`, `?` or `!`.
-   *
-   * @param {string} sentence A possibly unterminated sentence.
-   * @return {string} A new, terminated sentence.
-   */
-  function withPeriod(sentence) {
-    return sentence && !/[.;!?]/.test(sentence[sentence.length - 1]) ? (sentence + ".") : sentence;
-  }
 });

--- a/package-res/resources/web/pentaho/util/text.js
+++ b/package-res/resources/web/pentaho/util/text.js
@@ -54,6 +54,30 @@ define(function() {
         return text.firstUpperCase(name).replace(/([a-z\d])([A-Z])/g, "$1 $2");
       }
       return name;
+    },
+
+    /**
+     * Appends a sentence to another,
+     * making sure that the appended sentence ends with a period or is, otherwise,
+     * terminated by a punctuation character.
+     *
+     * @param {string} text The initial sentence.
+     * @param {?string} [sentence] A sentence to append to `text`, that can not be properly terminated.
+     * @return {string} A new, terminated sentence.
+     */
+    andSentence: function(text, sentence) {
+      return text + (sentence ? (" " + this.withPeriod(sentence)) : "");
+    },
+
+    /**
+     * Ensures a sentence is terminated with a period or another punctuation character,
+     * like `;`, `?` or `!`.
+     *
+     * @param {string} sentence A possibly unterminated sentence.
+     * @return {string} A new, terminated sentence.
+     */
+    withPeriod: function(sentence) {
+      return sentence && !/[.;!?]/.test(sentence[sentence.length - 1]) ? (sentence + ".") : sentence;
     }
   };
 

--- a/package-res/resources/web/pentaho/visual/base/View.js
+++ b/package-res/resources/web/pentaho/visual/base/View.js
@@ -42,8 +42,8 @@ define([
    * @param {HTMLElement} element The DOM element where the visualization should render.
    * An error is thrown if this is not a valid DOM element.
    * @param {pentaho.visual.base.Model} model The base visualization `Model`.
-   * @throws {Error} Argument required. The constructor must be invoked with two arguments.
-   * @throws {Error} Argument invalid. A valid DOM element must be passed to the constructor.
+   *
+   * @throws {pentaho.lang.ArgumentInvalidError} When `element` is not an HTML DOM element.
    */
 
   var View = Base.extend(/** @lends pentaho.visual.base.View# */{

--- a/test-js/unit/pentaho/lang/Base.Spec.js
+++ b/test-js/unit/pentaho/lang/Base.Spec.js
@@ -1642,6 +1642,42 @@ define([
       });
     });
 
+    describe("Base.Error", function() {
+      it("should extend the JavaScript Error class", function() {
+        expect(Base.Error.prototype instanceof Error).toBe(true);
+
+        var o = new Base.Error();
+        expect(o instanceof Error).toBe(true);
+      });
+
+      describe("instances", function() {
+        it("should have __root_proto__ property", function() {
+          var o = new Base.Error();
+          expect(o.__root_proto__).toBe(Base.Error.prototype);
+        });
+
+        it("should respect the specified message", function() {
+          var o = new Base.Error("foo");
+          expect(o.message).toBe("foo");
+        });
+
+        // support depends on engine...
+        it("should have a stack property of type string or undefined", function() {
+          var o = new Base.Error();
+          expect(typeof o.stack === "string" || o.stack === undefined).toBe(true);
+        });
+      });
+
+      describe("when extended", function() {
+        it("should return a subclass of Base.Error", function() {
+          var Top = Base.Error.extend();
+
+          expect(Top).not.toBe(Base.Error);
+          expect(Top.ancestor).toBe(Base.Error);
+        });
+      });
+    });
+
     describe("instances of literal objects", function() {
       describe("when extended", function() {
         var alien;

--- a/test-js/unit/pentaho/type/Context.Spec.js
+++ b/test-js/unit/pentaho/type/Context.Spec.js
@@ -440,7 +440,7 @@ define([
         var context = new Context();
 
         return callGet(context, sync, [123, 234]);
-      }, errorMatch.argInvalid("typeSpec")));
+      }, errorMatch.argInvalid("typeRef")));
 
       it("should be able to create a refinement type using normal notation", testGet(function(sync, Context) {
         var context = new Context();

--- a/test-js/unit/pentaho/type/PropertyMetaCollection.Spec.js
+++ b/test-js/unit/pentaho/type/PropertyMetaCollection.Spec.js
@@ -16,19 +16,17 @@
 define([
   "pentaho/type/Context",
   "pentaho/type/Property",
-  "pentaho/type/boolean",
-  "pentaho/type/string",
   "pentaho/type/PropertyMetaCollection",
-  "pentaho/type/complex"
-], function(Context, Property, booleanFactory, stringFactory, PropertyMetaCollection, complexFactory) {
+  "tests/pentaho/util/errorMatch"
+], function(Context, Property, PropertyMetaCollection, errorMatch) {
   "use strict";
 
   /* global describe:false, it:false, expect:false, beforeEach:false */
 
   var context = new Context();
-  var Boolean = context.get(booleanFactory);
-  var String = context.get(stringFactory);
-  var Complex = context.get(complexFactory);
+  var Boolean = context.get("pentaho/type/boolean");
+  var String = context.get("pentaho/type/string");
+  var Complex = context.get("pentaho/type/complex");
   var Derived = Complex.extend({
     meta: {
       label: "Derived",
@@ -52,7 +50,7 @@ define([
       it("should throw if constructor directly called without a declaring complex", function() {
         expect(function() {
           props = new PropertyMetaCollection();
-        }).toThrowError(/required/);
+        }).toThrow(errorMatch.argRequired("declaringMeta"));
       });
 
       it("should return an object", function() {
@@ -94,7 +92,7 @@ define([
           ].forEach(function(name) {
             expect(function() {
               props.add(name);
-            }).toThrowError(/required/);
+            }).toThrow(errorMatch.argRequired("props[i]"));
           });
         });
 
@@ -110,13 +108,13 @@ define([
           props.add({name: "foo", type: "boolean"});
           expect(function() {
             props.replace({name: "bar", type: "string"}, 0);
-          }).toThrowError(/invalid/);
+          }).toThrow(errorMatch.argInvalid("props[i]"));
         });
 
         it("should throw when calling replace with no arguments", function() {
           expect(function() {
             props.replace();
-          }).toThrowError(/required/);
+          }).toThrow(errorMatch.argRequired("props[i]"));
         });
       });
 
@@ -124,7 +122,7 @@ define([
         it("should throw if invoked with no arguments", function() {
           expect(function() {
             props.configure();
-          }).toThrowError(/config/);
+          }).toThrow(errorMatch.argRequired("config"));
         });
 
         it("should accept an array of pentaho.type.UPropertyMeta", function() {
@@ -159,7 +157,7 @@ define([
         it("should throw when attempting to configure with key that does not match its property name", function() {
           expect(function() {
             props.configure({foo: {name: "bar", type: "boolean"}});
-          }).toThrowError(/config/);
+          }).toThrow(errorMatch.argInvalid("config"));
         });
 
         it("should use the key as property name if the property spec does not include a name", function() {
@@ -192,7 +190,7 @@ define([
       });
     });
 
-    describe("property ineritance", function() {
+    describe("property inheritance", function() {
       var MoreDerived = Derived.extend({
         meta: {
           label: "MoreDerived",
@@ -222,7 +220,7 @@ define([
         it("should throw if using List.add() to override a inherited property's 'type' to something that isn't a subtype of the base property's 'type'", function() {
           expect(function() {
             props.add({name: "foo", type: "boolean"});
-          }).toThrowError(/invalid/);
+          }).toThrow(errorMatch.argInvalid("type"));
         });
 
         it("should use List.replace() to override a inherited property with the same name", function() {
@@ -236,7 +234,7 @@ define([
         it("should throw if using List.replace() to override a inherited property's 'type' to something that isn't a subtype of the base property's 'type'", function() {
           expect(function() {
             props.replace({name: "foo", type: "boolean"}, 0);
-          }).toThrowError(/invalid/);
+          }).toThrow(errorMatch.argInvalid("type"));
         });
       });
     });

--- a/test-js/unit/pentaho/type/complex.Spec.js
+++ b/test-js/unit/pentaho/type/complex.Spec.js
@@ -30,8 +30,39 @@ define([
   var String = context.get("pentaho/type/string");
   var List = context.get("pentaho/type/list");
 
-  describe("pentaho.type.Complex -", function() {
-    describe("anatomy -", function() {
+  function itShouldLenientMethod(getter, args, lenientResult, error) {
+
+    it("should throw when lenient is unspecified", function() {
+      expect(function() { getter(args); }).toThrow(error);
+    });
+
+    it("should throw when lenient is false", function() {
+      var args2 = args.concat(false);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should throw when lenient is null", function() {
+      var args2 = args.concat(null);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should throw when lenient is undefined", function() {
+      var args2 = args.concat(undefined);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should return `" + lenientResult + "` when lenient is true", function() {
+      var args2 = args.concat(true);
+
+      expect(getter(args2)).toBe(lenientResult);
+    });
+  }
+
+  describe("pentaho.type.Complex", function() {
+    describe("anatomy", function() {
       it("is a function", function() {
         expect(typeof Complex).toBe("function");
       });
@@ -57,7 +88,7 @@ define([
       });
     }); // anatomy
 
-    describe(".extend({...}) - the returned value -", function() {
+    describe(".extend({...}) - the returned value", function() {
       it("should be a function", function() {
         var Derived = Complex.extend({
           meta: {
@@ -80,47 +111,65 @@ define([
         expect(Derived.prototype instanceof Complex).toBe(true);
       });
 
-      it(".Meta should be a function", function() {
-        var Derived = Complex.extend({
-          meta: {
-            label: "Derived"
+      describe(".Meta", function() {
+        describe("anatomy", function() {
+          it("should be a function", function() {
+            var Derived = Complex.extend({
+              meta: {
+                label: "Derived"
+              }
+            });
+
+            expect(typeof Derived.Meta).toBe("function");
+          });
+
+          it("should be a sub-class of Complex", function() {
+            var Derived = Complex.extend({
+              meta: {
+                label: "Derived"
+              }
+            });
+
+            expect(Derived.Meta).not.toBe(Value.Meta);
+            expect(Derived.Meta).not.toBe(Complex.Meta);
+            expect(Derived.meta instanceof Complex.Meta).toBe(true);
+          });
+        });
+
+        describe("#has(name)", function() {
+          it("should return false when called with no arguments", function() {
+            expect(Complex.meta.has()).toBe(false);
+          });
+        });
+
+        describe("#at(index[, lenient])", function() {
+          function getter(args) {
+            return Complex.meta.at.apply(Complex.meta, args);
           }
+
+          var lenientResult = null;
+
+          describe("when index is null", function() {
+            var error = errorMatch.argRequired("index");
+            var index = null;
+            itShouldLenientMethod(getter, [index], lenientResult, error);
+          });
+
+          describe("when index is undefined", function() {
+            var error = errorMatch.argRequired("index");
+            var index = undefined;
+            itShouldLenientMethod(getter, [index], lenientResult, error);
+          });
+
+          describe("when index is out of range", function() {
+            var error = errorMatch.argOutOfRange("index");
+            var index = 1;
+            itShouldLenientMethod(getter, [index], lenientResult, error);
+          });
         });
 
-        expect(typeof Derived.Meta).toBe("function");
-      });
-
-      it(".Meta should be a sub-class of Complex", function() {
-        var Derived = Complex.extend({
-          meta: {
-            label: "Derived"
-          }
-        });
-
-        expect(Derived.Meta).not.toBe(Value.Meta);
-        expect(Derived.Meta).not.toBe(Complex.Meta);
-        expect(Derived.meta instanceof Complex.Meta).toBe(true);
-      });
-
-      describe(".Meta properties -", function() {
-        it("#has() should return false when called with no arguments", function() {
-          expect(Complex.meta.has()).toBe(false);
-        });
-
-        it("#at() should throw when called with no argument", function() {
-          expect(function() { Complex.meta.at(); }).toThrow(errorMatch.argRequired("index"));
-        });
-
-        it("#at() should throw when called with nully argument", function() {
-          expect(function() { Complex.meta.at(null); }).toThrow(errorMatch.argRequired("index"));
-        });
-
-        it("#at() should return null if index doesn't exists", function() {
-          expect(Complex.meta.at(1)).toBe(null);
-        });
-
-        describe("#add -", function() {
-          it("should add new properties", function () {
+        describe("#add", function() {
+          it("should add new properties", function() {
             var Derived = Complex.extend({
               meta: {
                 name: "derived",
@@ -141,7 +190,7 @@ define([
           });
         });
 
-        describe("when not specified or specified empty -", function() {
+        describe("when props is not specified or specified empty", function() {
           it("should have no properties", function() {
             var Derived = Complex.extend({
               meta: {
@@ -202,10 +251,10 @@ define([
           });
         }); // when [#props is] not specified or specified empty
 
-        describe("when specified non-empty -", function() {
+        describe("when props is specified non-empty", function() {
 
           // string
-          describe("with a single 'string' entry -", function() {
+          describe("with a single 'string' entry", function() {
             var Derived = Complex.extend({
               meta: {
                 name: "derived",
@@ -226,7 +275,7 @@ define([
               expect(Derived.meta.has("fooBar2")).toBe(false);
             });
 
-            describe("the single property meta -", function() {
+            describe("the single property meta", function() {
               var propMeta = Derived.meta.at(0);
 
               it("#has() should return true for a defined property", function() {
@@ -279,7 +328,7 @@ define([
             });
           });
 
-          describe("with two entries -", function() {
+          describe("with two entries", function() {
             var Derived = Complex.extend({
               meta: {
                 label: "Derived",
@@ -313,7 +362,7 @@ define([
             });
           });
 
-          describe("with an entry that overrides a base type property -", function() {
+          describe("with an entry that overrides a base type property", function() {
             var A = Complex.extend({
               meta: {
                 label: "A",
@@ -355,7 +404,7 @@ define([
             });
           });
 
-          describe("with an entry that is not a base type property -", function() {
+          describe("with an entry that is not a base type property", function() {
             var A = Complex.extend({
               meta: {
                 label: "A",
@@ -380,7 +429,7 @@ define([
             });
           });
 
-          describe("with a dictionary -", function() {
+          describe("with a dictionary", function() {
             it("should define the defined properties", function() {
               var A = Complex.extend({
                 meta: {
@@ -453,7 +502,7 @@ define([
 
     }); // .extend({...})
 
-    describe("new Complex() -", function() {
+    describe("new Complex()", function() {
       it("should be possible to create an instance with no arguments", function() {
         new Complex();
       });
@@ -468,7 +517,7 @@ define([
       });
     });
 
-    describe("new DerivedComplex() -", function() {
+    describe("new DerivedComplex()", function() {
       var Derived;
 
       beforeEach(function() {
@@ -484,7 +533,7 @@ define([
         });
       });
 
-      describe("when given empty arguments -", function() {
+      describe("when given empty arguments", function() {
         it("should not throw", function() {
           new Derived();
         });
@@ -543,10 +592,9 @@ define([
           expect(derived.get("z").at(0).formatted).toBe("0.0 POUNDS");
         });
       });
-
     });
 
-    describe("#uid -", function() {
+    describe("#uid", function() {
       it("should return a string value", function() {
         var uid = new Complex().uid;
         expect(typeof uid).toBe("string");
@@ -562,14 +610,14 @@ define([
       });
     });
 
-    describe("#key -", function() {
+    describe("#key", function() {
       it("should return the value of #uid", function() {
         var value = new Complex();
         expect(value.uid).toBe(value.key);
       });
     });
 
-    describe("#get(name, lenient)", function() {
+    describe("#get(name[, lenient])", function() {
       it("should return the `Value` of an existing singular property", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x", type: "string"}]}
@@ -764,7 +812,7 @@ define([
       });
     });
 
-    describe("#getv(name, index)", function() {
+    describe("#getv(name, index[, lenient])", function() {
       it("should return the value of an existing property", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x", type: "string"}]}
@@ -776,15 +824,20 @@ define([
         expect(value).toBe("1");
       });
 
-      it("should return null for a requested index on a non-list property", function() {
+      describe("when name is that of an element property and index is non-zero", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x", type: "string"}]}
         });
 
         var derived = new Derived({x: "1"});
 
-        var value = derived.getv("x", 2);
-        expect(value).toBe(undefined);
+        var getter = function(args) {
+          return derived.getv.apply(derived, args);
+        };
+
+        var lenientResult = undefined;
+
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
       });
 
       it("should return first value if no index provided for a list property", function() {
@@ -809,27 +862,36 @@ define([
         expect(value).toBe("2");
       });
 
-      it("should return undefined for an out of range requested index value of an existing list property", function() {
+      describe("when name is that of an existing list property and index is out of range", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x", type: ["string"]}]}
         });
 
         var derived = new Derived({"x": ["1", "2"]});
 
-        var value = derived.getv("x", 2);
-        expect(value).toBe(undefined);
+        var getter = function(args) {
+          return derived.getv.apply(derived, args);
+        };
+
+        var lenientResult = undefined;
+
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
       });
 
-      it("should throw when given the name of an undefined property", function() {
+      describe("when name is that of an undefined property", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x"}]}
         });
 
         var derived = new Derived();
 
-        expect(function() {
-          derived.getv("y");
-        }).toThrow(errorMatch.argInvalid("name"));
+        var getter = function(args) {
+          return derived.getv.apply(derived, args);
+        };
+
+        var lenientResult = undefined;
+
+        itShouldLenientMethod(getter, ["y", 0], lenientResult, errorMatch.argInvalid("name"));
       });
     });
 
@@ -867,27 +929,52 @@ define([
         expect(value).toBe("2");
       });
 
-      it("should return empty string for an out of range requested index value of an existing list property", function() {
+      describe("when name is that of an element property and index is non-zero", function() {
+        var Derived = Complex.extend({
+          meta: {props: [{name: "x", type: "string"}]}
+        });
+
+        var derived = new Derived({x: "1"});
+
+        var getter = function(args) {
+          return derived.getf.apply(derived, args);
+        };
+
+        var lenientResult = "";
+
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
+      });
+
+      describe("when name is that of an existing list property and index is out of range", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x", type: ["string"]}]}
         });
 
         var derived = new Derived({"x": ["1", "2"]});
 
-        var value = derived.getf("x", 2);
-        expect(value).toBe("");
+        var getter = function(args) {
+          return derived.getf.apply(derived, args);
+        };
+
+        var lenientResult = "";
+
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
       });
 
-      it("should throw when given the name of an undefined property", function() {
+      describe("when name is that of an undefined property", function() {
         var Derived = Complex.extend({
           meta: {props: [{name: "x"}]}
         });
 
         var derived = new Derived();
 
-        expect(function() {
-          derived.getf("y");
-        }).toThrow(errorMatch.argInvalid("name"));
+        var getter = function(args) {
+          return derived.getf.apply(derived, args);
+        };
+
+        var lenientResult = "";
+
+        itShouldLenientMethod(getter, ["y", 0], lenientResult, errorMatch.argInvalid("name"));
       });
     });
 
@@ -1278,7 +1365,7 @@ define([
         expect(derived.path("x", "y", 1)).toBe(null);
       });
 
-      it("should throw if a path having multiple steps has an undefined property name along the way", function() {
+      it("should return null if a path having multiple steps has an undefined property name along the way", function() {
         var Derived = Complex.extend({
           meta: {
             props: [
@@ -1296,10 +1383,7 @@ define([
 
         var derived = new Derived({x: {y: [1]}});
 
-        expect(function() {
-          derived.path("x", "z", 1);
-        }).toThrow(errorMatch.argInvalid("name"));
-
+        expect(derived.path("x", "z", 1)).toBe(null);
       });
     }); // end path
 

--- a/test-js/unit/pentaho/type/complex.Spec.js
+++ b/test-js/unit/pentaho/type/complex.Spec.js
@@ -162,7 +162,7 @@ define([
           });
 
           describe("when index is out of range", function() {
-            var error = errorMatch.argOutOfRange("index");
+            var error = errorMatch.argRange("index");
             var index = 1;
             itShouldLenientMethod(getter, [index], lenientResult, error);
           });
@@ -837,7 +837,7 @@ define([
 
         var lenientResult = undefined;
 
-        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argRange("index"));
       });
 
       it("should return first value if no index provided for a list property", function() {
@@ -875,7 +875,7 @@ define([
 
         var lenientResult = undefined;
 
-        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argRange("index"));
       });
 
       describe("when name is that of an undefined property", function() {
@@ -942,7 +942,7 @@ define([
 
         var lenientResult = "";
 
-        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argRange("index"));
       });
 
       describe("when name is that of an existing list property and index is out of range", function() {
@@ -958,7 +958,7 @@ define([
 
         var lenientResult = "";
 
-        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argOutOfRange("index"));
+        itShouldLenientMethod(getter, ["x", 2], lenientResult, errorMatch.argRange("index"));
       });
 
       describe("when name is that of an undefined property", function() {
@@ -1267,6 +1267,16 @@ define([
         expect(function() {
           derived.count("y");
         }).toThrow(errorMatch.argInvalid("name"));
+      });
+
+      it("should return 0 when lenient and given the name of an undefined property", function() {
+        var Derived = Complex.extend({
+          meta: {props: [{name: "x"}]}
+        });
+
+        var derived = new Derived();
+
+        expect(derived.count("y", true)).toBe(0);
       });
     }); // end count
 

--- a/test-js/unit/pentaho/type/list.Spec.js
+++ b/test-js/unit/pentaho/type/list.Spec.js
@@ -373,7 +373,7 @@ define([
         }
 
         var lenientResult = null;
-        var error = errorMatch.argOutOfRange("index");
+        var error = errorMatch.argRange("index");
         var index = -10;
 
         itShouldLenientMethod(getter, [index], lenientResult, error);
@@ -401,7 +401,7 @@ define([
         }
 
         var lenientResult = null;
-        var error = errorMatch.argOutOfRange("index");
+        var error = errorMatch.argRange("index");
         var index = 10;
 
         itShouldLenientMethod(getter, [index], lenientResult, error);
@@ -415,7 +415,7 @@ define([
         }
 
         var lenientResult = null;
-        var error = errorMatch.argOutOfRange("index");
+        var error = errorMatch.argRange("index");
         var index = 10;
 
         itShouldLenientMethod(getter, [index], lenientResult, error);

--- a/test-js/unit/pentaho/type/list.Spec.js
+++ b/test-js/unit/pentaho/type/list.Spec.js
@@ -28,7 +28,38 @@ define([
   var context = new Context(),
       Value = context.get(valueFactory),
       List = context.get(listFactory),
-      Number = context.get(numberFactory);
+      PentahoNumber = context.get(numberFactory);
+
+  function itShouldLenientMethod(getter, args, lenientResult, error) {
+
+    it("should throw when lenient is unspecified", function() {
+      expect(function() { getter(args); }).toThrow(error);
+    });
+
+    it("should throw when lenient is false", function() {
+      var args2 = args.concat(false);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should throw when lenient is null", function() {
+      var args2 = args.concat(null);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should throw when lenient is undefined", function() {
+      var args2 = args.concat(undefined);
+
+      expect(function() { getter(args2); }).toThrow(error);
+    });
+
+    it("should return `" + lenientResult + "` when lenient is true", function() {
+      var args2 = args.concat(true);
+
+      expect(getter(args2)).toBe(lenientResult);
+    });
+  }
 
   function expectNoChanges(list) {
     expect(list._changes).toBe(null);
@@ -36,7 +67,7 @@ define([
   }
 
   var NumberList = List.extend({
-    meta: {of: Number}
+    meta: {of: PentahoNumber}
   });
 
   describe("pentaho.type.List -", function() {
@@ -50,7 +81,7 @@ define([
       // NOTE: see also refinement.Spec.js, list usage unit tests
 
       it("accepts an `of` property be given a type derived from `Element`", function() {
-        expect(NumberList.meta.of).toBe(Number.meta);
+        expect(NumberList.meta.of).toBe(PentahoNumber.meta);
       });
 
       it("should throw if given a nully `of` property", function() {
@@ -89,7 +120,7 @@ define([
         var SubList = List.extend();
 
         expect(function() {
-          SubList.meta.of = Number;
+          SubList.meta.of = PentahoNumber;
         }).toThrow(errorMatch.operInvalid());
       });
 
@@ -181,9 +212,9 @@ define([
           var list = new NumberList([1, 2, 3]);
           var elems = list._elems;
 
-          expect(elems[1] instanceof Number).toBe(true);
-          expect(elems[0] instanceof Number).toBe(true);
-          expect(elems[2] instanceof Number).toBe(true);
+          expect(elems[1] instanceof PentahoNumber).toBe(true);
+          expect(elems[0] instanceof PentahoNumber).toBe(true);
+          expect(elems[2] instanceof PentahoNumber).toBe(true);
 
           expect(elems[0].value).toBe(1);
           expect(elems[1].value).toBe(2);
@@ -212,9 +243,9 @@ define([
           var list = new NumberList({d: [1, 2, 3]});
           var elems = list._elems;
 
-          expect(elems[1] instanceof Number).toBe(true);
-          expect(elems[0] instanceof Number).toBe(true);
-          expect(elems[2] instanceof Number).toBe(true);
+          expect(elems[1] instanceof PentahoNumber).toBe(true);
+          expect(elems[0] instanceof PentahoNumber).toBe(true);
+          expect(elems[2] instanceof PentahoNumber).toBe(true);
 
           expect(elems[0].value).toBe(1);
           expect(elems[1].value).toBe(2);
@@ -246,9 +277,9 @@ define([
           var list2 = new NumberList(list1);
           var elems = list2._elems;
 
-          expect(elems[1] instanceof Number).toBe(true);
-          expect(elems[0] instanceof Number).toBe(true);
-          expect(elems[2] instanceof Number).toBe(true);
+          expect(elems[1] instanceof PentahoNumber).toBe(true);
+          expect(elems[0] instanceof PentahoNumber).toBe(true);
+          expect(elems[2] instanceof PentahoNumber).toBe(true);
 
           expect(elems[0].value).toBe(1);
           expect(elems[1].value).toBe(2);
@@ -334,20 +365,60 @@ define([
         expect(list.at(2).value).toBe(3);
       });
 
-      it("should return `null` when the index is negative", function() {
+      describe("when the index is negative", function() {
         var list = new NumberList([1, 2, 3]);
 
-        expect(list.at(-10)).toBe(null);
+        function getter(args) {
+          return list.at.apply(list, args);
+        }
+
+        var lenientResult = null;
+        var error = errorMatch.argOutOfRange("index");
+        var index = -10;
+
+        itShouldLenientMethod(getter, [index], lenientResult, error);
       });
 
-      it("should return `null` when the index is not less than the number of elements", function() {
+      describe("when the index is null", function() {
         var list = new NumberList([1, 2, 3]);
 
-        expect(list.at(10)).toBe(null);
+        function getter(args) {
+          return list.at.apply(list, args);
+        }
 
-        list = new NumberList();
+        var lenientResult = null;
+        var error = errorMatch.argRequired("index");
+        var index = null;
 
-        expect(list.at(10)).toBe(null);
+        itShouldLenientMethod(getter, [index], lenientResult, error);
+      });
+
+      describe("when the index is not less than the number of elements", function() {
+        var list = new NumberList([1, 2, 3]);
+
+        function getter(args) {
+          return list.at.apply(list, args);
+        }
+
+        var lenientResult = null;
+        var error = errorMatch.argOutOfRange("index");
+        var index = 10;
+
+        itShouldLenientMethod(getter, [index], lenientResult, error);
+      });
+
+      describe("when the index is positive and there are no elements", function() {
+        var list = new NumberList([]);
+
+        function getter(args) {
+          return list.at.apply(list, args);
+        }
+
+        var lenientResult = null;
+        var error = errorMatch.argOutOfRange("index");
+        var index = 10;
+
+        itShouldLenientMethod(getter, [index], lenientResult, error);
       });
     });
 
@@ -426,12 +497,12 @@ define([
 
       it("should return `false` when a given element is not present", function() {
         var list = new NumberList([1, 2, 3]);
-        expect(list.includes(new Number(4))).toBe(false);
+        expect(list.includes(new PentahoNumber(4))).toBe(false);
       });
 
       it("should return `false` when a given element is not present although it is equal", function() {
         var list = new NumberList([1, 2, 3]);
-        expect(list.includes(new Number(1))).toBe(false);
+        expect(list.includes(new PentahoNumber(1))).toBe(false);
       });
     });
 
@@ -452,12 +523,12 @@ define([
 
       it("should return `-1` when a given element is not present", function() {
         var list = new NumberList([1, 2, 3]);
-        expect(list.indexOf(new Number(4))).toBe(-1);
+        expect(list.indexOf(new PentahoNumber(4))).toBe(-1);
       });
 
       it("should return `-1` when a given element is not present although it is equal", function() {
         var list = new NumberList([1, 2, 3]);
-        expect(list.indexOf(new Number(1))).toBe(-1);
+        expect(list.indexOf(new PentahoNumber(1))).toBe(-1);
       });
     });
     //endregion
@@ -588,7 +659,8 @@ define([
     // insert or update
     describe("#insert(fragment, index) -", function() {
 
-      it("should append a given array of convertible values, to an empty list, when index is not specified", function() {
+      it("should append a given array of convertible values, to an empty list, when index is not specified",
+      function() {
 
         var list = new NumberList();
 
@@ -600,7 +672,8 @@ define([
         expect(list.at(2).value).toBe(3);
       });
 
-      it("should append a given array of convertible values to a non-empty list, when index is not specified", function() {
+      it("should append a given array of convertible values to a non-empty list, when index is not specified",
+      function() {
 
         var list = new NumberList([1, 2, 3]);
 
@@ -618,7 +691,8 @@ define([
         expect(list.at(5).value).toBe(6);
       });
 
-      it("should insert a given array of convertible values to a non-empty list, at the specified existing index", function() {
+      it("should insert a given array of convertible values to a non-empty list, at the specified existing index",
+      function() {
 
         var list = new NumberList([1, 2, 3]);
 
@@ -807,20 +881,21 @@ define([
 
         // ----
 
-        list.remove(new Number(5));
+        list.remove(new PentahoNumber(5));
 
         // ----
 
         expect(list.count).toBe(4);
       });
 
-      it("should ignore a given element that is not present in the list, although it is equal to one that is", function() {
+      it("should ignore a given element that is not present in the list, although it is equal to one that is",
+      function() {
         var list = new NumberList([1, 2, 3, 4]);
         expect(list.count).toBe(4);
 
         // ----
 
-        list.remove(new Number(4));
+        list.remove(new PentahoNumber(4));
 
         // ----
 

--- a/test-js/unit/pentaho/type/value.Spec.js
+++ b/test-js/unit/pentaho/type/value.Spec.js
@@ -16,9 +16,9 @@
 define([
   "pentaho/type/Item",
   "pentaho/type/Context",
-  "pentaho/util/error",
+  "tests/pentaho/util/errorMatch",
   "pentaho/i18n!/pentaho/type/i18n/types"
-], function(Item, Context, error, bundle) {
+], function(Item, Context, errorMatch, bundle) {
 
   "use strict";
 
@@ -204,10 +204,7 @@ define([
 
           expect(function() {
             String.meta.create({_: "pentaho/type/number", v: 1});
-          }).toThrowError(
-              error.operInvalid(
-                  bundle.format(
-                      bundle.structured.errors.value.notOfExpectedBaseType, ["pentaho/type/string"])).message);
+          }).toThrow(errorMatch.operInvalid());
         });
 
         it("should not throw if given a type-annotated value that does extend from the given baseType", function() {
@@ -225,10 +222,7 @@ define([
 
           expect(function() {
             Value.meta.create({_: MyAbstract});
-          }).toThrowError(
-              error.operInvalid(
-                  bundle.format(
-                      bundle.structured.errors.value.cannotCreateInstanceOfAbstractType, ["Complex"])).message);
+          }).toThrow(errorMatch.operInvalid());
         });
 
         it("should throw if given a value and called on an abstract type", function() {
@@ -236,10 +230,7 @@ define([
 
           expect(function() {
             MyAbstract.meta.create({});
-          }).toThrowError(
-              error.operInvalid(
-                  bundle.format(
-                      bundle.structured.errors.value.cannotCreateInstanceOfAbstractType, ["Complex"])).message);
+          }).toThrow(errorMatch.operInvalid());
         });
 
         // ---

--- a/test-js/unit/pentaho/type/value.refine.Spec.js
+++ b/test-js/unit/pentaho/type/value.refine.Spec.js
@@ -65,6 +65,9 @@ define([
 
       MyRefinement = Element.refine("FOO");
       expect(MyRefinement.prototype instanceof Refinement).toBe(true);
+
+      MyRefinement = Element.refine({});
+      expect(MyRefinement.prototype instanceof Refinement).toBe(true);
     });
   });
 });

--- a/test-js/unit/pentaho/type/value.refine.Spec.js
+++ b/test-js/unit/pentaho/type/value.refine.Spec.js
@@ -59,24 +59,12 @@ define([
       expect(MyRefinement.name || MyRefinement.displayName).toBe("FOOO");
     });
 
-    it("should throw if instSpec is not specified", function() {
-      expect(function() {
-        Element.refine();
-      }).toThrow(errorMatch.argRequired("instSpec"));
+    it("should create a refinement type if instSpec is not specified", function() {
+      var MyRefinement = Element.refine();
+      expect(MyRefinement.prototype instanceof Refinement).toBe(true);
 
-      expect(function() {
-        Element.refine("FOO");
-      }).toThrow(errorMatch.argRequired("instSpec"));
-    });
-
-    it("should throw if instSpec.meta is not specified", function() {
-      expect(function() {
-        Element.refine({});
-      }).toThrow(errorMatch.argRequired("instSpec.meta"));
-
-      expect(function() {
-        Element.refine("FOO", {});
-      }).toThrow(errorMatch.argRequired("instSpec.meta"));
+      MyRefinement = Element.refine("FOO");
+      expect(MyRefinement.prototype instanceof Refinement).toBe(true);
     });
   });
 });

--- a/test-js/unit/pentaho/util/error.Spec.js
+++ b/test-js/unit/pentaho/util/error.Spec.js
@@ -58,7 +58,7 @@ define([
       itShouldHaveMessage("argInvalid", ["foo", "bar"], "Argument foo is invalid. bar.");
     });
 
-    describe("argInvalidType(name, [expectedType], (gotType)) -", function() {
+    describe("argInvalidType(name, [expectedType], (actualType)) -", function() {
       it("should be a function", function() {
         expect(typeof error.argInvalidType).toBe("function");
       });
@@ -85,12 +85,12 @@ define([
           "Argument foo is invalid. Expected type to be one of string, function or Array, but got boolean.");
     });
 
-    describe("argOutOfRange(name) -", function() {
+    describe("argRange(name) -", function() {
       it("should be a function", function() {
-        expect(typeof error.argOutOfRange).toBe("function");
+        expect(typeof error.argRange).toBe("function");
       });
 
-      itShouldHaveMessage("argOutOfRange", ["foo"], "Argument foo is out of range.");
+      itShouldHaveMessage("argRange", ["foo"], "Argument foo is out of range.");
     });
 
     describe("operInvalid((text)) -", function() {


### PR DESCRIPTION
* Made the error classes public, as they were showing up in public documented
  methods in any way.
* Left the private pentaho/util/error façade there, although now it is simply
  a mostly empty convenience for not having to require many Error class modules...
* Adapted the testing errorMatch utility
* Moved pentaho/util/error's inner methods to pentaho/util/text
* Added a new Base root for errors: Base.Error, that derives from the native
  Error class.

@pentaho/millenniumfalcon please review.

This PR depends on the previous PR https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/644, so don't merge before that one.