### PR TITLE
Testing requirejs - DO NOT MERGE

### DIFF
--- a/config/karma.ci.conf.js
+++ b/config/karma.ci.conf.js
@@ -25,6 +25,7 @@ module.exports = function (config) {
       // AMD configuration
       "build-res/requireCfg-raw.js",
       "test-js/unit/require-config.js",
+      "test-js/unit/require-test.js",
 
       // TEST files (must be after require-config.js, or it is not included)
       {pattern: "test-js/unit/**", included: false},

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = function (config) {
       // AMD configuration
       "build-res/requireCfg-raw.js",
       "test-js/unit/require-config.js",
+      "test-js/unit/require-test.js",
 
       // TEST files (must be after require-config.js, or it is not included)
       {pattern: "test-js/unit/**", included: false},

--- a/config/nodojo.karma.conf.js
+++ b/config/nodojo.karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function (config) {
       // AMD configuration
       "build-res/requireCfg-raw.js",
       "test-js/unit/require-config.js",
+      "test-js/unit/require-test.js",
 
       // TEST files (must be after require-config.js, or it is not included)
       {pattern: "test-js/unit/**", included: false},

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 define([
+  "require",
   "module",
   "./Item",
   "../i18n!types",
@@ -24,7 +25,7 @@ define([
   "../util/error",
   "../util/object",
   "../util/fun"
-], function(module, Item, bundle, standard, Base, promiseUtil, arg, error, O, F) {
+], function(localRequire, module, Item, bundle, standard, Base, promiseUtil, arg, error, O, F) {
 
   "use strict";
 
@@ -415,7 +416,7 @@ define([
 
         var predicate = F.predicate(keyArgs);
         var me = this;
-        return promiseUtil.require("pentaho/service!" + baseTypeId)
+        return promiseUtil.require("pentaho/service!" + baseTypeId, localRequire)
             .then(function(factories) {
               return Promise.all(factories.map(me.getAsync, me));
             })
@@ -502,8 +503,8 @@ define([
       return sync
           // `require` fails if a module with the id in the `typeSpec` var
           // is not already _loaded_.
-          ? this._get(require(id), true)
-          : promiseUtil.require(id).then(this._get.bind(this));
+          ? this._get(localRequire(id), true)
+          : promiseUtil.require(id, localRequire).then(this._get.bind(this));
     },
 
     /**
@@ -682,7 +683,7 @@ define([
       var customTypeIds = collectTypeIds(typeSpec);
       return customTypeIds.length
           // Require them all and only then invoke the synchronous BaseMeta.extend method.
-          ? promiseUtil.require(customTypeIds).then(resolveSync)
+          ? promiseUtil.require(customTypeIds, localRequire).then(resolveSync)
           // All types are standard and can be assumed to be already loaded.
           // However, we should behave asynchronously as requested.
           : promiseUtil.wrapCall(resolveSync);

--- a/package-res/resources/web/pentaho/type/Item.Meta.js
+++ b/package-res/resources/web/pentaho/type/Item.Meta.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 define([
+  "require",
   "../i18n!types",
   "../lang/Base",
   "../lang/_AnnotatableLinked",
@@ -21,7 +22,7 @@ define([
   "../util/arg",
   "../util/object",
   "../util/promise"
-], function(bundle, Base, AnnotatableLinked, error, arg, O, promiseUtil) {
+], function(localRequire, bundle, Base, AnnotatableLinked, error, arg, O, promiseUtil) {
   "use strict";
 
   // Unique item class id exposed through Item.Meta#uid and used by Context instances.
@@ -639,7 +640,7 @@ define([
      */
     get viewClass() {
       var view = this._view;
-      return view && (view.promise || (view.promise = promiseUtil.require(view.value)));
+      return view && (view.promise || (view.promise = promiseUtil.require(view.value, localRequire)));
     },
     //endregion
 

--- a/package-res/resources/web/pentaho/type/refinement.js
+++ b/package-res/resources/web/pentaho/type/refinement.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 define([
+  "require",
   "module",
   "./facets/Refinement",
   "./valueHelper",
@@ -21,7 +22,7 @@ define([
   "../util/error",
   "../util/fun",
   "../i18n!types"
-], function(module, RefinementFacet, valueHelper, O, error, F, bundle) {
+], function(localRequire, module, RefinementFacet, valueHelper, O, error, F, bundle) {
 
   "use strict";
 
@@ -348,7 +349,7 @@ define([
             if(id.indexOf("/") < 0)
               id = _baseFacetsMid + id;
 
-            return require(id);
+            return localRequire(id);
           }
         },
         //endregion

--- a/package-res/resources/web/pentaho/util/has.js
+++ b/package-res/resources/web/pentaho/util/has.js
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([], function() {
+  "use strict";
+
+  var capabilities = {
+    "Object.setPrototypeOf": Object.setPrototypeOf != null,
+    "Object.prototype.__proto__": {}.__proto__ != null
+  };
+
+  return capabilities;
+});

--- a/package-res/resources/web/pentaho/util/object.js
+++ b/package-res/resources/web/pentaho/util/object.js
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(function() {
+define(["pentaho/util/has"], function(has) {
   "use strict";
 
   var O_hasOwn = Object.prototype.hasOwnProperty,
-      A_empty  = [],
-      setProtoOf = Object.setPrototypeOf || ({}.__proto__ ? setProtoProp : setProtoCopy);
+    A_empty  = [],
+    setProtoOf = has["Object.setPrototypeOf"] ? Object.setPrototypeOf : (has["Object.prototype.__proto__"] ? setProtoProp : setProtoCopy);
 
   /**
    * The `object` namespace contains functions for

--- a/test-js/unit/pentaho/util/robject.Spec.js
+++ b/test-js/unit/pentaho/util/robject.Spec.js
@@ -1,0 +1,115 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function() {
+  "use strict";
+
+  /*global describe:false, it:false, expect:false, beforeEach:false, beforeAll:false, Object:false*/
+
+  describe("squire pentaho.util.object - ", function() {
+    var Spam, protoEggs, parrot;
+
+    beforeEach(function() {
+      Spam = function() {
+        this.bar = "bar";
+      };
+      Spam.prototype = new (function() {
+        this.spam = "spam";
+      })();
+      parrot = new Spam();
+
+      var myProto = function() {
+        this.spam = "eggs";
+      };
+      protoEggs = new myProto();
+    });
+
+    it("should return the input object, if the desired prototype is an object", function(done){
+      var localRequire = require.new();
+
+      localRequire(["pentaho/util/object"], function(O) {
+        expect(O.setPrototypeOf(parrot, protoEggs)).toBe(parrot);
+
+        localRequire.dispose();
+        done();
+      });
+    });
+  });
+
+  describe("squire-mocking pentaho.util.object", function() {
+
+    var Spam, protoEggs, parrot;
+    beforeEach(function() {
+
+      Spam = function() {
+        this.bar = "bar";
+      };
+      Spam.prototype = new (function() {
+        this.spam = "spam";
+      })();
+      parrot = new Spam();
+
+      var myProto = function() {
+        this.spam = "eggs";
+      };
+      protoEggs = new myProto();
+    });
+
+
+    [{
+      label: "setProtoProp",
+      has: {
+        "Object.setPrototypeOf": false,
+        "Object.prototype.__proto__": true
+      }
+    }, {
+      label: "ES5",
+      has: {
+        "Object.setPrototypeOf": true,
+        "Object.prototype.__proto__": true
+      }
+    }, {
+      label: "setProtoCopy",
+      has: {
+        "Object.setPrototypeOf": false,
+        "Object.prototype.__proto__": false
+      }
+    }].forEach(function(conf) {
+
+      it("should return the input object, if the desired prototype is an object - " + conf.label, function(done) {
+
+        var localRequire = require.new()
+              .define("pentaho/util/has", conf.has);
+
+        localRequire(["pentaho/util/object"], function(O) {
+          try {
+            var result = O.setPrototypeOf(parrot, protoEggs);
+            expect(result).toBe(parrot);
+
+            // Dispose context
+            localRequire.dispose();
+
+            done();
+          } catch(ex) {
+            done.fail(ex);
+          }
+        }, done.fail);
+      });
+
+    });
+  });
+
+
+}); // pentaho.util.object

--- a/test-js/unit/require-config.js
+++ b/test-js/unit/require-config.js
@@ -26,6 +26,9 @@
 
   /*global requireCfg:false, window:false, KARMA_DEBUG:false*/
 
+  // ignore better written in dot notation error
+  /*jshint sub:true*/
+
   // Karma serves files from '/base'
 
   requireCfg.baseUrl = "/base/build-res/module-scripts/";

--- a/test-js/unit/require-test.js
+++ b/test-js/unit/require-test.js
@@ -29,7 +29,7 @@
    * To apply additional configurations to the context, call the `config` method.
    *
    * To provide module definitions to the context, call the `define` method.
-   * Only non-anonymous methods are supported.
+   * Only non-anonymous modules are supported.
    *
    * To dispose the context, call the `dispose` method.
    *

--- a/test-js/unit/require-test.js
+++ b/test-js/unit/require-test.js
@@ -1,0 +1,187 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function() {
+
+  "use strict";
+
+  /*global require:false */
+
+  var _nextUid = 1;
+
+  /**
+   * Creates a new RequireJS context and returns its `require` function.
+   *
+   * The new context's initial configuration is that of the parent context.
+   *
+   * To apply additional configurations to the context, call the `config` method.
+   *
+   * To provide module definitions to the context, call the `define` method.
+   * Only non-anonymous methods are supported.
+   *
+   * To dispose the context, call the `dispose` method.
+   *
+   * @alias new
+   * @return {function} A contextual, disposable require function.
+   */
+  require.new = function() {
+    // Get a new, unique name for the context.
+    // Create the new context with a configuration cloned from the parent or default context.
+    var name           = newContextName();
+    var parentName     = this.contextName || "_";
+    var config         = newContextConfig(name, parentName);
+    var contextRequire = require.config(config);
+    var context        = getContextByName(name);
+
+    /**
+     * The name of the context.
+     *
+     * @alias contextName
+     * @type {string}
+     */
+    contextRequire.contextName = name;
+
+    contextRequire.new = require.newContext;
+
+    /**
+     * Configures the context.
+     *
+     * @alias config
+     * @param {Object} config The configuration.
+     * @return {function} The `require` function.
+     */
+    contextRequire.config = function(config) {
+      context.configure(config);
+      return this;
+    };
+
+    /**
+     * Defines a module in the context.
+     *
+     * @alias define
+     * @param {string} id The module id.
+     * @param {string[]} [deps] The ids of dependencies.
+     * @param {function|any} callback The module definition function or the module's value.
+     * @return {function} The `require` function.
+     */
+    contextRequire.define = function(id, deps, callback) {
+      if(typeof id !== "string")
+        throw new Error("Argument 'id' is required. Anonymous modules are not supported.");
+
+      // This module may not have dependencies
+      if(!Array.isArray(deps)) {
+        callback = deps;
+        deps = null;
+      }
+
+      if(!deps && typeof callback === "function") {
+        deps = [];
+      }
+
+      // Publish module in this context's queue.
+      // A require call will process these first.
+      context.defQueue.push([id, deps, callback]);
+      context.defQueueMap[id] = true;
+
+      return this;
+    };
+
+    /**
+     * Disposes the context.
+     * @alias dispose
+     */
+    contextRequire.dispose = function() {
+      delete require.s.contexts[name];
+    };
+
+    return contextRequire;
+  };
+
+  // ---
+
+  function newContextName() {
+    return "_NEW_" + (_nextUid++);
+  }
+
+  function getContextByName(name) {
+    return require.s.contexts[name];
+  }
+
+  function newContextConfig(contextName, parentName) {
+    var configClone = {
+      context: contextName
+    };
+
+    var parentContext = getContextByName(parentName);
+
+    if(parentContext) eachProp(parentContext.config, function(v, p) {
+      switch(p) {
+        // Don't apply to non-default contexts or are internal state.
+        case "deps":
+        case "callback":
+        case "context": // shouldn't happen
+        case "pkgs": return; // ignore
+
+
+        case "shim": v = cloneConfigShims(v); break;
+
+        // Object deep clone
+        case "packages":
+        case "paths":
+        case "bundles":
+        case "config":
+        case "map": v = cloneDeep(v); break;
+      }
+
+      configClone[p] = v;
+    });
+
+    return configClone;
+  }
+
+  function cloneConfigShims(shims) {
+    var shimsClone = {};
+
+    // Make sure to exclude internally computed property 'exportsFn'
+    eachProp(shims, function(shim, mid) {
+      shimsClone[mid] = {deps: shim.deps, exports: shim.exports, init: shim.init};
+    });
+
+    return shimsClone;
+  }
+
+  // ---
+
+  function cloneDeep(source) {
+    if(typeof source === "object") {
+      if(!source) return source; // null
+      if(source instanceof Array) return source.map(cloneDeep);
+      if(source.constructor === Object) {
+        var target = {};
+        eachProp(source, function(v, p) { target[p] = cloneDeep(v); });
+        return target;
+      }
+      // Of Object subclasses (Date, Error, RegExp, ... ?)
+    }
+    // undefined, number, boolean, string, function
+    return source;
+  }
+
+  function eachProp(obj, fun, ctx) {
+    if(obj) Object.keys(obj).forEach(function(p) {
+      fun.call(ctx, obj[p], p);
+    });
+  }
+}());


### PR DESCRIPTION
This PR is for discussion only.
 
Hi, this is my attempt at understanding the minimal features that RequireJS would need to expose for being able to test with it properly. Check out require-test.js file and robject.Spec.js for an example using it.

Didn't test if it works in those scenarios where Squire and Jasq fails...

The fact that one of the tests still fails in PhantomJS — the Object.setPrototypeOf one —, tells us that for the env strategy to work, we can only trick the system if we're downgrading its features. We can't test the Object.setPrototypeOf branch in IE6, for example :-)...

How can we solve that problem? Skip the unit tests that an environment can't test? 

@pentaho/milleniumfalcon