### PR TITLE
[CLEANUP] Modularize engine dependent checks

### DIFF
--- a/package-res/resources/web/pentaho/util/has.js
+++ b/package-res/resources/web/pentaho/util/has.js
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([], function() {
+  "use strict";
+
+  var O_hasOwn = Object.prototype.hasOwnProperty;
+
+  var capabilities = {
+    "Object.setPrototypeOf": Object.setPrototypeOf != null,
+    "Object.prototype.__proto__": {}.__proto__ != null
+  };
+
+  return has;
+
+  function has(capability) {
+    return O_hasOwn.call(capabilities, capability) && !!capabilities[capability];
+  }
+});

--- a/package-res/resources/web/pentaho/util/object.js
+++ b/package-res/resources/web/pentaho/util/object.js
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(function() {
+define(["pentaho/util/has"], function(has) {
   "use strict";
 
   var O_hasOwn = Object.prototype.hasOwnProperty,
-      A_empty  = [],
-      setProtoOf = Object.setPrototypeOf || ({}.__proto__ ? setProtoProp : setProtoCopy);
+    A_empty  = [],
+    setProtoOf = has("Object.setPrototypeOf") ? Object.setPrototypeOf : (has("Object.prototype.__proto__") ? setProtoProp : setProtoCopy);
 
   /**
    * The `object` namespace contains functions for


### PR DESCRIPTION
Creates `pentaho/util/has`. To be expanded as needed. For now, used by `pentaho/util/object`.

@pentaho/millenniumfalcon please review.