### PR TITLE
[BACKLOG-6757] - Cherry pick to branch 6.1.0.0

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/FilterDialog.js
+++ b/package-res/resources/web/dojo/pentaho/common/FilterDialog.js
@@ -662,7 +662,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
     var values = "";
 
     var aggregation = ' ';
-    if (filter.selectedAggType) {
+    if (filter.selectedAggType && filter.selectedAggType.toLowerCase() != 'none') {
       aggregation = ' (' + pentaho.pda.Column.AGG_TYPES_STRINGS[filter.selectedAggType] + ') ';
     }
 


### PR DESCRIPTION
PIR - Human readable filters and Filters created by prompts are now displaying (None)
