### PR TITLE
[BISERVER-12918] the report parameter/prompt panel flashes when autosubmit off

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -835,7 +835,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
             }
           }
 
-          if (!value || value == "" || value == "null") {
+          if (param.list && (!value || value == "" || value == "null")) {
             if (!this.nullValueParams) {
               this.nullValueParams = [];
             }

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -394,16 +394,54 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         expect(parameterChangedSpyGeneric).toHaveBeenCalled();
       });
 
-      it("parameterChanged", function() {
-        var param = {};
-        var name = "name";
-        spyOn(panel, "_setTimeoutRefreshPrompt");
-        panel.parameterChanged(param, name);
-        expect(panel.parametersChanged).toBeTruthy();
-        expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
-        expect(panel.nullValueParams).toBeDefined();
-        expect(panel.nullValueParams.length).toBe(1);
-        expect(panel.nullValueParams[0]).toBe(param);
+      describe("parameterChanged", function(){
+        var param;
+        var name;
+        beforeEach(function() {
+          param = {};
+          name = "name";
+          spyOn(panel, "_setTimeoutRefreshPrompt");
+        });
+
+        it("should not fill nullValueParams for single components (Text Area, Text Box, etc.) with null values", function() {
+          param.list = false; // means that it is single component
+
+          panel.parameterChanged(param, name);
+          expect(panel.nullValueParams).toBeUndefined();
+          expect(panel.parametersChanged).toBeTruthy();
+          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+        });
+
+        it("should not fill nullValueParams for single components (Text Area, Text Box, etc.) with not null values", function() {
+          param.list = false; // means that it is single component
+          var value = "value"
+
+          panel.parameterChanged(param, name);
+          expect(panel.nullValueParams).toBeUndefined();
+          expect(panel.parametersChanged).toBeTruthy();
+          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+        });
+
+        it("should fill nullValueParams for multi components (Multi Selection Button, Drop Down, etc.) with null values", function() {
+          param.list = true; // means that it is multi component
+
+          panel.parameterChanged(param, name);
+          expect(panel.nullValueParams).toBeDefined();
+          expect(panel.nullValueParams.length).toBe(1);
+          expect(panel.nullValueParams[0]).toBe(param);
+          expect(panel.parametersChanged).toBeTruthy();
+          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+        });
+
+        it("should not fill nullValueParams for multi components (Multi Selection Button, Drop Down, etc.) with not null values", function() {
+          param.list = true; // means that it is multi component
+          var value = "value";
+
+          panel.parameterChanged(param, name, value);
+          expect(panel.nullValueParams).toBeUndefined();
+          expect(panel.parametersChanged).toBeTruthy();
+          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+        });
       });
 
       it("parameterChanged with specific parameter callback", function() {

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -394,7 +394,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         expect(parameterChangedSpyGeneric).toHaveBeenCalled();
       });
 
-      describe("parameterChanged", function(){
+      describe("parameterChanged", function() {
         var param;
         var name;
         beforeEach(function() {
@@ -403,44 +403,90 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           spyOn(panel, "_setTimeoutRefreshPrompt");
         });
 
-        it("should not fill nullValueParams for single components (Text Area, Text Box, etc.) with null values", function() {
-          param.list = false; // means that it is single component
+        describe("for single components (Text Area, Text Box, etc.)", function() {
+          beforeEach(function() {
+            param.list = false; // means that it is single component
+          });
 
-          panel.parameterChanged(param, name);
-          expect(panel.nullValueParams).toBeUndefined();
-          expect(panel.parametersChanged).toBeTruthy();
-          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+          var assertForSingleComponents = function() {
+            expect(panel.nullValueParams).toBeUndefined();
+            expect(panel.parametersChanged).toBeTruthy();
+            expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+          };
+
+          it("should not fill nullValueParams with undefined value", function() {
+            panel.parameterChanged(param, name);
+            assertForSingleComponents();
+          });
+
+          it("should not fill nullValueParams with null value", function() {
+            var value = null;
+            panel.parameterChanged(param, name, value);
+            assertForSingleComponents();
+          });
+
+          it("should not fill nullValueParams with \"null\" value", function() {
+            var value = "null";
+            panel.parameterChanged(param, name, value);
+            assertForSingleComponents();
+          });
+
+          it("should not fill nullValueParams with \"\" value", function() {
+            var value = "";
+            panel.parameterChanged(param, name, value);
+            assertForSingleComponents();
+          });
+
+          it("should not fill nullValueParams with not empty value", function() {
+            var value = "value";
+            panel.parameterChanged(param, name, value);
+            assertForSingleComponents();
+          });
         });
 
-        it("should not fill nullValueParams for single components (Text Area, Text Box, etc.) with not null values", function() {
-          param.list = false; // means that it is single component
-          var value = "value"
+        describe("for multi components (Multi Selection Button, Drop Down, etc.)", function() {
+          beforeEach(function() {
+            param.list = true; // means that it is multi component
+          });
 
-          panel.parameterChanged(param, name);
-          expect(panel.nullValueParams).toBeUndefined();
-          expect(panel.parametersChanged).toBeTruthy();
-          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
-        });
+          var assertForMultiComponents = function() {
+            expect(panel.nullValueParams).toBeDefined();
+            expect(panel.nullValueParams.length).toBe(1);
+            expect(panel.nullValueParams[0]).toBe(param);
+            expect(panel.parametersChanged).toBeTruthy();
+            expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+          };
 
-        it("should fill nullValueParams for multi components (Multi Selection Button, Drop Down, etc.) with null values", function() {
-          param.list = true; // means that it is multi component
+          it("should fill nullValueParams with undefined value", function() {
+            panel.parameterChanged(param, name);
+            assertForMultiComponents();
+          });
 
-          panel.parameterChanged(param, name);
-          expect(panel.nullValueParams).toBeDefined();
-          expect(panel.nullValueParams.length).toBe(1);
-          expect(panel.nullValueParams[0]).toBe(param);
-          expect(panel.parametersChanged).toBeTruthy();
-          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
-        });
+          it("should fill nullValueParams with null value", function() {
+            var value = null;
+            panel.parameterChanged(param, name, value);
+            assertForMultiComponents();
+          });
 
-        it("should not fill nullValueParams for multi components (Multi Selection Button, Drop Down, etc.) with not null values", function() {
-          param.list = true; // means that it is multi component
-          var value = "value";
+          it("should fill nullValueParams with \"null\" value", function() {
+            var value = "null";
+            panel.parameterChanged(param, name, value);
+            assertForMultiComponents();
+          });
 
-          panel.parameterChanged(param, name, value);
-          expect(panel.nullValueParams).toBeUndefined();
-          expect(panel.parametersChanged).toBeTruthy();
-          expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+          it("should fill nullValueParams with \"\" value", function() {
+            var value = "";
+            panel.parameterChanged(param, name, value);
+            assertForMultiComponents();
+          });
+
+          it("should not fill nullValueParams with not empty value", function() {
+            var value = "value";
+            panel.parameterChanged(param, name, value);
+            expect(panel.nullValueParams).toBeUndefined();
+            expect(panel.parametersChanged).toBeTruthy();
+            expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
+          });
         });
       });
 


### PR DESCRIPTION
Changed nullValueParams condition to ignore single components (Text Area, Text Box, etc.).
Added unit test.

@pamval, @diogofscmariano, @krivera-pentaho, @annapopova1 could you please review?