### PR TITLE
[CLEANUP] Use the "mocha" karma reporter instead of the basic "progress" reporter.

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -7,7 +7,8 @@ module.exports = function (config) {
     plugins: [
       'karma-jasmine',
       'karma-requirejs',
-      'karma-chrome-launcher'
+      'karma-chrome-launcher',
+      'karma-mocha-reporter'
     ],
 
     files: [
@@ -42,7 +43,7 @@ module.exports = function (config) {
     autoWatch: true,
 
     browsers:  ["Chrome"],
-    reporters: ["progress"],
+    reporters: ["mocha"], // "progress"
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG

--- a/config/nodojo.karma.conf.js
+++ b/config/nodojo.karma.conf.js
@@ -7,7 +7,8 @@ module.exports = function (config) {
     plugins: [
       'karma-jasmine',
       'karma-requirejs',
-      'karma-chrome-launcher'
+      'karma-chrome-launcher',
+      'karma-mocha-reporter'
     ],
 
     files: [
@@ -48,7 +49,7 @@ module.exports = function (config) {
     autoWatch: true,
 
     browsers:  ["Chrome"],
-    reporters: ["progress"],
+    reporters: ["mocha"], // "progress"
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-html-reporter": "^0.2.0",
     "karma-junit-reporter": "^0.3.8",
+    "karma-mocha-reporter": "^1.1.6",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-requirejs": "0.2.x",
     "phantomjs-prebuilt": "^2.1.3",


### PR DESCRIPTION
This uses a mocha-like reporter for the DEV-time karma configs. It prints a nice outline of the test suites, marking them green, red or gray according to success, failure and ignored (https://www.npmjs.com/package/karma-mocha-reporter).

The only problem I see with the reporter is that console.logs get interleaved with the test titles. And code bases like prompting and angular directives abuse of console.log'ing... But this is a problem we already have...

What do you guys think?

@pentaho/millenniumfalcon, @pentaho/orlandocalisbon please review.