### PR TITLE
[BACKLOG-6898] - Re-implement PromptPanel#getString function

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,11 @@
  */
 define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/util/util', 'common-ui/util/GUIDHelper', './WidgetBuilder', 'cdf/Dashboard.Clean', './parameters/ParameterDefinitionDiffer', 'common-ui/jquery-clean'],
     function (Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashboard, ParamDiff, $) {
+
+      // Add specific prompting message bundle
+      if (pentaho.common.Messages) {
+        pentaho.common.Messages.addUrlBundle('prompting',CONTEXT_PATH+'i18n?plugin=common-ui&name=resources/web/prompting/messages/messages');
+      }
 
       var _STATE_CONSTANTS = {
         readOnlyProperties: ["promptNeeded", "paginate", "totalPages", "showParameterUI", "allowAutoSubmit"],
@@ -595,20 +600,6 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          */
         getAutoSubmitSetting: function () {
           return this.autoSubmit;
-        },
-
-        /**
-         * Get a localized string for this prompt panel.
-         *
-         * @name PromptPanel#getString
-         * @method
-         * @param {String} key The key
-         * @param {String} defaultString The default value
-         *
-         * @returns {String} The localized string
-         */
-        getString: function (key, defaultString) {
-          return defaultString || '!' + key + '!';
         },
 
         /**

--- a/package-res/resources/web/prompting/builders/SubmitComponentBuilder.js
+++ b/package-res/resources/web/prompting/builders/SubmitComponentBuilder.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,24 @@
  * @class
  * @extends Base
  */
-define(['cdf/lib/Base', '../components/SubmitPromptComponent'],
-    function (Base, SubmitPromptComponent) {
+define(['cdf/lib/Base', '../components/SubmitPromptComponent', 'pentaho/common/Messages'],
+    function (Base, SubmitPromptComponent, Messages) {
+    
+      /*
+       * Gets a message from the messages bundle.
+       *
+       * @name SubmitComponentBuilder#_getMessage
+       * @method
+       *
+       * @param  {String} key String the key in the bundle which references the desired string.
+       * @param  {Array} substitutionVars Array of String (optional) an array of strings
+       * to substitute into the message string.
+       * @returns {String} The message that corresponds to the key.
+       * @private
+       */  
+      var _getMessage = function(key, substitutionVars) {
+        return Messages.getString(key, substitutionVars);
+      }
 
       return Base.extend({
 
@@ -64,8 +80,8 @@ define(['cdf/lib/Base', '../components/SubmitPromptComponent'],
             type: 'SubmitPromptComponent',
             name: guid,
             htmlObject: guid,
-            label: args.promptPanel.getString('submitButtonLabel', 'Submit'),
-            autoSubmitLabel: args.promptPanel.getString('autoSubmitLabel', 'Auto-Submit'),
+            label: _getMessage('submitButtonLabel', 'Submit'),
+            autoSubmitLabel: _getMessage('autoSubmitLabel', 'Auto-Submit'),
             promptPanel: args.promptPanel,
             paramDefn: args.promptPanel.paramDefn,
             executeAtStart: true

--- a/package-res/resources/web/prompting/messages/messages.properties
+++ b/package-res/resources/web/prompting/messages/messages.properties
@@ -1,0 +1,3 @@
+# Prompting specific labels
+submitButtonLabel=View Report
+autoSubmitLabel=Auto-Submit

--- a/package-res/resources/web/prompting/messages/messages_de.properties
+++ b/package-res/resources/web/prompting/messages/messages_de.properties
@@ -1,0 +1,3 @@
+# Prompting specific labels
+submitButtonLabel=Bericht anzeigen
+autoSubmitLabel=Automatisches Absenden

--- a/package-res/resources/web/prompting/messages/messages_fr.properties
+++ b/package-res/resources/web/prompting/messages/messages_fr.properties
@@ -1,0 +1,3 @@
+# Prompting specific labels
+submitButtonLabel=Afficher le rapport
+autoSubmitLabel=Soumettre automatiquement

--- a/package-res/resources/web/prompting/messages/messages_ja.properties
+++ b/package-res/resources/web/prompting/messages/messages_ja.properties
@@ -1,0 +1,3 @@
+# Prompting specific labels
+submitButtonLabel=\u30ec\u30dd\u30fc\u30c8\u8868\u793a
+autoSubmitLabel=\u81ea\u52d5\u30b5\u30d6\u30df\u30c3\u30c8

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file expect in compliance with the License.
@@ -67,20 +67,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
       it("getAutoSubmitSetting", function() {
         var autoSubmit = panel.getAutoSubmitSetting();
         expect(panel.autoSubmit).toBeTruthy();
-      });
-
-      describe("getString", function() {
-        var defaultStr = "default";
-        var key = "key";
-        it("should return default string", function() {
-          var str = panel.getString(key, defaultStr);
-          expect(str).toBe(defaultStr);
-        });
-
-        it("should return key string", function() {
-          var str = panel.getString(key);
-          expect(str).toBe("!" + key + "!");
-        });
       });
 
       it("getParameterName with parameter object", function() {

--- a/test-js/unit/prompting/builders/SubmitComponentBuilderSpec.js
+++ b/test-js/unit/prompting/builders/SubmitComponentBuilderSpec.js
@@ -45,6 +45,12 @@ define(['common-ui/prompting/builders/SubmitComponentBuilder'], function(SubmitC
       expect(component.type).toBe('SubmitPromptComponent');
     });
 
+    it("should return default label values", function() {
+      var component = submitComponentBuilder.build(args);
+      expect(component.label).toEqual('submitButtonLabel');
+      expect(component.autoSubmitLabel).toEqual('autoSubmitLabel');
+    });
+
   });
 
 });


### PR DESCRIPTION
- Removed the getString function from the PromptPanel
- Required the localization service on the SubmitComponentBuilder
- Added message properties files with prompting specific messages
- Removed the unit tests from the prompt panel