### PR TITLE
[BISERVER-13106]

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -957,6 +957,10 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                     };
                   }
                 }
+
+                if(c.param) {
+                  c.param = paramDefn.getParameter(c.param.name);
+                }
               });
 
               this._focusedParam = focusedParam;
@@ -1164,17 +1168,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                   promptPanel: this
                 }, param.attributes["parameter-render-type"]).valuesArray;
 
-                // Compare values array from param (which is formatted into valuesArray) with the current valuesArray
-                // We need to update the components if autoSubmit is off
-                var valArr;
-                if ( component.valuesArray ) {
-                  valArr = component.valuesArray.slice();
-                  if ( "" == component.valuesArray[0][0] && "" == component.valuesArray[0][1] ) {
-                    //no update needed if component.valuesArray equals newValuesArray except first empty(default) value
-                    valArr = component.valuesArray.slice(1);
-                  }
-                }
-                if (JSON.stringify(valArr) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
+                if (JSON.stringify(component.valuesArray) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
                   // Find selected value in param values list and set it. This works, even if the data in valuesArray is different
                   this._initializeParameterValue(null, param);
 
@@ -1195,8 +1189,8 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                 }
 
                 if (!updateNeeded) {
-                  var paramValue = this.dashboard.getParameterValue(component.parameter);
-                  updateNeeded = _areParamsDifferent(paramValue, paramSelectedValues, paramType);
+                  updateNeeded = _areParamsDifferent(this.dashboard.getParameterValue(component.parameter),
+                      paramSelectedValues, paramType);
                 }
 
                 if (updateNeeded) {

--- a/package-res/resources/web/prompting/WidgetBuilder.js
+++ b/package-res/resources/web/prompting/WidgetBuilder.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,12 +53,12 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
       './builders/ErrorLabelBuilder', './builders/DropDownBuilder', './builders/RadioBuilder', './builders/CheckBuilder',
       './builders/MultiButtonBuilder', './builders/ListBuilder', './builders/DateInputBuilder',
       './builders/ExternalInputBuilder', './builders/TextAreaBuilder',
-      './builders/TextInputBuilder'],
+      './builders/StaticAutocompleteBoxBuilder'],
 
     function (PromptPanelBuilder, ParameterGroupPanelBuilder, ParameterPanelBuilder, SubmitPanelBuilder,
               SubmitComponentBuilder, LabelBuilder, ErrorLabelBuilder, DropDownBuilder, RadioBuilder, CheckBuilder,
               MultiButtonBuilder, ListBuilder, DateInputBuilder, ExternalInputBuilder, TextAreaBuilder,
-              TextInputBuilder) {
+              StaticAutocompleteBoxBuilder) {
 
       return {
         /**
@@ -81,7 +81,7 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
           'filebrowser': new ExternalInputBuilder(),
           'external-input': new ExternalInputBuilder(),
           'multi-line': new TextAreaBuilder(),
-          'default': new TextInputBuilder()
+          'default': new StaticAutocompleteBoxBuilder()
         },
 
         /**

--- a/package-res/resources/web/prompting/builders/DropDownBuilder.js
+++ b/package-res/resources/web/prompting/builders/DropDownBuilder.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ define(['cdf/components/SelectComponent', './ValueBasedParameterWidgetBuilder', 
       if (args.promptPanel.paramDefn.ignoreBiServer5538 && !args.param.hasSelection()) {
         // If there is no empty selection, and no value is selected, create one. This way, we can represent
         // the unselected state.
-        widget.valuesArray = [['', '']].concat(widget.valuesArray);
+        widget.valuesArray = widget.valuesArray.concat([['', '']]);
       }
 
       $.extend(widget, {

--- a/package-res/resources/web/prompting/builders/StaticAutocompleteBoxBuilder.js
+++ b/package-res/resources/web/prompting/builders/StaticAutocompleteBoxBuilder.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,13 +40,11 @@
  *
  * @name StaticAutocompleteBoxBuilder
  * @class
- * @extends FormattedParameterWidgetBuilderBase
+ * @extends ValueBasedParameterWidgetBuilder
  */
-define(['./FormattedParameterWidgetBuilderBase', '../components/StaticAutocompleteBoxComponent', 'common-ui/jquery-clean'],
-    function (FormattedParameterWidgetBuilderBase, StaticAutocompleteBoxComponent, $) {
-
-      return FormattedParameterWidgetBuilderBase.extend({
-
+define(['common-ui/util/formatting', './ValueBasedParameterWidgetBuilder', '../components/StaticAutocompleteBoxComponent', 'common-ui/jquery-clean'],
+    function(FormatUtils, ValueBasedParameterWidgetBuilder, StaticAutocompleteBoxComponent, $) {
+      return ValueBasedParameterWidgetBuilder.extend({
 
         /**
          * Creates and returns a new instance of StaticAutocompleteBoxBuilder.
@@ -59,12 +57,14 @@ define(['./FormattedParameterWidgetBuilderBase', '../components/StaticAutocomple
          * @param {Parameter} args.param - The Parameter instance
          * @returns {StaticAutocompleteBoxComponent} The new instance of StaticAutocompleteBoxComponent
          */
-        build: function (args) {
-          var convertToAutocompleteValues = function (param) {
-            return $.map(param.values, function (v) {
-              var value = this.formatter ? this.formatter.format(this.transportFormatter.parse(v.value)) : v.value;
+        build: function(args) {
+          var formatter = FormatUtils.createFormatter(args.promptPanel.paramDefn, args.param);
+          var transportFormatter = FormatUtils.createDataTransportFormatter(args.promptPanel.paramDefn, args.param);
+          var convertToAutocompleteValues = function(valuesArray) {
+            return $.map(valuesArray, function(v) {
+              var value = formatter ? formatter.format(transportFormatter.parse(v[0])) : v[0];
               // Label is key if it doesn't exist
-              var label = (this.formatter ? this.formatter.format(this.transportFormatter.parse(v.label)) : v.label) || value;
+              var label = (formatter ? formatter.format(transportFormatter.parse(v[1])) : v[1]) || value;
               return {
                 value: value,
                 label: label
@@ -73,13 +73,14 @@ define(['./FormattedParameterWidgetBuilderBase', '../components/StaticAutocomple
           };
 
           var widget = this.base(args);
-
-          $.extend(widget, {
+          widget = $.extend(widget, {
             type: 'StaticAutocompleteBoxComponent',
-            valuesArray: convertToAutocompleteValues(args.param)
+            valuesArray: convertToAutocompleteValues(widget.valuesArray),
+            transportFormatter: transportFormatter,
+            formatter: formatter
           });
 
           return new StaticAutocompleteBoxComponent(widget);
         }
-      });
+      })
     });

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -579,12 +579,14 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         });
 
         it("should init also with components and find focused param", function() {
-          var paramDefn = jasmine.createSpyObj("paramDefnSpy", [ "showParameterUI", "allowAutoSubmit" ]);
-          var comp = jasmine.createSpyObj("compSpy", [ "placeholder", "topValue" ]);
-          comp.topValue.and.returnValue(100);
-          comp.param = {
+          var paramDefn = jasmine.createSpyObj("paramDefnSpy", [ "showParameterUI", "allowAutoSubmit", "getParameter" ]);
+          var param = {
             name : "test_param_name"
           };
+          paramDefn.getParameter.and.returnValue(param);
+          var comp = jasmine.createSpyObj("compSpy", [ "placeholder", "topValue" ]);
+          comp.topValue.and.returnValue(100);
+          comp.param = param;
           comp.promptType = "prompt";
           comp.type = "SelectMultiComponent";
           spyOn($.fn, "init").and.returnValue([ {} ]);
@@ -593,7 +595,8 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel._focusedParam).toBe(comp.param.name);
+          expect(paramDefn.getParameter).toHaveBeenCalled();
+          expect(panel._focusedParam).toBe(param.name);
           expect(panel._multiListBoxTopValuesByParam).toBeDefined();
         });
 
@@ -807,8 +810,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
             label : "test label"
           };
           panel.paramDefn.errors[param.name] = [ "Error 1" ];
-          spyOn(panel.widgetBuilder.mapping['default'], '_createFormatter').and.returnValue(null);
-          spyOn(panel.widgetBuilder.mapping['default'], '_createDataTransportFormatter').and.returnValue(null);
           var paramPanel = panel._buildPanelForParameter(param);
           expect(paramPanel).toBeDefined();
           expect(panel._initializeParameterValue).toHaveBeenCalledWith(panel.paramDefn, param);
@@ -816,7 +817,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           expect(paramPanel.components.length).toBe(3);
           expect(paramPanel.components[0].type).toBe("TextComponent");
           expect(paramPanel.components[1].type).toBe("TextComponent");
-          expect(paramPanel.components[2].type).toBe("TextInputComponent");
+          expect(paramPanel.components[2].type).toBe("StaticAutocompleteBoxComponent");
           expect(paramPanel.components[0].promptType).toBe("label");
           expect(paramPanel.components[1].promptType).toBe("label");
           expect(paramPanel.components[2].promptType).toBe("prompt");
@@ -1131,8 +1132,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               };
 
               spyOn(panel, "setParameterValue");
-              spyOn(panel.widgetBuilder.mapping['default'], '_createFormatter').and.returnValue(null);
-              spyOn(panel.widgetBuilder.mapping['default'], '_createDataTransportFormatter').and.returnValue(null);
 
               componentSpy = jasmine.createSpyObj("componentSpy", ["getPanel"]);
               componentSpy.parameter = paramName;
@@ -1154,7 +1153,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
               panel._changeComponentsByDiff(change);
 
-              expect(panel.setParameterValue).not.toHaveBeenCalled();
+              expect(panel.setParameterValue).toHaveBeenCalled();
               expect(panel.forceSubmit).toBeDefined();
               expect(panel.forceSubmit).toEqual(true);
             });
@@ -1164,7 +1163,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               spyOn(panel, "_initializeParameterValue");
               panel.dashboard.getParameterValue.and.returnValue("do");
 
-              var valuesArrayWithDefaults = [ ["", ""], ["test1", "test1"], ["test2", "test2"] ];
+              var valuesArrayWithDefaults = [ ["test1", "test1"], ["test2", "test2"] ];
               componentSpy.valuesArray = valuesArrayWithDefaults;
 
               var valuesArray = [ ["test1", "test1"], ["test2", "test2"] ];

--- a/test-js/unit/prompting/builders/DropDownBuilderSpec.js
+++ b/test-js/unit/prompting/builders/DropDownBuilderSpec.js
@@ -59,6 +59,20 @@ define(['common-ui/prompting/builders/DropDownBuilder'], function(DropDownBuilde
       expect(component.valuesArray[0][1]).toEqual("");
     });
 
+    it("should create an empty selection at the end if no value is selected", function() {
+      spyOn(args.param, 'hasSelection').and.returnValue(false);
+
+      args.param.values = [
+        { label: "banana", value: "banana" }
+      ];
+
+      var component = dropDownBuilder.build(args);
+      expect(args.param.hasSelection).toHaveBeenCalled();
+      expect(component.valuesArray.length > 0).toBeTruthy();
+      expect(component.valuesArray[1][0]).toEqual("");
+      expect(component.valuesArray[1][1]).toEqual("");
+    });
+
     it ("should set defaultIfEmpty to true for non-multi select on preExecution", function() {
       var component = dropDownBuilder.build(args);
 

--- a/test-js/unit/prompting/builders/StaticAutocompleteBoxBuilderSpec.js
+++ b/test-js/unit/prompting/builders/StaticAutocompleteBoxBuilderSpec.js
@@ -21,9 +21,7 @@ define(['common-ui/prompting/builders/StaticAutocompleteBoxBuilder'], function(S
     var args = {
       promptPanel: {
         generateWidgetGUID: function() { },
-        getParameterName: function() { },
-        createFormatter: function() { },
-        createDataTransportFormatter: function() { }
+        getParameterName: function() { }
       }, 
       param:  {
         values: { },
@@ -35,8 +33,6 @@ define(['common-ui/prompting/builders/StaticAutocompleteBoxBuilder'], function(S
 
     beforeEach(function() {
       staticAutocompleteBoxBuilder = new StaticAutocompleteBoxBuilder();
-      spyOn(staticAutocompleteBoxBuilder, '_createFormatter').and.returnValue(null);
-      spyOn(staticAutocompleteBoxBuilder, '_createDataTransportFormatter').and.returnValue(null);
     });
 
     it("should throw an error building component with no parameters", function() {


### PR DESCRIPTION
- Added auto complete component back
- Fixed BISERVER-12961 without having checks on the values array, creating unneeded updates
- Fixed param property, storing the param definition for the component. With the prompt flow, this property was not updated properly causing values to return to its original value
- Updated unit tests accordingly