### PR TITLE
[SP-2534] - Backport of BISERVER-13106

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -751,6 +751,10 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                     };
                   }
                 }
+
+                if(c.param) {
+                  c.param = paramDefn.getParameter(c.param.name);
+                }
               });
 
               this._focusedParam = focusedParam;
@@ -958,17 +962,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
                   promptPanel: this
                 }, param.attributes["parameter-render-type"]).valuesArray;
 
-                // Compare values array from param (which is formatted into valuesArray) with the current valuesArray
-                // We need to update the components if autoSubmit is off
-                var valArr;
-                if ( component.valuesArray ) {
-                  valArr = component.valuesArray.slice();
-                  if ( "" == component.valuesArray[0][0] && "" == component.valuesArray[0][1] ) {
-                    //no update needed if component.valuesArray equals newValuesArray except first empty(default) value
-                    valArr = component.valuesArray.slice(1);
-                  }
-                }
-                if (JSON.stringify(valArr) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
+                if (JSON.stringify(component.valuesArray) !== JSON.stringify(newValuesArray) || param.forceUpdate) {
                   // Find selected value in param values list and set it. This works, even if the data in valuesArray is different
                   this._initializeParameterValue(null, param);
 

--- a/package-res/resources/web/prompting/WidgetBuilder.js
+++ b/package-res/resources/web/prompting/WidgetBuilder.js
@@ -53,12 +53,12 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
       './builders/ErrorLabelBuilder', './builders/DropDownBuilder', './builders/RadioBuilder', './builders/CheckBuilder',
       './builders/MultiButtonBuilder', './builders/ListBuilder', './builders/DateInputBuilder',
       './builders/ExternalInputBuilder', './builders/TextAreaBuilder',
-      './builders/TextInputBuilder'],
+      './builders/StaticAutocompleteBoxBuilder'],
 
     function (PromptPanelBuilder, ParameterGroupPanelBuilder, ParameterPanelBuilder, SubmitPanelBuilder,
               SubmitComponentBuilder, LabelBuilder, ErrorLabelBuilder, DropDownBuilder, RadioBuilder, CheckBuilder,
               MultiButtonBuilder, ListBuilder, DateInputBuilder, ExternalInputBuilder, TextAreaBuilder,
-              TextInputBuilder) {
+              StaticAutocompleteBoxBuilder) {
 
       return {
         /**
@@ -81,7 +81,7 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
           'filebrowser': new ExternalInputBuilder(),
           'external-input': new ExternalInputBuilder(),
           'multi-line': new TextAreaBuilder(),
-          'default': new TextInputBuilder()
+          'default': new StaticAutocompleteBoxBuilder()
         },
 
         /**

--- a/package-res/resources/web/prompting/builders/DropDownBuilder.js
+++ b/package-res/resources/web/prompting/builders/DropDownBuilder.js
@@ -70,7 +70,7 @@ define(['cdf/components/SelectComponent', './ValueBasedParameterWidgetBuilder'],
       if (args.promptPanel.paramDefn.ignoreBiServer5538 && !args.param.hasSelection()) {
         // If there is no empty selection, and no value is selected, create one. This way, we can represent
         // the unselected state.
-        widget.valuesArray = [['', '']].concat(widget.valuesArray);
+        widget.valuesArray = widget.valuesArray.concat([['', '']]);
       }
 
       $.extend(widget, {

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -425,12 +425,14 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         });
 
         it("should init also with components and find focused param", function() {
-          var paramDefn = jasmine.createSpyObj("paramDefnSpy", [ "showParameterUI" ]);
-          var comp = jasmine.createSpyObj("compSpy", [ "placeholder", "topValue" ]);
-          comp.topValue.and.returnValue(100);
-          comp.param = {
+          var paramDefn = jasmine.createSpyObj("paramDefnSpy", [ "showParameterUI", "allowAutoSubmit", "getParameter" ]);
+          var param = {
             name : "test_param_name"
           };
+          paramDefn.getParameter.and.returnValue(param);
+          var comp = jasmine.createSpyObj("compSpy", [ "placeholder", "topValue" ]);
+          comp.topValue.and.returnValue(100);
+          comp.param = param;
           comp.promptType = "prompt";
           comp.type = "SelectMultiComponent";
           spyOn(window, "$").and.returnValue([ {} ]);
@@ -439,7 +441,8 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel._focusedParam).toBe(comp.param.name);
+          expect(paramDefn.getParameter).toHaveBeenCalled();
+          expect(panel._focusedParam).toBe(param.name);
           expect(panel._multiListBoxTopValuesByParam).toBeDefined();
         });
 
@@ -662,7 +665,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           expect(paramPanel.components.length).toBe(3);
           expect(paramPanel.components[0].type).toBe("TextComponent");
           expect(paramPanel.components[1].type).toBe("TextComponent");
-          expect(paramPanel.components[2].type).toBe("TextInputComponent");
+          expect(paramPanel.components[2].type).toBe("StaticAutocompleteBoxComponent");
           expect(paramPanel.components[0].promptType).toBe("label");
           expect(paramPanel.components[1].promptType).toBe("label");
           expect(paramPanel.components[2].promptType).toBe("prompt");
@@ -1000,7 +1003,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
               panel._changeComponentsByDiff(change);
 
-              expect(panel.setParameterValue).not.toHaveBeenCalled();
+              expect(panel.setParameterValue).toHaveBeenCalled();
               expect(panel.forceSubmit).toBeDefined();
               expect(panel.forceSubmit).toEqual(true);
             });
@@ -1010,7 +1013,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               spyOn(panel, "_initializeParameterValue");
               panel.dashboard.getParameterValue.and.returnValue("do");
 
-              var valuesArrayWithDefaultEmtyStrings = [["", ""],["test1", "test1"],["test2", "test2"]];
+              var valuesArrayWithDefaultEmtyStrings = [["test1", "test1"],["test2", "test2"]];
               componentSpy.valuesArray = valuesArrayWithDefaultEmtyStrings;
 
               changedParam = new Parameter();

--- a/package-res/resources/web/test/prompting/builders/DropDownBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/DropDownBuilderSpec.js
@@ -1,4 +1,4 @@
-/*!
+  /*!
  * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,6 +57,20 @@ define(['common-ui/prompting/builders/DropDownBuilder'], function(DropDownBuilde
       expect(component.valuesArray.length > 0).toBeTruthy();
       expect(component.valuesArray[0][0]).toEqual("");
       expect(component.valuesArray[0][1]).toEqual("");
+    });
+
+    it("should create an empty selection at the end if no value is selected", function() {
+      spyOn(args.param, 'hasSelection').and.returnValue(false);
+
+      args.param.values = [
+        { label: "banana", value: "banana" }
+      ];
+
+      var component = dropDownBuilder.build(args);
+      expect(args.param.hasSelection).toHaveBeenCalled();
+      expect(component.valuesArray.length > 0).toBeTruthy();
+      expect(component.valuesArray[1][0]).toEqual("");
+      expect(component.valuesArray[1][1]).toEqual("");
     });
 
     it ("should set defaultIfEmpty to true for non-multi select on preExecution", function() {

--- a/package-res/resources/web/test/prompting/builders/StaticAutocompleteBoxBuilderSpec.js
+++ b/package-res/resources/web/test/prompting/builders/StaticAutocompleteBoxBuilderSpec.js
@@ -21,9 +21,7 @@ define(['common-ui/prompting/builders/StaticAutocompleteBoxBuilder'], function(S
     var args = {
       promptPanel: {
         generateWidgetGUID: function() { },
-        getParameterName: function() { },
-        createFormatter: function() { },
-        createDataTransportFormatter: function() { }
+        getParameterName: function() { }
       }, 
       param:  {
         values: { },


### PR DESCRIPTION
- Added auto complete component back
- Fixed BISERVER-12961 without having checks on the values array, creating unneeded updates
- Fixed param property, storing the param definition for the component. With the prompt flow, this property was not updated properly causing values to return to its original value
- Updated unit tests accordingly