### PR TITLE
[SP-2383] - Backport of PPP-3455 - Dynamic code injection vulnerabilities found (6.0 Suite)

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/overrides/dojox/json/ref.js
+++ b/package-res/resources/web/dojo/pentaho/common/overrides/dojox/json/ref.js
@@ -232,7 +232,7 @@ return dojox.json.ref = {
 			return refObject;
 		}
 		try{
-			var root = eval('(' + str + ')'); // do the eval
+			var root = JSON.parse(str); // parse JSON
 		}catch(e){
 			throw new SyntaxError("Invalid JSON string: " + e.message + " parsing: "+ str);
 		}


### PR DESCRIPTION
- in ref.js, replace `eval()` with `JSON.parse()`
- in models-svc.js, replace old-fashioned `pentahoPost()` with `request.post()` from Dojo
(cherry-picked from 089d23b2eaafd045a353a730b00d2b18f444d1e4)

@rfellows, review it please. This is a backport of https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/610