### PR TITLE
[CLEANUP] Removed the direct use of console.log and updated license headers

### DIFF
--- a/package-res/resources/web/pentaho/data/AbstractTable.js
+++ b/package-res/resources/web/pentaho/data/AbstractTable.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/AtomicTypeName.js
+++ b/package-res/resources/web/pentaho/data/AtomicTypeName.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Attribute.js
+++ b/package-res/resources/web/pentaho/data/Attribute.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/AttributeCollection.js
+++ b/package-res/resources/web/pentaho/data/AttributeCollection.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Cell.js
+++ b/package-res/resources/web/pentaho/data/Cell.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/CellTuple.js
+++ b/package-res/resources/web/pentaho/data/CellTuple.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Member.js
+++ b/package-res/resources/web/pentaho/data/Member.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/MemberCollection.js
+++ b/package-res/resources/web/pentaho/data/MemberCollection.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Model.js
+++ b/package-res/resources/web/pentaho/data/Model.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Structure.js
+++ b/package-res/resources/web/pentaho/data/Structure.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/StructurePosition.js
+++ b/package-res/resources/web/pentaho/data/StructurePosition.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/Table.js
+++ b/package-res/resources/web/pentaho/data/Table.js
@@ -1,6 +1,6 @@
 
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/TableView.js
+++ b/package-res/resources/web/pentaho/data/TableView.js
@@ -1,6 +1,6 @@
 
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/WellKnownGeoRole.js
+++ b/package-res/resources/web/pentaho/data/WellKnownGeoRole.js
@@ -1,6 +1,6 @@
 
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_OfAttribute.js
+++ b/package-res/resources/web/pentaho/data/_OfAttribute.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_WithCellTupleBase.js
+++ b/package-res/resources/web/pentaho/data/_WithCellTupleBase.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_WithStructure.js
+++ b/package-res/resources/web/pentaho/data/_WithStructure.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_cross/Axis.js
+++ b/package-res/resources/web/pentaho/data/_cross/Axis.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_cross/AxisPosition.js
+++ b/package-res/resources/web/pentaho/data/_cross/AxisPosition.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_cross/MeasureCellSet.js
+++ b/package-res/resources/web/pentaho/data/_cross/MeasureCellSet.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_cross/Table.js
+++ b/package-res/resources/web/pentaho/data/_cross/Table.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/AbstractFilter.IFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/AbstractFilter.IFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/AbstractFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/AbstractFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/AbstractPropertyFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/AbstractPropertyFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/AbstractTreeFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/AbstractTreeFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/And.IFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/And.IFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/And.js
+++ b/package-res/resources/web/pentaho/data/_filter/And.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/IsEqual.js
+++ b/package-res/resources/web/pentaho/data/_filter/IsEqual.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/IsIn.js
+++ b/package-res/resources/web/pentaho/data/_filter/IsIn.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/Not.js
+++ b/package-res/resources/web/pentaho/data/_filter/Not.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/Or.IFilter.js
+++ b/package-res/resources/web/pentaho/data/_filter/Or.IFilter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/Or.js
+++ b/package-res/resources/web/pentaho/data/_filter/Or.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/_Element.js
+++ b/package-res/resources/web/pentaho/data/_filter/_Element.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/_apply.js
+++ b/package-res/resources/web/pentaho/data/_filter/_apply.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_filter/_toSpec.js
+++ b/package-res/resources/web/pentaho/data/_filter/_toSpec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_plain/Row.js
+++ b/package-res/resources/web/pentaho/data/_plain/Row.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_plain/RowList.js
+++ b/package-res/resources/web/pentaho/data/_plain/RowList.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_plain/Table.js
+++ b/package-res/resources/web/pentaho/data/_plain/Table.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_trend-linear.js
+++ b/package-res/resources/web/pentaho/data/_trend-linear.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_trends.js
+++ b/package-res/resources/web/pentaho/data/_trends.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/filter.js
+++ b/package-res/resources/web/pentaho/data/filter.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/trends.js
+++ b/package-res/resources/web/pentaho/data/trends.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/i18n.js
+++ b/package-res/resources/web/pentaho/i18n.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/ArgumentError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/ArgumentInvalidError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentInvalidError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/ArgumentInvalidTypeError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentInvalidTypeError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/ArgumentRangeError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentRangeError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/ArgumentRequiredError.js
+++ b/package-res/resources/web/pentaho/lang/ArgumentRequiredError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/Collection.js
+++ b/package-res/resources/web/pentaho/lang/Collection.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/Event.js
+++ b/package-res/resources/web/pentaho/lang/Event.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/EventSource.js
+++ b/package-res/resources/web/pentaho/lang/EventSource.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/EventSource.js
+++ b/package-res/resources/web/pentaho/lang/EventSource.js
@@ -17,8 +17,9 @@
 define([
   "./Base",
   "./Event",
-  "../util/error"
-], function(Base, Event, error) {
+  "../util/error",
+  "../util/logger"
+], function(Base, Event, error, logger) {
 
   "use strict";
 
@@ -324,11 +325,12 @@ define([
       try {
         result = this._emit(event);
       } catch(e) {
-        if (event) {
-          console.log("Exception thrown during '", (event.type || "NO_TYPE"), "' loop:", e);
+        if(event) {
+          logger.warn("Exception thrown during '" + (event.type || "NO_TYPE") + "' loop");
         } else {
-          console.log("Exception thrown due to an invalid event:", e);
+          logger.warn("Exception thrown due to an invalid event");
         }
+        logger.warn(e);
       }
       return result;
     }

--- a/package-res/resources/web/pentaho/lang/List.js
+++ b/package-res/resources/web/pentaho/lang/List.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/NotImplementedError.js
+++ b/package-res/resources/web/pentaho/lang/NotImplementedError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/OperationInvalidError.js
+++ b/package-res/resources/web/pentaho/lang/OperationInvalidError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/UserError.js
+++ b/package-res/resources/web/pentaho/lang/UserError.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_Annotatable.js
+++ b/package-res/resources/web/pentaho/lang/_Annotatable.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_AnnotatableLinked.js
+++ b/package-res/resources/web/pentaho/lang/_AnnotatableLinked.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/service.js
+++ b/package-res/resources/web/pentaho/service.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/shim/es5.js
+++ b/package-res/resources/web/pentaho/shim/es5.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/shim/es6-promise.js
+++ b/package-res/resources/web/pentaho/shim/es6-promise.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/Instance.js
+++ b/package-res/resources/web/pentaho/type/Instance.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/Property.js
+++ b/package-res/resources/web/pentaho/type/Property.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/PropertyTypeCollection.js
+++ b/package-res/resources/web/pentaho/type/PropertyTypeCollection.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/boolean.js
+++ b/package-res/resources/web/pentaho/type/boolean.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/date.js
+++ b/package-res/resources/web/pentaho/type/date.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/element.js
+++ b/package-res/resources/web/pentaho/type/element.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/facets/DiscreteDomain.js
+++ b/package-res/resources/web/pentaho/type/facets/DiscreteDomain.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/facets/Refinement.js
+++ b/package-res/resources/web/pentaho/type/facets/Refinement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/function.js
+++ b/package-res/resources/web/pentaho/type/function.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/number.js
+++ b/package-res/resources/web/pentaho/type/number.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/object.js
+++ b/package-res/resources/web/pentaho/type/object.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/refinement.js
+++ b/package-res/resources/web/pentaho/type/refinement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/simple.js
+++ b/package-res/resources/web/pentaho/type/simple.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/standard.js
+++ b/package-res/resources/web/pentaho/type/standard.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/string.js
+++ b/package-res/resources/web/pentaho/type/string.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/value.js
+++ b/package-res/resources/web/pentaho/type/value.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/valueHelper.js
+++ b/package-res/resources/web/pentaho/type/valueHelper.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/MessageBundle.js
+++ b/package-res/resources/web/pentaho/util/MessageBundle.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/arg.js
+++ b/package-res/resources/web/pentaho/util/arg.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/error.js
+++ b/package-res/resources/web/pentaho/util/error.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/has.js
+++ b/package-res/resources/web/pentaho/util/has.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/logger.js
+++ b/package-res/resources/web/pentaho/util/logger.js
@@ -1,0 +1,127 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function () {
+
+  /**
+   * The `logger` namespace contains functions used to log messages in the console.
+   *
+   * @name logger
+   * @memberOf pentaho.util
+   * @namespace
+   * @amd pentaho/util/Logger
+   */
+  var logger =/** @lends pentaho.util.logger */{
+
+    /**
+     *  Property enumerating the various log levels.
+     *
+     *  @property logLevels
+     *  @type Array
+     */
+    logLevels: ["debug", "log", "info", "warn", "error", "exception"],
+
+
+    /**
+     *  Current log level. Assign a new value to this property to change the log level.
+     *
+     *  @property logLevel
+     *  @type string
+     */
+    logLevel: "log",
+
+    /**
+     * Logs a message at debug level.
+     *
+     * @param {string} m - Message to log.
+     */
+    log: function (m) {
+      return _log(m, "log");
+    },
+
+    /**
+     * Logs a message at debug level.
+     *
+     * @param {string} m - Message to log.
+     */
+    debug: function (m) {
+      return _log(m, "debug");
+    },
+    /**
+     * Logs a message at info level.
+     *
+     * @param {string} m - Message to log.
+     */
+
+    info: function (m) {
+      return _log(m, "info");
+    },
+
+    /**
+     * Logs a message at warn level.
+     *
+     * @param {string} m - Message to log.
+     */
+    warn: function (m) {
+      return _log(m, "warn");
+    },
+
+    /**
+     * Logs a message at error level.
+     *
+     * @param {string} m - Message to log.
+     */
+    error: function (m) {
+      return _log(m, "error");
+    },
+
+    /**
+     * Logs a message at exception level.
+     *
+     * @param {string} m - Message to log.
+     */
+    exception: function (m) {
+      return _log(m, "exception");
+    }
+  };
+
+  function _log(m, type, css) {
+    type = type || "info";
+    if(logger.logLevels.indexOf(type) < logger.logLevels.indexOf(logger.logLevel)) {
+      return;
+    }
+    if(typeof console !== "undefined") {
+      if (!console[type]) {
+        if (type === "exception") {
+          type = "error";
+          m = m.stack || m;
+        } else {
+          type = "log";
+        }
+      }
+      if (css) {
+        try {
+          console[type]("%c" + m, css);
+          return;
+        } catch (e) {
+          //styling is not supported
+        }
+      }
+      console[type](m);
+    }
+  }
+
+  return logger;
+});

--- a/package-res/resources/web/pentaho/util/promise.js
+++ b/package-res/resources/web/pentaho/util/promise.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/text.js
+++ b/package-res/resources/web/pentaho/util/text.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/Wrapper.js
+++ b/package-res/resources/web/pentaho/visual/2.5/Wrapper.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/ISelection.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/ISelection.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/IVisual.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/IVisual.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/IVisualCallbacks.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/IVisualCallbacks.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/IVisualCreateOptions.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/IVisualCreateOptions.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/SelectionMode.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/SelectionMode.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/spec/IVisual.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/spec/IVisual.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/_doc/spec/IVisualDraw.js
+++ b/package-res/resources/web/pentaho/visual/2.5/_doc/spec/IVisualDraw.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/config.js
+++ b/package-res/resources/web/pentaho/visual/2.5/config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/editor/_doc.js
+++ b/package-res/resources/web/pentaho/visual/2.5/editor/_doc.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/editor/_doc/IVisualEditorDocument.js
+++ b/package-res/resources/web/pentaho/visual/2.5/editor/_doc/IVisualEditorDocument.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/editor/utils.js
+++ b/package-res/resources/web/pentaho/visual/2.5/editor/utils.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/samples/calc/Calc.js
+++ b/package-res/resources/web/pentaho/visual/2.5/samples/calc/Calc.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/samples/calc/analyzer_plugin.js
+++ b/package-res/resources/web/pentaho/visual/2.5/samples/calc/analyzer_plugin.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/samples/calc/analyzer_plugin_loader.js
+++ b/package-res/resources/web/pentaho/visual/2.5/samples/calc/analyzer_plugin_loader.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/samples/calc/visualTypeProvider.js
+++ b/package-res/resources/web/pentaho/visual/2.5/samples/calc/visualTypeProvider.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/spec/helper.js
+++ b/package-res/resources/web/pentaho/visual/2.5/spec/helper.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IGeneralRequirement.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IGeneralRequirement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IGeneralRequirementUI.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IGeneralRequirementUI.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IRequirement.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IRequirement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IRequirementSet.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IRequirementSet.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualEditModel.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualEditModel.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualRoleRequirement.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualRoleRequirement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualType.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/IVisualType.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/_doc/UIType.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/_doc/UIType.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/helper.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/helper.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/2.5/type/registry.js
+++ b/package-res/resources/web/pentaho/visual/2.5/type/registry.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/2.5/all.js
+++ b/package-res/resources/web/pentaho/visual/ccc/2.5/all.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/2.5/analyzer_plugin.js
+++ b/package-res/resources/web/pentaho/visual/ccc/2.5/analyzer_plugin.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/2.5/analyzer_plugin_loader.js
+++ b/package-res/resources/web/pentaho/visual/ccc/2.5/analyzer_plugin_loader.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/2.5/visualApiConfig.js
+++ b/package-res/resources/web/pentaho/visual/ccc/2.5/visualApiConfig.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/2.5/visualTypeProvider.js
+++ b/package-res/resources/web/pentaho/visual/ccc/2.5/visualTypeProvider.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/ColumnAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/ColumnAxis.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/RowAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/RowAxis.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
@@ -1,8 +1,9 @@
 define([
   "pentaho/util/object",
+  "pentaho/util/logger",
   "pentaho/data/filter",
   "pentaho/visual/base/types/selectionModes"
-], function(O, filter, selectionModes) {
+], function(O, logger, filter, selectionModes) {
   "use strict";
 
   return {
@@ -50,12 +51,12 @@ define([
       });
 
       event.dataFilter = dataFilter;
-      console.log("Event:", event);
+      logger.log(event);
     },
 
     // Temporary. Used for demo of BACKLOG-5989
     _onWillExecute: function(event) {
-      console.log("Event:", event);
+      logger.log(event);
     },
 
     // Temporary. Used for demo of BACKLOG-5989
@@ -75,7 +76,7 @@ define([
       var url = "http://www.google.com/search?as_q=\"" + queryValue + "\"";
       window.open(url, "_blank");
 
-      console.log("Google Search:" + url);
+      logger.log("Google Search: " + url);
     },
 
     _hackedRender: function(){

--- a/package-res/resources/web/pentaho/visual/ccc/trends.js
+++ b/package-res/resources/web/pentaho/visual/ccc/trends.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/color/_doc/IColorPalette.js
+++ b/package-res/resources/web/pentaho/visual/color/_doc/IColorPalette.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/color/_doc/_namespace.js
+++ b/package-res/resources/web/pentaho/visual/color/_doc/_namespace.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/events.js
+++ b/package-res/resources/web/pentaho/visual/events.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/samples/sandbox/container.js
+++ b/package-res/resources/web/pentaho/visual/samples/sandbox/container.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-js/unit/pentaho/lang/EventSource.Spec.js
+++ b/test-js/unit/pentaho/lang/EventSource.Spec.js
@@ -16,8 +16,9 @@
 define([
   "pentaho/lang/Event",
   "pentaho/lang/EventSource",
-  "tests/pentaho/util/errorMatch"
-], function(Event, EventSource, errorMatch) {
+  "tests/pentaho/util/errorMatch",
+  "pentaho/util/logger"
+], function(Event, EventSource, errorMatch, logger) {
   "use strict";
 
   /* global jasmine:false, describe:false, it:false, expect:false, beforeEach:false, spyOn: false */
@@ -565,7 +566,7 @@ define([
 
       beforeEach(function() {
         event = new Event("foo", eventSource, true);
-        spyOn(console, 'log');
+        spyOn(logger, "warn");
       });
 
       it("should return null when no parameters provided.", function() {
@@ -575,13 +576,13 @@ define([
 
         expect(eventSource._emitSafe(undefined)).toBe(null);
 
-        expect(console.log).toHaveBeenCalledTimes(3);
+        expect(logger.warn).toHaveBeenCalledTimes(6);
       });
 
       it("should return null when the argument is of an invalid type.", function() {
         expect(eventSource._emitSafe({})).toBe(null);
 
-        expect(console.log).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledTimes(2);
       });
 
       it("should interrupt the event being processed and return null if a listener throws an exception.", function() {
@@ -602,7 +603,7 @@ define([
 
         expect(listeners.second).not.toHaveBeenCalled();
 
-        expect(console.log).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledTimes(2);
       });
 
     }); // #_emit


### PR DESCRIPTION
The headers were updated using this regex in Intellij:
 - Copyright 2010 - (\d{4}) Pentaho Corporation\\.(\s+)All rights reserved\\.

@pentaho/millenniumfalcon please review