### PR TITLE
[BACKLOG-5799] Report Viewer - will not show a special pop-up if ther…

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/Dialog.js
+++ b/package-res/resources/web/dojo/pentaho/common/Dialog.js
@@ -32,6 +32,10 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             closeIcon: undefined,
             _onCancelCallback: undefined,
 
+            constructor: function() {
+              Dialog._DialogLevelManager._beginZIndex = 1051;
+            },
+
             setLocalizationLookupFunction: function(f) {
               this.getLocaleString = f;
               this._localize();
@@ -179,19 +183,19 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
                         style.get(this.domNode, 'borderRightWidth')) +'px';
                   }
                   style.set(this.popup.domNode, 'width', this.width);
-                  style.set(query('.dijitDialogPaneContent',this.popup.domNode),'width', this.width);
-                  style.set(query('.dijitDialogPaneContent',this.domNode),'width', this.width);
+                  query('.dijitDialogPaneContent', this.popup.domNode).forEach(function(node) {style.set(node, 'width', this.width);});
+                  query('.dijitDialogPaneContent', this.domNode).forEach(function(node) {style.set(node, 'width', this.width);});
                 }
               } else {
                 if(!this.shown) {
                   style.set(this.domNode, 'width', this.width);
                   style.set(this.popup.domNode, 'width', this.width);
-                  style.set(query('.dijitDialogPaneContent',this.popup.domNode),'width', this.width);
-                  style.set(query('.dijitDialogPaneContent',this.domNode),'width', this.width);
+                  query('.dijitDialogPaneContent', this.popup.domNode).forEach(function(node) {style.set(node, 'width', this.width);});
+                  query('.dijitDialogPaneContent', this.domNode).forEach(function(node) {style.set(node, 'width', this.width);});
                   style.set(this.domNode, 'height', this.height);
                   style.set(this.popup.domNode, 'height', this.height);
-                  style.set(query('.dijitDialogPaneContent',this.popup.domNode),'height', this.height);
-                  style.set(query('.dijitDialogPaneContent',this.domNode),'height', this.height);
+                  query('.dijitDialogPaneContent', this.popup.domNode).forEach(function(node) {style.set(node, 'height', this.height);});
+                  query('.dijitDialogPaneContent', this.domNode).forEach(function(node) {style.set(node, 'height', this.height);});
                 }
               }
 


### PR DESCRIPTION
…e is a fatal error

Fixed 2 problems:
- incorrect code for setting style to elements. "dojo/dom-style" works with single domNode but "dojo/query" returns nodeList and we should use forEach to set width.
- progress indicator from blockUi is located over the dijit dialog (pentaho.common.Dialog). he reason is blockUi uses 1000 and 1011 z-index by default but dijit dialog uses 950 z-index by default. To fix it I set default z-index for dijit dialog.

@pentaho/orlandocalisbon please review