### PR TITLE
[BISERVER-13107] Query-driven textbox parameters defined as Number ar…

### DIFF
--- a/package-res/resources/web/prompting/components/StaticAutocompleteBoxComponent.js
+++ b/package-res/resources/web/prompting/components/StaticAutocompleteBoxComponent.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@
  * @class
  * @extends BaseComponent
  */
-define([ 'common-ui/util/util', 'cdf/components/BaseComponent', 'dojo/number', 'amd!cdf/lib/jquery.ui' ], function(Utils, BaseComponent, DojoNumber,
+define([ 'common-ui/util/util', 'cdf/components/BaseComponent', 'dojo/i18n', 'dojo/number', 'amd!cdf/lib/jquery.ui' ], function(Utils, BaseComponent, DojoNumber,
   $) {
 
   return BaseComponent.extend({
@@ -92,7 +92,7 @@ define([ 'common-ui/util/util', 'cdf/components/BaseComponent', 'dojo/number', '
               } else {
                 if (Utils.isNumberType(v.type)) {
                   valueParsed = DojoNumber.format(v.label, {
-                    locale : SESSION_LOCALE.toLowerCase()
+                    locale : SESSION_LOCALE.toLowerCase().replace('_', '-')
                   });
                 } else {
                   valueParsed = v.label;


### PR DESCRIPTION
…e formatted as ##,### when screen reloads

- define i18n dojo module for preload internationalization bundle
- pass locale which was converted to dojo format (en_Us to en-us) for properly load localized number format