### PR TITLE
[BACKLOG-6961] Fixed usage of underscore dependency

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -108,7 +108,7 @@
     init: function() {
       return $.noConflict(true);
     }
-  } 
+  }
 
   requirePaths["common-ui/handlebars"] = basePath + "/handlebars/handlebars";
   requireShim ["common-ui/handlebars"] = ["common-ui/jquery"];
@@ -124,7 +124,8 @@
   requireShim ["common-ui/ring"] = {deps: ["common-ui/underscore"], exports: "ring"};
 
   requirePaths["common-ui/underscore"] = basePath + "/underscore/underscore" + minSuffix;
-  requirePaths["underscore"] = basePath + "/underscore/underscore" + minSuffix;
+  // underscore should be required using the module ID above, creating a map entry to guarantee backwards compatibility
+  requireMap["*"]["underscore"] = "common-ui/underscore"; // deprecated
 
   // Intended for private use of "pentaho/shim/es6-promise" only!
   if(minSuffix) {


### PR DESCRIPTION
    - Removed duplicate path configuration for the same underscore file
    - Added a mapping to guarantee backwards compatibility