### PR TITLE
[BACKLOG-6052] More refactoring to Context.Spec + support type construction with temporary ids

### DIFF
--- a/package-res/resources/web/pentaho/type/Type.js
+++ b/package-res/resources/web/pentaho/type/Type.js
@@ -25,7 +25,9 @@ define([
   "../util/object",
   "../util/fun",
   "../util/promise"
-], function(localRequire, SpecificationScope, SpecificationContext, bundle, Base, AnnotatableLinked, error, arg, O, F, promiseUtil) {
+], function(localRequire, SpecificationScope, SpecificationContext, bundle, Base,
+    AnnotatableLinked, error, arg, O, F, promiseUtil) {
+
   "use strict";
 
   // Unique type class id exposed through Type#uid and used by Context instances.
@@ -272,7 +274,7 @@ define([
       value = nonEmptyString(value);
 
       // Is it a temporary id? If so, ignore it.
-      if(value && value[0] === "_") value = null;
+      if(SpecificationContext.isIdTemporary(value)) value = null;
 
       // Can only be set once or throws.
       O.setConst(this, "_id", value);
@@ -941,7 +943,8 @@ define([
      * When a type is not anonymous, the cheapest reference,
      * the [id]{@link pentaho.type.Type#id}, is returned.
      *
-     * For anonymous types, a temporary, serialization-only id is generated.
+     * For anonymous types, a [temporary]{@link pentaho.type.SpecificationContext.isIdTemporary},
+     * serialization-only id is generated.
      * In the first occurrence in the given scope,
      * that id is returned, within a full specification of the type,
      * obtained by calling [toSpecInContext]{@link pentaho.type.Type#toSpecInContext}.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IValueTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IValueTypeProto.jsdoc
@@ -40,13 +40,16 @@
  *
  * For serialization purposes,
  * a **temporary id** can be assigned to an anonymous type.
- * An id is _temporary_ if it starts with an `_` character.
+ * An id is _temporary_ if it starts with
+ * [idTemporaryPrefix]{@link pentaho.type.SpecificationContext.idTemporaryPrefix}.
  *
  * Temporary ids are ignored after type construction.
  *
  * @name id
  * @memberOf pentaho.type.spec.IValueTypeProto#
  * @type {?string}
+ *
+ * @see pentaho.type.SpecificationContext.isIdTemporary
  */
 
 /**

--- a/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
@@ -21,18 +21,25 @@
  *
  * ##### A _type id_ string
  *
- * A type's [id]{@link pentaho.type.Type#id},
- * that must the id of a defined module in the AMD module system.
+ * A type's permanent [id]{@link pentaho.type.Type#id} —
+ * the id of a defined module in the AMD module system —,
+ * or a [temporary]{@link pentaho.type.SpecificationContext.isIdTemporary},
+ * serialization-only id.
  *
- * If the id does not contain any "/" character,
+ * If the id is permanent and does not contain any "/" character,
  * it is considered a standard type, and, thus,
  * is taken relative to Pentaho's `"pentaho/type"` module.
  *
  * Note that relative AMD module ids, like, for example, `"./foo"`, are not supported.
  *
- * Example:
+ * Example absolute, permanent id:
  * ```js
  * "pentaho/type/string"
+ * ```
+ *
+ * Example temporary id:
+ * ```js
+ * "_:1"
  * ```
  *
  * ##### An _instance constructor_ function

--- a/test-js/unit/pentaho/type/Context.Spec.js
+++ b/test-js/unit/pentaho/type/Context.Spec.js
@@ -19,80 +19,64 @@ var __global__ = this;
 
 define([
   "pentaho/type/standard",
-  "tests/pentaho/util/errorMatch",
-  "pentaho/util/promise"
-], function(standard, errorMatch, promiseUtil) {
+  "tests/test-utils"
+], function(standard, testUtils) {
 
   "use strict";
 
-  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, Promise:false*/
+  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, Promise:false, spyOn:false*/
 
   // These should really be writable, i.e. globalVar: true
   /*global SESSION_NAME:true, active_theme:true, SESSION_LOCALE:true */
 
-  //region test helpers
-  // NOTE: can only be used with `it`; does not work in `describe`.
-  function withContext(testFun) {
-    var localRequire = require.new();
-
-    return function(done) {
-
-      // load fresh Context class
-      localRequire(["pentaho/type/Context", "tests/pentaho/util/errorMatch"], function(Context, errorMatch) {
-        try {
-          var promise = testFun(Context, localRequire, errorMatch);
-          if(!promise) {
-            done();
-            localRequire.dispose();
-          } else {
-            promise.then(function() {
-              done();
-              localRequire.dispose();
-            }, function(ex) {
-              done.fail(ex);
-              localRequire.dispose();
-            });
-          }
-        } catch(ex) {
-          done.fail(ex);
-          localRequire.dispose();
-        }
-      }, function(ex) {
-        done.fail(ex);
-        localRequire.dispose();
-      });
-    };
-  }
-  //endregion
+  // Use alternate, promise-aware version of `it`.
+  var it = testUtils.itAsync;
+  var expectToRejectWith = testUtils.expectToRejectWith;
 
   describe("pentaho.type.Context -", function() {
 
-    it("is a function", withContext(function(Context) {
-      expect(typeof Context).toBe("function");
-    }));
+    it("is a function", function() {
+
+      return require.using(["pentaho/type/Context"], function(Context) {
+        expect(typeof Context).toBe("function");
+      });
+    });
 
     describe("new Context(spec) -", function() {
 
-      it("should return a context instance", withContext(function(Context) {
-        var context = new Context();
-        expect(context instanceof Context).toBe(true);
-      }));
+      it("should return a context instance", function() {
+
+        return require.using(["pentaho/type/Context"], function(Context) {
+          var context = new Context();
+          expect(context instanceof Context).toBe(true);
+        });
+      });
 
       describe("container -", function() {
-        it("should have a null value when unspecified and there is no current one", withContext(function(Context) {
-          var context = new Context();
-          expect(context.container).toBe(null);
-        }));
 
-        it("should have a null value when specified empty", withContext(function(Context) {
-          var context = new Context({container: ""});
-          expect(context.container).toBe(null);
-        }));
+        it("should have a null value when unspecified and there is no current one", function() {
 
-        it("should respect a specified non-empty value", withContext(function(Context) {
-          var context = new Context({container: "FOO"});
-          expect(context.container).toBe("FOO");
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context();
+            expect(context.container).toBe(null);
+          });
+        });
+
+        it("should have a null value when specified empty", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({container: ""});
+            expect(context.container).toBe(null);
+          });
+        });
+
+        it("should respect a specified non-empty value", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({container: "FOO"});
+            expect(context.container).toBe("FOO");
+          });
+        });
       });
 
       describe("user -", function() {
@@ -107,26 +91,38 @@ define([
           __global__.SESSION_NAME = _SESSION_NAME;
         });
 
-        it("should have a null value when unspecified and there is no current one", withContext(function(Context) {
-          var context = new Context();
-          expect(context.user).toBe(null);
-        }));
+        it("should have a null value when unspecified and there is no current one", function() {
 
-        it("should have a null value when specified empty", withContext(function(Context) {
-          var context = new Context({user: ""});
-          expect(context.user).toBe(null);
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context();
+            expect(context.user).toBe(null);
+          });
+        });
 
-        it("should respect a specified non-empty value", withContext(function(Context) {
-          var context = new Context({user: "FOO"});
-          expect(context.user).toBe("FOO");
-        }));
+        it("should have a null value when specified empty", function() {
 
-        it("should default to the existing current one", withContext(function(Context) {
-          __global__.SESSION_NAME = "ABC";
-          var context = new Context();
-          expect(context.user).toBe("ABC");
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({user: ""});
+            expect(context.user).toBe(null);
+          });
+        });
+
+        it("should respect a specified non-empty value", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({user: "FOO"});
+            expect(context.user).toBe("FOO");
+          });
+        });
+
+        it("should default to the existing current one", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            __global__.SESSION_NAME = "ABC";
+            var context = new Context();
+            expect(context.user).toBe("ABC");
+          });
+        });
       });
 
       describe("theme -", function() {
@@ -140,26 +136,38 @@ define([
           __global__.active_theme = _active_theme;
         });
 
-        it("should have a null value when unspecified and there is no current one", withContext(function(Context) {
-          var context = new Context();
-          expect(context.theme).toBe(null);
-        }));
+        it("should have a null value when unspecified and there is no current one", function() {
 
-        it("should have a null value when specified empty", withContext(function(Context) {
-          var context = new Context({theme: ""});
-          expect(context.theme).toBe(null);
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context();
+            expect(context.theme).toBe(null);
+          });
+        });
 
-        it("should respect a specified non-empty value", withContext(function(Context) {
-          var context = new Context({theme: "FOO"});
-          expect(context.theme).toBe("FOO");
-        }));
+        it("should have a null value when specified empty", function() {
 
-        it("should default to the existing current one", withContext(function(Context) {
-          __global__.active_theme = "ABC";
-          var context = new Context();
-          expect(context.theme).toBe("ABC");
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({theme: ""});
+            expect(context.theme).toBe(null);
+          });
+        });
+
+        it("should respect a specified non-empty value", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({theme: "FOO"});
+            expect(context.theme).toBe("FOO");
+          });
+        });
+
+        it("should default to the existing current one", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            __global__.active_theme = "ABC";
+            var context = new Context();
+            expect(context.theme).toBe("ABC");
+          });
+        });
       });
 
       describe("locale -", function() {
@@ -173,38 +181,50 @@ define([
           SESSION_LOCALE = _SESSION_LOCALE;
         });
 
-        it("should have a null value when unspecified and there is no current one", withContext(function(Context) {
-          var context = new Context();
-          expect(context.locale).toBe(null);
-        }));
+        it("should have a null value when unspecified and there is no current one", function() {
 
-        it("should have a null value when specified empty", withContext(function(Context) {
-          var context = new Context({locale: ""});
-          expect(context.locale).toBe(null);
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context();
+            expect(context.locale).toBe(null);
+          });
+        });
 
-        it("should respect a specified non-empty value", withContext(function(Context) {
-          var context = new Context({locale: "FOO"});
-          expect(context.locale).toBe("FOO");
-        }));
+        it("should have a null value when specified empty", function() {
 
-        it("should default to the existing current one", withContext(function(Context) {
-          __global__.SESSION_LOCALE = "ABC";
-          var context = new Context();
-          expect(context.locale).toBe("ABC");
-        }));
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({locale: ""});
+            expect(context.locale).toBe(null);
+          });
+        });
+
+        it("should respect a specified non-empty value", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            var context = new Context({locale: "FOO"});
+            expect(context.locale).toBe("FOO");
+          });
+        });
+
+        it("should default to the existing current one", function() {
+
+          return require.using(["pentaho/type/Context"], function(Context) {
+            __global__.SESSION_LOCALE = "ABC";
+            var context = new Context();
+            expect(context.locale).toBe("ABC");
+          });
+        });
       });
     });
 
     describe("#get|getAsync(type)", function() {
 
-      //region test helpers
+      //region get test helpers
       /**
        * Each of the following tests is performed both synchronously and asynchronously
        * using a single tester function.
        *
        * A test that should succeed uses testGet.
-       * A test that should fail uses testGetError.
+       * A test that should fail uses testGet and expectToRejectWith.
        */
 
       /**
@@ -219,65 +239,14 @@ define([
        *
        * If the `tester` function returns a promise, it is resolved and expected to succeed.
        */
-      function testGet(tester) {
 
-        return function testStub(overallDone) {
+      function testGet(getTester) {
 
-          var syncDone = function() {
-            // Test async
-            withContext(tester.bind(null, false))(overallDone);
-          };
-
-          syncDone.fail = overallDone.fail;
-
-          withContext(tester.bind(null, true))(syncDone);
-        };
-      }
-
-      /**
-       * Creates an async test function suitable for `it`.
-       *
-       * Receives a _get-test_ function, `tester`, that is called in two modes: sync and async.
-       *
-       * The `tester` function has the signature `function(sync, Context) : ?Promise`.
-       *
-       * The `tester` function should use `callGet(context, sync, spec)` to actually call the
-       * corresponding get method, sync or async, while providing the test's specific spec argument.
-       *
-       * When async, the `tester` function should return a promise that should be rejected.
-       * When sync, the `tester` is expected to throw...
-       *
-       * In both cases, the error should be `exExpected`.
-       */
-      function testGetError(tester, funCreateExpectedError) {
-
-        return function testStub(overallDone) {
-
-          var syncDone = function() {
-            // Async test
-            withContext(function(Context, localRequire, errorMatch) {
-
-              var promise = tester(false, Context, localRequire);
-              expect(promise instanceof Promise);
-              return promise
-                  .then(overallDone.fail, function(ex) {
-                    expect(ex).toEqual(funCreateExpectedError(errorMatch));
-                  });
-
-            })(overallDone);
-          };
-
-          syncDone.fail = overallDone.fail;
-
-          // Sync test
-          withContext(function(Context, localRequire, errorMatch) {
-
-            expect(function() {
-              tester(true, Context, localRequire);
-            }).toThrow(funCreateExpectedError(errorMatch));
-
-          })(syncDone);
-        };
+        return testUtils.modal([true, false], function(sync) {
+          return require.using(
+              ["pentaho/type/Context", "require", "tests/pentaho/util/errorMatch"],
+              getTester.bind(null, sync));
+        });
       }
 
       /**
@@ -296,172 +265,242 @@ define([
       }
       //endregion
 
-      it("should have preloaded standard primitive types and facets", withContext(function(Context, localRequire) {
-        var context = new Context();
-        var p;
+      it("should have preloaded standard primitive types and facets", function() {
 
-        for(p in standard)
-          if(standard.hasOwnProperty(p))
-            if(p !== "facets" && p !== "Instance")
-              expect(!!context.get("pentaho/type/" + p)).toBe(true);
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
+          var context = new Context();
+          var p;
 
-        for(p in standard.facets)
-          if(standard.facets.hasOwnProperty(p))
-            localRequire("pentaho/type/facets/" + p);
-      }));
+          for(p in standard)
+            if(standard.hasOwnProperty(p))
+              if(p !== "facets" && p !== "Instance")
+                expect(!!context.get("pentaho/type/" + p)).toBe(true);
+
+          for(p in standard.facets)
+            if(standard.facets.hasOwnProperty(p))
+              localRequire("pentaho/type/facets/" + p);
+        });
+      });
 
       describe("by id", function() {
-        it("should be able to get a standard type given its relative id", testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, "string");
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.type.id).toBe("pentaho/type/string");
+        it("should be able to get a standard type given its relative id", function() {
+
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, "string");
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.type.id).toBe("pentaho/type/string");
+            });
           });
-        }));
+        });
 
-        it("should be able to get a standard type given its absolute id", testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, "pentaho/type/string");
+        it("should be able to get a standard type given its absolute id", function() {
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.type.id).toBe("pentaho/type/string");
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, "pentaho/type/string");
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.type.id).toBe("pentaho/type/string");
+            });
           });
-        }));
+        });
 
-        it("should be able to get an already loaded non-standard type given its absolute id",
-        testGet(function(sync, Context, localRequire) {
-          var mid = "pentaho/foo/bar";
-          localRequire.define(mid,[], function() {
-            return function(context) {
-              var Simple = context.get("pentaho/type/simple");
-              return Simple.extend({type: {id: mid}});
-            };
+        it("should be able to get an already loaded non-standard type given its absolute id", function() {
+
+          return testGet(function(sync, Context, localRequire) {
+
+            var mid = "pentaho/foo/bar";
+
+            localRequire.define(mid,[], function() {
+              return function(context) {
+                var Simple = context.get("pentaho/type/simple");
+                return Simple.extend({type: {id: mid}});
+              };
+            });
+
+            return localRequire.promise([mid])
+                .then(function() {
+                  var context = new Context();
+                  return callGet(context, sync, mid);
+                })
+                .then(function(InstCtor) {
+                  expect(InstCtor.type.id).toBe(mid);
+                });
           });
-
-          return promiseUtil.require(mid, localRequire)
-              .then(function() {
-                var context = new Context();
-                return callGet(context, sync, mid);
-              })
-              .then(function(InstCtor) {
-                expect(InstCtor.type.id).toBe(mid);
-              });
-        }));
+        });
       });
 
       describe("by type factory function", function() {
-        it("should be able to get a standard type",
-        testGet(function(sync, Context, localRequire) {
-          var context = new Context();
-          var valueFactory = localRequire("pentaho/type/value");
-          var promise = callGet(context, sync, valueFactory);
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.type.id).toBe("pentaho/type/value");
+        it("should be able to get a standard type", function() {
+
+          return testGet(function(sync, Context, localRequire) {
+            var context = new Context();
+            var valueFactory = localRequire("pentaho/type/value");
+            var promise = callGet(context, sync, valueFactory);
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.type.id).toBe("pentaho/type/value");
+            });
           });
-        }));
+        });
       });
 
       describe("by type instance constructor (Instance)", function() {
-        it("should be able to get a standard type", testGet(function(sync, Context) {
-          var context = new Context();
-          var Value   = context.get("pentaho/type/value");
-          var promise = callGet(context, sync, Value);
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.type.id).toBe("pentaho/type/value");
+        it("should be able to get a standard type", function() {
+
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var Value   = context.get("pentaho/type/value");
+            var promise = callGet(context, sync, Value);
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.type.id).toBe("pentaho/type/value");
+            });
           });
-        }));
+        });
 
-        it("should throw/reject if given a type from a different context", testGetError(function(sync, Context) {
-          var context1 = new Context();
-          var context2 = new Context();
-          var Value    = context2.get("pentaho/type/value");
+        it("should throw/reject if given a type from a different context", function() {
 
-          return callGet(context1, sync, Value);
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context1 = new Context();
+            var context2 = new Context();
+            var Value    = context2.get("pentaho/type/value");
 
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
-
-        it("should configure a type", testGet(function(sync, Context) {
-          // "value" is configured on the Context constructor, so need to wire the prototype...
-
-          spyOn(Context.prototype, "_getConfig").and.callFake(function(id) {
-            if(id === "pentaho/type/value") {
-              return {foo: "bar", instance: {bar: "foo"}};
-            }
+            return expectToRejectWith(
+                function() { return callGet(context1, sync, Value); },
+                errorMatch.argInvalid("typeRef"));
           });
+        });
 
-          var context = new Context();
+        it("should configure a type", function() {
 
-          var promise = callGet(context, sync, "pentaho/type/value");
+          return testGet(function(sync, Context) {
+            // "value" is configured on the Context constructor, so need to wire the prototype...
 
-          return promise.then(function(InstCtor) {
-            expect(Context.prototype._getConfig).toHaveBeenCalledWith("pentaho/type/value");
+            spyOn(Context.prototype, "_getConfig").and.callFake(function(id) {
+              if(id === "pentaho/type/value") {
+                return {foo: "bar", instance: {bar: "foo"}};
+              }
+            });
 
-            expect(InstCtor.prototype.bar).toBe("foo");
-            expect(InstCtor.type.foo).toBe("bar");
+            var context = new Context();
+
+            var promise = callGet(context, sync, "pentaho/type/value");
+
+            return promise.then(function(InstCtor) {
+              expect(Context.prototype._getConfig).toHaveBeenCalledWith("pentaho/type/value");
+
+              expect(InstCtor.prototype.bar).toBe("foo");
+              expect(InstCtor.type.foo).toBe("bar");
+            });
           });
-        }));
+        });
       });
 
-      describe("by type (object)", function() {
-        it("should be able to get a standard type given its type object", testGet(function(sync, Context) {
-          var context = new Context();
-          var Value   = context.get("pentaho/type/value");
-          var promise = callGet(context, sync, Value.type);
+      describe("by type object", function() {
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.type.id).toBe("pentaho/type/value");
+        it("should be able to get a standard type given its type object", function() {
+
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var Value   = context.get("pentaho/type/value");
+            var promise = callGet(context, sync, Value.type);
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.type.id).toBe("pentaho/type/value");
+            });
           });
-        }));
+        });
       });
 
       describe("by others, invalid", function() {
-        it("should throw/reject when given the type-constructor (Type)", testGetError(function(sync, Context) {
-          var context = new Context();
-          var Value   = context.get("pentaho/type/value");
-          return callGet(context, sync, Value.type.constructor);
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
 
-        it("should throw/reject when given null", testGetError(function(sync, Context) {
-          var context = new Context();
-          return callGet(context, sync, null);
-        }, function(errorMatch) { return errorMatch.argRequired("typeRef"); }));
+        it("should throw/reject when given the type-constructor (Type)", function() {
 
-        it("should throw/reject when given undefined", testGetError(function(sync, Context) {
-          var context = new Context();
-          return callGet(context, sync, undefined);
-        }, function(errorMatch) { return errorMatch.argRequired("typeRef"); }));
+          return testGet(function(sync, Context, localRequire, errorMatch) {
 
-        it("should throw/reject when given an empty string", testGetError(function(sync, Context) {
-          var context = new Context();
-          return callGet(context, sync, "");
-        }, function(errorMatch) { return errorMatch.argRequired("typeRef"); }));
+            var context = new Context();
+            var Value   = context.get("pentaho/type/value");
 
-        it("should throw/reject when given a standard type instance prototype",
-        testGetError(function(sync, Context) {
-          var context = new Context();
-          var Value   = context.get("pentaho/type/value");
+            return expectToRejectWith(
+                function() { return callGet(context, sync, Value.type.constructor); },
+                errorMatch.argInvalid("typeRef"));
+          });
+        });
 
-          return callGet(context, sync, Value.prototype);
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+        it("should throw/reject when given null", function() {
 
-        it("should throw/reject if given a number (not a string, function or object)",
-        testGetError(function(sync, Context) {
-          var context = new Context();
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
 
-          return callGet(context, sync, 1);
+            return expectToRejectWith(
+                function() { return callGet(context, sync, null); },
+                errorMatch.argRequired("typeRef"));
+          });
+        });
 
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+        it("should throw/reject when given undefined", function() {
 
-        it("should throw/reject if given a boolean (not a string, function or object)",
-        testGetError(function(sync, Context) {
-          var context = new Context();
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
 
-          return callGet(context, sync, true);
+            return expectToRejectWith(
+                function() { return callGet(context, sync, undefined); },
+                errorMatch.argRequired("typeRef"));
+          });
+        });
 
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+        it("should throw/reject when given an empty string", function() {
+
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
+
+            return expectToRejectWith(
+                function() {
+                  return callGet(context, sync, "");
+                },
+                errorMatch.argRequired("typeRef"));
+          });
+        });
+
+        it("should throw/reject when given a standard type instance prototype", function() {
+
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
+            var Value   = context.get("pentaho/type/value");
+
+            return expectToRejectWith(
+                function() { return callGet(context, sync, Value.prototype); },
+                errorMatch.argInvalid("typeRef"));
+          });
+        });
+
+        it("should throw/reject if given a number (not a string, function or object)", function() {
+
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
+
+            return expectToRejectWith(
+                function() { return callGet(context, sync, 1); },
+                errorMatch.argInvalid("typeRef"));
+          });
+        });
+
+        it("should throw/reject if given a boolean (not a string, function or object)", function() {
+
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
+
+            return expectToRejectWith(
+                function() { return callGet(context, sync, true); },
+                errorMatch.argInvalid("typeRef"));
+          });
+        });
       });
 
       describe("by generic or specialized type specification syntax", function() {
@@ -469,259 +508,308 @@ define([
         // {id: "foo", base: "complex", ...}
 
         describe("`base` and `id`", function() {
+
           describe("when `base` is not specified", function() {
 
-            it("should default `base` to `null` when `id` is 'value'", testGet(function(sync, Context) {
-              var context = new Context();
-              var promise = callGet(context, sync, {id: 'value'});
+            it("should default `base` to `null` when `id` is 'value'", function() {
 
-              return promise.then(function(InstCtor) {
-                var Value = context.get("pentaho/type/value");
+              return testGet(function(sync, Context) {
+                var context = new Context();
+                var promise = callGet(context, sync, {id: 'value'});
 
-                expect(InstCtor).toBe(Value);
+                return promise.then(function(InstCtor) {
+                  var Value = context.get("pentaho/type/value");
+
+                  expect(InstCtor).toBe(Value);
+                });
               });
-            }));
+            });
 
-            it("should default `base` to 'complex' when `id` is not specified", testGet(function(sync, Context) {
-              var context = new Context();
-              var promise = callGet(context, sync, {props: ["a", "b"]});
+            it("should default `base` to 'complex' when `id` is not specified", function() {
 
-              return promise.then(function(InstCtor) {
-                var Complex = context.get("pentaho/type/complex");
+              return testGet(function(sync, Context) {
+                var context = new Context();
+                var promise = callGet(context, sync, {props: ["a", "b"]});
 
-                expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+                return promise.then(function(InstCtor) {
+                  var Complex = context.get("pentaho/type/complex");
 
-                expect(InstCtor.ancestor).toBe(Complex);
-                expect(InstCtor.type.has("a")).toBe(true);
-                expect(InstCtor.type.has("b")).toBe(true);
+                  expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+
+                  expect(InstCtor.ancestor).toBe(Complex);
+                  expect(InstCtor.type.has("a")).toBe(true);
+                  expect(InstCtor.type.has("b")).toBe(true);
+                });
               });
-            }));
+            });
           });
 
           describe("when `base` is `undefined`", function() {
 
-            it("should default `base` to 'complex'",
-            testGet(function(sync, Context) {
-              var context = new Context();
-              var promise = callGet(context, sync, {base: undefined, props: ["a", "b"]});
+            it("should default `base` to 'complex'", function() {
 
-              return promise.then(function(InstCtor) {
-                var Complex = context.get("pentaho/type/complex");
+              return testGet(function(sync, Context) {
+                var context = new Context();
+                var promise = callGet(context, sync, {base: undefined, props: ["a", "b"]});
 
-                expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+                return promise.then(function(InstCtor) {
+                  var Complex = context.get("pentaho/type/complex");
 
-                expect(InstCtor.ancestor).toBe(Complex);
-                expect(InstCtor.type.has("a")).toBe(true);
-                expect(InstCtor.type.has("b")).toBe(true);
+                  expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+
+                  expect(InstCtor.ancestor).toBe(Complex);
+                  expect(InstCtor.type.has("a")).toBe(true);
+                  expect(InstCtor.type.has("b")).toBe(true);
+                });
               });
-            }));
+            });
           });
 
           describe("when `base` is `null`", function() {
-            it("should throw/reject when `id` is not 'value'",
-            testGetError(function(sync, Context) {
-              var context = new Context();
 
-              return callGet(context, sync, {id: "foo", base: null});
-            }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+            it("should throw/reject when `id` is not 'value'", function() {
+
+              return testGet(function(sync, Context, localRequire, errorMatch) {
+                var context = new Context();
+
+                return expectToRejectWith(
+                    function() { return callGet(context, sync, {id: "foo", base: null}); },
+                    errorMatch.argInvalid("typeRef"));
+              });
+            });
           });
 
           describe("when `base` is specified non-nully", function() {
-            it("should throw/reject when `id` is 'value'",
-            testGetError(function(sync, Context) {
-              var context = new Context();
 
-              return callGet(context, sync, {id: "value", base: "foo"});
-            }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+            it("should throw/reject when `id` is 'value'", function() {
+
+              return testGet(function(sync, Context, localRequire, errorMatch) {
+                var context = new Context();
+
+                return expectToRejectWith(
+                    function() { return callGet(context, sync, {id: "value", base: "foo"}); },
+                    errorMatch.argInvalid("typeRef"));
+              });
+            });
           });
         });
 
         //region complex
-        it("should be able to create an anonymous complex type with base complex", testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, {base: "complex", props: ["a", "b"]});
+        it("should be able to create an anonymous complex type with base complex", function() {
 
-          return promise.then(function(InstCtor) {
-            var Complex = context.get("pentaho/type/complex");
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, {base: "complex", props: ["a", "b"]});
 
-            expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+            return promise.then(function(InstCtor) {
+              var Complex = context.get("pentaho/type/complex");
 
-            expect(InstCtor.ancestor).toBe(Complex);
-            expect(InstCtor.type.has("a")).toBe(true);
-            expect(InstCtor.type.has("b")).toBe(true);
+              expect(InstCtor.type.isSubtypeOf(Complex.type)).toBe(true);
+
+              expect(InstCtor.ancestor).toBe(Complex);
+              expect(InstCtor.type.has("a")).toBe(true);
+              expect(InstCtor.type.has("b")).toBe(true);
+            });
           });
-        }));
+        });
         //endregion
 
         //region list
-        it("should be able to create a list type using generic notation", testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, {
-              base: "list",
-              of:   {props: ["a", "b"]}
+        it("should be able to create a list type using generic notation", function() {
+
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, {
+                base: "list",
+                of:   {props: ["a", "b"]}
+              });
+
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.prototype instanceof context.get("list")).toBe(true);
+
+              var ofType = InstCtor.type.of;
+              expect(ofType.instance instanceof context.get("complex")).toBe(true);
+              expect(ofType.count).toBe(2);
+              expect(ofType.has("a")).toBe(true);
+              expect(ofType.has("b")).toBe(true);
             });
-
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.prototype instanceof context.get("list")).toBe(true);
-
-            var ofType = InstCtor.type.of;
-            expect(ofType.instance instanceof context.get("complex")).toBe(true);
-            expect(ofType.count).toBe(2);
-            expect(ofType.has("a")).toBe(true);
-            expect(ofType.has("b")).toBe(true);
           });
-        }));
+        });
 
-        it("should be able to create a list type using the shorthand list-type notation",
-        testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, [
-            {props: ["a", "b"]}
-          ]);
+        it("should be able to create a list type using the shorthand list-type notation", function() {
 
-          return promise.then(function(InstCtor) {
-            expect(InstCtor.prototype instanceof context.get("list")).toBe(true);
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, [
+              {props: ["a", "b"]}
+            ]);
 
-            var ofType = InstCtor.type.of;
-            expect(ofType.instance instanceof context.get("complex")).toBe(true);
-            expect(ofType.count).toBe(2);
-            expect(ofType.has("a")).toBe(true);
-            expect(ofType.has("b")).toBe(true);
+            return promise.then(function(InstCtor) {
+              expect(InstCtor.prototype instanceof context.get("list")).toBe(true);
+
+              var ofType = InstCtor.type.of;
+              expect(ofType.instance instanceof context.get("complex")).toBe(true);
+              expect(ofType.count).toBe(2);
+              expect(ofType.has("a")).toBe(true);
+              expect(ofType.has("b")).toBe(true);
+            });
           });
-        }));
+        });
 
-        it("should throw/reject if the shorthand list-type notation has two entries",
-        testGetError(function(sync, Context) {
-          var context = new Context();
+        it("should throw/reject if the shorthand list-type notation has two entries", function() {
 
-          return callGet(context, sync, [123, 234]);
-        }, function(errorMatch) { return errorMatch.argInvalid("typeRef"); }));
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var context = new Context();
+
+            return expectToRejectWith(
+                function() { return callGet(context, sync, [123, 234]); },
+                errorMatch.argInvalid("typeRef"));
+          });
+        });
         //endregion
 
         //region refinement
-        it("should be able to create a refinement type using generic notation", testGet(function(sync, Context) {
-          var context = new Context();
-          var promise = callGet(context, sync, {
-            base: "refinement",
-            of:   "number"
-          });
+        it("should be able to create a refinement type using generic notation", function() {
 
-          return promise.then(function(InstCtor) {
-            var Refinement = context.get("refinement");
-            expect(InstCtor.type.isSubtypeOf(Refinement.type)).toBe(true);
+          return testGet(function(sync, Context) {
+            var context = new Context();
+            var promise = callGet(context, sync, {
+              base: "refinement",
+              of:   "number"
+            });
 
-            expect(InstCtor.ancestor).toBe(Refinement);
+            return promise.then(function(InstCtor) {
+              var Refinement = context.get("refinement");
+              expect(InstCtor.type.isSubtypeOf(Refinement.type)).toBe(true);
+
+              expect(InstCtor.ancestor).toBe(Refinement);
+            });
           });
-        }));
+        });
         //endregion
       });
 
       describe("type factory function", function() {
-        it("should throw if it does not return a function",
-        testGet(function(sync, Context, localRequire, errorMatch) {
-          var mid = "pentaho/foo/bar2";
 
-          localRequire.define(mid,[], function() {
-            return function(context) {
-              return "not a function";
-            };
+        it("should throw if it does not return a function", function() {
+
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var mid = "pentaho/foo/bar2";
+
+            localRequire.define(mid,[], function() {
+              return function(context) {
+                return "not a function";
+              };
+            });
+
+            return localRequire.promise([mid])
+                .then(function() {
+                  var context = new Context();
+                  return callGet(context, sync, mid);
+                })
+                .then(function() {
+                  expect("to throw").toBe(true);
+                }, function(ex) {
+                  expect(ex).toEqual(errorMatch.operInvalid());
+                });
           });
+        });
 
-          return promiseUtil.require(mid, localRequire)
-              .then(function() {
-                var context = new Context();
-                return callGet(context, sync, mid);
-              })
-              .then(function() {
-                expect("to throw").toBe(true);
-              }, function(ex) {
-                expect(ex).toEqual(errorMatch.operInvalid());
-              });
-        }));
+        it("should throw if it does return a function that is not an Instance", function() {
 
-        it("should throw if it does return a function that is not an Instance",
-        testGet(function(sync, Context, localRequire, errorMatch) {
-          var mid = "pentaho/foo/bar2";
+          return testGet(function(sync, Context, localRequire, errorMatch) {
+            var mid = "pentaho/foo/bar2";
 
-          localRequire.define(mid,[], function() {
-            return function(context) {
-              return function(){};
-            };
+            localRequire.define(mid,[], function() {
+              return function(context) {
+                return function(){};
+              };
+            });
+
+            return localRequire.promise([mid])
+                .then(function() {
+                  var context = new Context();
+                  return callGet(context, sync, mid);
+                })
+                .then(function() {
+                  expect("to throw").toBe(true);
+                }, function(ex) {
+                  expect(ex).toEqual(errorMatch.operInvalid());
+                });
           });
-
-          return promiseUtil.require(mid, localRequire)
-              .then(function() {
-                var context = new Context();
-                return callGet(context, sync, mid);
-              })
-              .then(function() {
-                expect("to throw").toBe(true);
-              }, function(ex) {
-                expect(ex).toEqual(errorMatch.operInvalid());
-              });
-        }));
+        });
       });
 
-      it("should collect non-standard type ids in getAsync", withContext(function(Context, localRequire) {
-        function defineTempModule(mid) {
-          localRequire.define(mid, [], function() {
-            return function(context) {
-              return context.get("pentaho/type/simple").extend({type: {id: mid}});
-            };
-          });
-        }
+      it("should collect non-standard type ids in getAsync", function() {
 
-        function defineTempFacet(mid) {
-          localRequire.define(mid, ["pentaho/type/facets/Refinement"], function(Refinement) {
-            return Refinement.extend(null, {id: mid});
-          });
-        }
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
 
-        defineTempModule("pentaho/foo/dudu1");
-        defineTempModule("pentaho/foo/dudu2");
-        defineTempModule("pentaho/foo/dudu3");
-        defineTempModule("pentaho/foo/dudu4");
-        defineTempFacet("pentaho/foo/facets/Mixin1");
-        defineTempFacet("pentaho/foo/facets/Mixin2");
-        defineTempFacet("pentaho/foo/facets/Mixin3");
-        // -----
-
-        var context = new Context();
-        var RefinementMixin2 = localRequire("pentaho/type/facets/Refinement").extend(null, {id: "my/facets/foo"});
-        var spec = {
-          base: "complex",
-          props: [
-            {name: "foo1", type: "pentaho/foo/dudu1"},
-            {name: "foo2", type: {base: "pentaho/foo/dudu2"}},
-            {name: "foo3", type: {base: "list", of: "pentaho/foo/dudu3"}},
-            {name: "foo4", type: ["pentaho/foo/dudu3"]},
-            {name: "foo5", type: []},
-            {name: "foo6", type: {
-              base: "refinement",
-              of: "pentaho/foo/dudu3",
-              facets: ["pentaho/foo/facets/Mixin1", "pentaho/foo/facets/Mixin2", "DiscreteDomain", RefinementMixin2]
-            }},
-            {name: "foo7", type: {props: {
-              a: {type: "pentaho/foo/dudu4"},
-              b: {type: "pentaho/foo/dudu3"}
-            }}},
-            {name: "foo8", type: {
-              base: "refinement",
-              of: "string",
-              facets: "pentaho/foo/facets/Mixin3"
-            }}
-          ]
-        };
-
-        return context.getAsync(spec)
-            .then(function(InstCtor) {
-              expect(InstCtor.type.get("foo1").type.id).toBe("pentaho/foo/dudu1");
-              expect(InstCtor.type.get("foo2").type.ancestor.id).toBe("pentaho/foo/dudu2");
-              expect(InstCtor.type.get("foo3").type.of.id).toBe("pentaho/foo/dudu3");
-              expect(InstCtor.type.get("foo7").type.get("a").type.id).toBe("pentaho/foo/dudu4");
-              expect(InstCtor.type.get("foo8").type.facets[0]).toBe(localRequire("pentaho/foo/facets/Mixin3"));
+          function defineTempModule(mid) {
+            localRequire.define(mid, [], function() {
+              return function(context) {
+                return context.get("pentaho/type/simple").extend({type: {id: mid}});
+              };
             });
-      }));
+          }
+
+          function defineTempFacet(mid) {
+            localRequire.define(mid, ["pentaho/type/facets/Refinement"], function(Refinement) {
+              return Refinement.extend(null, {id: mid});
+            });
+          }
+
+          defineTempModule("pentaho/foo/dudu1");
+          defineTempModule("pentaho/foo/dudu2");
+          defineTempModule("pentaho/foo/dudu3");
+          defineTempModule("pentaho/foo/dudu4");
+          defineTempFacet("pentaho/foo/facets/Mixin1");
+          defineTempFacet("pentaho/foo/facets/Mixin2");
+          defineTempFacet("pentaho/foo/facets/Mixin3");
+
+          // -----
+
+          var context = new Context();
+          var RefinementMixin2 = localRequire("pentaho/type/facets/Refinement").extend(null, {id: "my/facets/foo"});
+          var spec = {
+            base: "complex",
+            props: [
+              {name: "foo1", type: "pentaho/foo/dudu1"},
+              {name: "foo2", type: {base: "pentaho/foo/dudu2"}},
+              {name: "foo3", type: {base: "list", of: "pentaho/foo/dudu3"}},
+              {name: "foo4", type: ["pentaho/foo/dudu3"]},
+              {name: "foo5", type: []},
+              {name: "foo6", type: {
+                base: "refinement",
+                of: "pentaho/foo/dudu3",
+                facets: [
+                  "pentaho/foo/facets/Mixin1",
+                  "pentaho/foo/facets/Mixin2",
+                  "DiscreteDomain",
+                  RefinementMixin2
+                ]
+              }},
+              {name: "foo7", type: {props: {
+                a: {type: "pentaho/foo/dudu4"},
+                b: {type: "pentaho/foo/dudu3"}
+              }}},
+              {name: "foo8", type: {
+                base: "refinement",
+                of: "string",
+                facets: "pentaho/foo/facets/Mixin3"
+              }}
+            ]
+          };
+
+          return context.getAsync(spec)
+              .then(function(InstCtor) {
+                expect(InstCtor.type.get("foo1").type.id).toBe("pentaho/foo/dudu1");
+                expect(InstCtor.type.get("foo2").type.ancestor.id).toBe("pentaho/foo/dudu2");
+                expect(InstCtor.type.get("foo3").type.of.id).toBe("pentaho/foo/dudu3");
+                expect(InstCtor.type.get("foo7").type.get("a").type.id).toBe("pentaho/foo/dudu4");
+                expect(InstCtor.type.get("foo8").type.facets[0]).toBe(localRequire("pentaho/foo/facets/Mixin3"));
+              });
+        });
+      });
 
       // should throw when sync and the requested module is not defined
       // should throw when sync and the requested module is not yet loaded
@@ -774,77 +862,94 @@ define([
         });
       }
 
-      it("should return a promise", withContext(function(Context, localRequire) {
-        configRequire(localRequire);
+      it("should return a promise", function() {
 
-        var context  = new Context();
-        var p = context.getAllAsync();
-        expect(p instanceof Promise).toBe(true);
-      }));
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
 
-      it("should return all registered Types under 'pentaho/type/value' by default",
-      withContext(function(Context, localRequire) {
-        configRequire(localRequire);
+          configRequire(localRequire);
 
-        var context = new Context();
+          var context = new Context();
+          var p = context.getAllAsync();
+          expect(p instanceof Promise).toBe(true);
+        });
+      });
 
-        return context
-            .getAllAsync()
-            .then(function(InstCtors) {
-              expect(InstCtors instanceof Array).toBe(true);
-              expect(InstCtors.length).toBe(1);
-              expect(InstCtors[0].type.id).toBe("exp/dude");
-            });
-      }));
+      it("should return all registered Types under 'pentaho/type/value' by default", function() {
 
-      it("should return an empty array when the specified baseType has no registrations",
-      withContext(function(Context, localRequire) {
-        configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
 
-        var context  = new Context();
+          configRequire(localRequire);
 
-        return context
-            .getAllAsync("abcdefgh")
-            .then(function(InstCtors) {
-              expect(InstCtors instanceof Array).toBe(true);
-              expect(InstCtors.length).toBe(0);
-            });
-      }));
+          var context = new Context();
 
-      it("should return all registered Types under a given base type id",
-      withContext(function(Context, localRequire) {
-        configRequire(localRequire);
+          return context
+              .getAllAsync()
+              .then(function(InstCtors) {
+                expect(InstCtors instanceof Array).toBe(true);
+                expect(InstCtors.length).toBe(1);
+                expect(InstCtors[0].type.id).toBe("exp/dude");
+              });
+        });
+      });
 
-        var context  = new Context();
+      it("should return an empty array when the specified baseType has no registrations", function() {
 
-        return context
-            .getAllAsync("exp/thing")
-            .then(function(InstCtors) {
-              expect(InstCtors instanceof Array).toBe(true);
-              expect(InstCtors.length).toBe(2);
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
 
-              var typeIds = InstCtors.map(function(InstCtor) { return InstCtor.type.id; });
-              var iFoo = typeIds.indexOf("exp/foo");
-              var iBar = typeIds.indexOf("exp/bar");
-              expect(iFoo).not.toBeLessThan(0);
-              expect(iBar).not.toBeLessThan(0);
-              expect(iFoo).not.toBe(iBar);
-            });
-      }));
+          configRequire(localRequire);
 
-      it("should return all registered Types that satisfy the isBrowsable filter",
-      withContext(function(Context, localRequire) {
-        configRequire(localRequire);
-        var context  = new Context();
+          var context = new Context();
 
-        return context
-            .getAllAsync("exp/thing", {"isBrowsable": true})
-            .then(function(InstCtors) {
-              expect(InstCtors instanceof Array).toBe(true);
-              expect(InstCtors.length).toBe(1);
-              expect(InstCtors[0].type.id).toBe("exp/foo");
-            });
-      }));
+          return context
+              .getAllAsync("abcdefgh")
+              .then(function(InstCtors) {
+                expect(InstCtors instanceof Array).toBe(true);
+                expect(InstCtors.length).toBe(0);
+              });
+        });
+      });
+
+      it("should return all registered Types under a given base type id", function() {
+
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
+
+          configRequire(localRequire);
+
+          var context  = new Context();
+
+          return context
+              .getAllAsync("exp/thing")
+              .then(function(InstCtors) {
+                expect(InstCtors instanceof Array).toBe(true);
+                expect(InstCtors.length).toBe(2);
+
+                var typeIds = InstCtors.map(function(InstCtor) { return InstCtor.type.id; });
+                var iFoo = typeIds.indexOf("exp/foo");
+                var iBar = typeIds.indexOf("exp/bar");
+                expect(iFoo).not.toBeLessThan(0);
+                expect(iBar).not.toBeLessThan(0);
+                expect(iFoo).not.toBe(iBar);
+              });
+        });
+      });
+
+      it("should return all registered Types that satisfy the isBrowsable filter", function() {
+
+        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
+
+          configRequire(localRequire);
+
+          var context  = new Context();
+
+          return context
+              .getAllAsync("exp/thing", {"isBrowsable": true})
+              .then(function(InstCtors) {
+                expect(InstCtors instanceof Array).toBe(true);
+                expect(InstCtors.length).toBe(1);
+                expect(InstCtors[0].type.id).toBe("exp/foo");
+              });
+        });
+      });
     }); // #getAllAsync
   }); // pentaho.type.Context
 });

--- a/test-js/unit/pentaho/type/Type.Spec.js
+++ b/test-js/unit/pentaho/type/Type.Spec.js
@@ -15,8 +15,9 @@
  */
 define([
   "pentaho/type/Instance",
+  "pentaho/type/SpecificationContext",
   "tests/pentaho/util/errorMatch"
-], function(Instance, errorMatch) {
+], function(Instance, SpecificationContext, errorMatch) {
 
   "use strict";
 
@@ -442,7 +443,7 @@ define([
 
         it("should ignore it, if it is a temporary id", function() {
           var Derived = Instance.extend({
-            type: {id: "_id"}
+            type: {id: SpecificationContext.idTemporaryPrefix + "id"}
           });
 
           expect(Derived.type.id).toBe(null);

--- a/test-js/unit/test-utils.js
+++ b/test-js/unit/test-utils.js
@@ -1,0 +1,104 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function() {
+
+  "use strict";
+
+  /* global it:false, expect:false, Promise:false */
+
+  return {
+    toAsyncJasmine: toAsyncJasmine,
+    itAsync: itAsync,
+    modal: modal,
+    expectToRejectWith: expectToRejectWith
+  };
+
+  /**
+   * Creates a function that adapts a given promise-based async test
+   * to a callback-based Jasmine-style async test.
+   *
+   * @param {function(any) : ?Promise} test A promise-based async test function.
+   *
+   * @return {function(function)} A Jasmine-style async test function.
+   */
+  function toAsyncJasmine(asyncTest) {
+    // Already has a `done` argument?
+    if(asyncTest.length > 0) {
+      return asyncTest;
+    }
+
+    return function(done) {
+      var promise = asyncTest();
+      if(!promise)
+        done();
+      else
+        promise.then(done, done.fail);
+    };
+  }
+
+  /**
+   * A Jasmine `it` function replacement that supports promise-based test functions,
+   * besides Jasmine-style test functions.
+   *
+   * @param {function(any) : ?Promise} test A promise-based async test function.
+   *
+   * @return {function(function)} A Jasmine-style async test function.
+   */
+  function itAsync(description, test) {
+    it(description, toAsyncJasmine(test));
+  }
+
+  /**
+   * Creates a promise that is resolved by waiting for all resulting promises
+   * of calling the given _modal_ test function with each of the given modes.
+   *
+   * @param {Array} modes An array of modes. Modes can be anything.
+   * @param {function(any) : ?Promise} modalTest A function that when given a mode returns a promise.
+   *
+   * @return {Promise} The overall promise.
+   */
+  function modal(modes, modalTest) {
+
+    return Promise.all(modes.map(testMode));
+
+    function testMode(mode) {
+      return Promise.resolve(modalTest(mode));
+    }
+  }
+
+  /**
+   * Jasmine helper that _expects_ that a given async function
+   * is rejected with a given type of error.
+   *
+   * @param {function() : ?Promise} asyncTest The async function that should throw or return a rejected promise
+   *  with a given error type.
+   * @param {any|Error|JasmineAsymmetricEqualityTester} [error] The error that is the cause for the rejection.
+   *  When unspecified, rejection of any type is still asserted.
+   */
+  function expectToRejectWith(asyncTest, error) {
+
+    return new Promise(function(resolve) { return resolve(asyncTest()); })
+        .then(function() {
+          return Promise.reject(new Error("Expected function to throw an error."));
+        }, function(ex) {
+          if(error != null) {
+            expect(ex).toEqual(error);
+          }
+          // All well, throw is expected. Swallow.
+        });
+  }
+});
+


### PR DESCRIPTION
* Tried to modularize the helper methods used to build test functions.
* Moved some resulting "primitives" to a new `test-utils.js` AMD module.
* Others, integrated into `require-test.js`

* Support for construction of types from generic type specifications with temporary ids.

@pentaho/millenniumfalcon please review.