### PR TITLE
[CLEANUP] License header updates and fix to keypress event listener

### DIFF
--- a/package-res/resources/web/pentaho/_doc/Class.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/Class.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/_doc/IRange.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/IRange.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/_doc/nonEmptyString.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/nonEmptyString.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/_doc/nully.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/nully.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/Atomic.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/Atomic.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/ITable.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/ITable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/ITableReadOnly.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/ITableReadOnly.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/Range.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/Range.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/CrossedColumn.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/CrossedColumn.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IAttribute.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IAttribute.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/ICell.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/ICell.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/ICrossedStructure.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/ICrossedStructure.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IFormatProvider.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IFormatProvider.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IMember.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IMember.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IMicColumn.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IMicColumn.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IMicTable.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IMicTable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IModel.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IModel.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/INumberFormat.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/INumberFormat.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/INumberFormatStyle.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/INumberFormatStyle.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IPlainColumn.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IPlainColumn.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IPlainTable.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IPlainTable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/IRow.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/IRow.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/ITable.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/ITable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/data/_doc/spec/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/spec/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/EventListener.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/EventListener.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IAnnotatable.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IAnnotatable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/ICollectionElement.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/ICollectionElement.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IConfigurable.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IConfigurable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IDisposable.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IDisposable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IEventRegistrationHandle.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IEventRegistrationHandle.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IListElement.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IListElement.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/ISpecifiable.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/ISpecifiable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/IWithKey.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/IWithKey.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/spec/IAnnotatable.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/spec/IAnnotatable.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/lang/_doc/spec/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/lang/_doc/spec/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/SpecificationContext.js
+++ b/package-res/resources/web/pentaho/type/SpecificationContext.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/SpecificationScope.js
+++ b/package-res/resources/web/pentaho/type/SpecificationScope.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/Factory.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/Factory.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/PropertyDynamicAttribute.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/PropertyDynamicAttribute.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IComplex.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IComplex.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IComplexProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IComplexProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IComplexTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IComplexTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IDate.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IDate.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IFunction.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IFunction.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IInstance.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IInstance.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IInstanceProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IInstanceProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IList.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IList.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IListProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IListProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IListTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IListTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IPropertyTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IPropertyTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IRefinementTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IRefinementTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/ISimple.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ISimple.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/ISimpleProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ISimpleProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/ISimpleTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ISimpleTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/ITypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ITypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IValue.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IValue.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IValueProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IValueProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IValueTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IValueTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UComplex.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UComplex.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UInstance.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UInstance.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UList.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UList.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UPropertyTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UPropertyTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/USimple.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/USimple.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/UValue.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UValue.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/_doc/spec/facets/IDiscreteDomainTypeProto.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/facets/IDiscreteDomainTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/type/facets/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/type/facets/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/util/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/util/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/visual/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/base/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/visual/base/_doc/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/base/_doc/spec/IModel.jsdoc
+++ b/package-res/resources/web/pentaho/visual/base/_doc/spec/IModel.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
@@ -11,7 +11,7 @@ define([
     _init: function() {
       this.base();
       var me = this;
-      window.onkeypress = function(e){
+      window.addEventListener("keypress", function(e) {
         var ignoreTags = ["TEXTAREA", "INPUT"];
 
         if(ignoreTags.includes(e.target.tagName)) return;
@@ -22,9 +22,9 @@ define([
           "KeyR": selectionModes.REPLACE,
           "KeyT": selectionModes.TOGGLE
         };
-        me.model.set("selectionMode", mode[e.code]);
 
-      };
+        me.model.set("selectionMode", mode[e.code]);
+      }, false);
 
       this.model.on("will:select",  this._onWillSelect.bind(this));
 
@@ -48,7 +48,7 @@ define([
       }, []);
 
       // Remove restrictions on the properties that span multiple charts.
-      var dataFilter = event.dataFilter.walk(function(node, children) {
+      var dataFilter = event.dataFilter.visit(function(node, children) {
         if(children !== null && children.length === 0) return null;
 
         if(node instanceof filter.AbstractPropertyFilter) {


### PR DESCRIPTION
The way our keypress event listener in ViewDemo was being created, was being used by [StaticAutocompleteBoxComponent](https://github.com/pentaho/pentaho-platform-plugin-common-ui/blob/master/package-res/resources/web/prompting/components/StaticAutocompleteBoxComponent.js)  and others. The reason for the failure was that it seems Phantom doesn't has Array.contains defined.

@pentaho/millenniumfalcon please review 