### PR TITLE
[BACKLOG-6733] Allow config of local require prior to its first use

### DIFF
--- a/test-js/unit/pentaho/type/Context.Spec.js
+++ b/test-js/unit/pentaho/type/Context.Spec.js
@@ -986,9 +986,7 @@ define([
 
       it("should return a promise", function() {
 
-        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
-
-          configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], configRequire, function(localRequire, Context) {
 
           var context = new Context();
           var p = context.getAllAsync();
@@ -998,9 +996,7 @@ define([
 
       it("should return all registered Types under 'pentaho/type/value' by default", function() {
 
-        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
-
-          configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], configRequire, function(localRequire, Context) {
 
           var context = new Context();
 
@@ -1016,9 +1012,7 @@ define([
 
       it("should return an empty array when the specified baseType has no registrations", function() {
 
-        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
-
-          configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], configRequire, function(localRequire, Context) {
 
           var context = new Context();
 
@@ -1033,9 +1027,7 @@ define([
 
       it("should return all registered Types under a given base type id", function() {
 
-        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
-
-          configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], configRequire, function(localRequire, Context) {
 
           var context  = new Context();
 
@@ -1057,9 +1049,7 @@ define([
 
       it("should return all registered Types that satisfy the isBrowsable filter", function() {
 
-        return require.using(["require", "pentaho/type/Context"], function(localRequire, Context) {
-
-          configRequire(localRequire);
+        return require.using(["require", "pentaho/type/Context"], configRequire, function(localRequire, Context) {
 
           var context  = new Context();
 

--- a/test-js/unit/require-test.js
+++ b/test-js/unit/require-test.js
@@ -126,7 +126,12 @@
     });
   };
 
-  require.using = function(deps, scopedFun) {
+  require.using = function(deps, config, scopedFun) {
+    if(!scopedFun && typeof config === "function") {
+      scopedFun = config;
+      config = null;
+    }
+
     // Identify the special "require" argument.
     // Copy the array, remove "require", and add `localRequire` in its place, later.
     var requireIndex = deps.indexOf("require");
@@ -134,6 +139,11 @@
       (deps = deps.slice()).splice(requireIndex, 1);
 
     var localRequire = this.new();
+    if(typeof config === "function") {
+      config.call(config, localRequire);
+    } else if(config !== null) {
+      localRequire.config(config);
+    }
 
     return localRequire.promise(deps)
         .then(processDeps)


### PR DESCRIPTION
* `require.using` receives `config` as second argument
* `config` can either be a function to be called with the cloned require or an object to pass to the `config` method
* the previous `using` method signature is still supported

@dcleao This resolves the issue we were seeing last friday. Please review.