### PR TITLE
[BACKLOG-6733] Documentation in JsDocs form

### DIFF
--- a/package-res/resources/web/pentaho/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/_namespace.jsdoc
@@ -21,3 +21,11 @@
  * @name pentaho
  * @namespace
  */
+
+/**
+ * The pentaho `spec` namespace contains specification interfaces
+ * used by the Pentaho Web Platform's classes and interfaces.
+ *
+ * @name pentaho.spec
+ * @namespace
+ */

--- a/package-res/resources/web/pentaho/_doc/spec/IContextVars.jsdoc
+++ b/package-res/resources/web/pentaho/_doc/spec/IContextVars.jsdoc
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.IContextVars` interface describes the variables that
+ * define a Pentaho client-side context.
+ *
+ * A {@link Nully} variable value is equivalent to a variable that is not present.
+ *
+ * @name pentaho.spec.IContextVars
+ * @interface
+ */
+
+/**
+ * The id of the application.
+ *
+ * @name application
+ * @memberOf pentaho.spec.IContextVars#
+ * @type {?string}
+ */
+
+/**
+ * The id of the user.
+ *
+ * @name user
+ * @memberOf pentaho.spec.IContextVars#
+ * @type {?string}
+ */
+
+/**
+ * The id of the theme.
+ *
+ * @name theme
+ * @memberOf pentaho.spec.IContextVars#
+ * @type {?string}
+ */
+
+/**
+ * The id of the locale.
+ *
+ * @name locale
+ * @memberOf pentaho.spec.IContextVars#
+ * @type {?string}
+ */

--- a/package-res/resources/web/pentaho/lang/Base.js
+++ b/package-res/resources/web/pentaho/lang/Base.js
@@ -267,6 +267,7 @@ define([
      * @memberOf pentaho.lang.Base#
      * @type {function}
      * @readonly
+     * @protected
      */
     Object.defineProperty(BaseRoot.prototype, "base", {
       configurable: true,

--- a/package-res/resources/web/pentaho/type/ComplexChangeset.js
+++ b/package-res/resources/web/pentaho/type/ComplexChangeset.js
@@ -118,7 +118,7 @@ define([
     },
 
     /**
-     * Prevents further changes to this changeset
+     * Prevents further changes to this changeset.
      */
     freeze: function(){
       O.eachOwn(this._properties, function(change){

--- a/package-res/resources/web/pentaho/type/_doc/IConfigurationService.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/IConfigurationService.jsdoc
@@ -1,0 +1,140 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `IConfigurationService` interface describes a service
+ * that manages configurations of [value types]{@link pentaho.type.Value.Type}
+ * of the Pentaho Client Metadata Model.
+ *
+ * The [add]{@link pentaho.type.IConfigurationService#add} method
+ * is used to register a [spec.ITypeConfiguration]{@link pentaho.type.spec.ITypeConfiguration}
+ * to the service.
+ *
+ * The [select]{@link pentaho.type.IConfigurationService#select} method
+ * selects the rules of added type configurations that apply to
+ * a given type and context variables,
+ * sorts these by specificity,
+ * then merges the rules' [type specifications]{@link pentaho.type.spec.ITypeConfigurationRule#apply}
+ * and returns the result.
+ * For more information on the specificity of rules,
+ * see [spec.ITypeConfiguration]{@link pentaho.type.spec.ITypeConfiguration}.
+ *
+ * The merged type configuration specification can then be used to configure a value type,
+ * by calling its [pentaho.type.Type.implement]{@link pentaho.lang.Base.implement} method.
+ *
+ * Normally, you won't call these operations directly.
+ *
+ * The singleton configuration service, {@link pentaho.type.configurationService},
+ * already handles loading of all type configurations registered
+ * with the [pentaho/service]{@link pentaho.service} module,
+ * under the service id `pentaho.type.spec.ITypeConfiguration`.
+ *
+ * Then, the [Context]{@link pentaho.type.Context} class
+ * already handles obtaining configurations from its configuration service,
+ * and applying these to the requested value types.
+ *
+ * The following example illustrates how an implementation of this service would be used:
+ *
+ * ```js
+ * var myTypeConfig = {
+ *   rules: [
+ *     // Disable a still experimental Viz.
+ *     {
+ *       select: {
+ *         type: "my/radial/bar"
+ *       },
+ *       apply: {
+ *         isBrowsable: false
+ *       }
+ *     },
+ *
+ *     // Enable it, only for the dev user, "john", when in Analyzer
+ *     {
+ *       select: {
+ *         type:      "my/radial/bar",
+ *         user:      "john",
+ *         container: "pentaho.analyzer"
+ *       },
+ *       apply: {
+ *         isBrowsable: true
+ *       }
+ *     }
+ *   ]
+ * };
+ *
+ * var configService = new SomeConfigurationService();
+ *
+ * configService.add(myTypeConfig);
+ *
+ * var mergedTypeConfigSpec = configService.select("pentaho/visual/ccc/bar", {
+ *      user:      "john",
+ *      container: "pentaho.cdf"
+ *    });
+ *
+ * // Results in a specification like:
+ * // {
+ * //   isBrowsable: false
+ * // }
+ * ```
+ *
+ * @name pentaho.type.IConfigurationService
+ * @interface
+ *
+ * @see pentaho.type.Context
+ * @see pentaho.type.spec.ITypeConfiguration
+ */
+
+/**
+ * Obtains the merged configuration specification of
+ * the selection of configuration rules that apply to a given type and context variables.
+ *
+ * @name select
+ * @memberOf pentaho.type.IConfigurationService#
+ * @method
+ *
+ * @param {string} typeId The [id]{@link pentaho.type.Type#id} of the type whose
+ * configuration specification is desired.
+ *
+ * @param {pentaho.type.IContextVars} [contextVars] The context variables that are used to select rules.
+ *
+ * A {@link Nully} variable value is equivalent to a variable that is not present.
+ * It matches only configuration rules that do not select that variable.
+ *
+ * When the map is unspecified,
+ * every variable will appear as though it had been specified with a `null` value.
+ *
+ * Variable values are matched against each value specified by a rule in its selection variables,
+ * using JavaScript's strict equality operator, `===`.
+ *
+ * @return {pentaho.type.spec.ITypeProto} The merged configuration specification,
+ * if any rule was selected, or `null`, if no rule was selected.
+ */
+
+/**
+ * Adds a configuration.
+ *
+ * An added configuration overrides previously added configurations,
+ * if all other rule-ordering criteria are equal.
+ * For more information on the specificity of rules,
+ * see [spec.ITypeConfiguration]{@link pentaho.type.spec.ITypeConfiguration}.
+ *
+ *
+ * @name add
+ * @memberOf pentaho.type.IConfigurationService#
+ * @method
+ *
+ * @param {!pentaho.type.ITypeConfiguration} config A type configuration to add.
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfiguration.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfiguration.jsdoc
@@ -1,0 +1,101 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.ITypeConfiguration` interface describes
+ * a list of [configuration rules]{@link pentaho.type.spec.ITypeConfiguration#rules}
+ * used to configure one or more [value types]{@link pentaho.type.Value.Type} of
+ * the Pentaho Client Metadata Model.
+ *
+ * The following example is a hypothetical configuration,
+ * where a developer (John) states that only he should see the visualization
+ * he is currently developing (my/radial/bar) and
+ * only then when working in Pentaho Analyzer:
+ *
+ * ```js
+ * var myTypeConfig = {
+ *   rules: [
+ *     // Disable a still experimental Viz.
+ *     {
+ *       select: {
+ *         type: "my/radial/bar"
+ *       },
+ *       apply: {
+ *         isBrowsable: false
+ *       }
+ *     },
+ *
+ *     // Enable it, only for the dev user, "john", when in Analyzer
+ *     {
+ *       select: {
+ *         type:        "my/radial/bar",
+ *         user:        "john",
+ *         application: "pentaho.analyzer"
+ *       },
+ *       apply: {
+ *         isBrowsable: true
+ *       }
+ *     }
+ *   ]
+ * };
+ * ```
+ *
+ * ### Rule Selection
+ *
+ * A rule is selected by a given type and context variables,
+ * if the type and variables match the rule's
+ * [selection variables]{@link pentaho.type.spec.ITypeConfigurationRule#select}.
+ *
+ * ### Rule Specificity
+ *
+ * Rule specificity is a measure of the relevance of a rule.
+ *
+ * When two or more _selected_ rules configure the same specification attribute,
+ * it is the value used by the most specific rule that wins.
+ * When configured values are structural and are instead merged,
+ * like with an {@link Object} value,
+ * specificity determines the order in the merge operation
+ * (most specific is merged over less specific).
+ *
+ * A rule is more specific than another if it:
+ *
+ * 1. has a greater [priority]{@link pentaho.type.spec.ITypeConfigurationRule#priority};
+ *    this is the attribute that most affects specificity, and can be used to easily
+ *    surpass every other affecting factors,
+ * 2. selects a user (and the other doesn't),
+ * 3. selects a theme (and the other doesn't),
+ * 4. selects a locale (and the other doesn't),
+ * 5. selects an application (and the other doesn't),
+ * 6. belongs to a type configuration that was added later, or
+ * 7. it is at a greater index in the type configuration rules list.
+ *
+ * @name pentaho.type.spec.ITypeConfiguration
+ * @interface
+ *
+ * @see pentaho.type.IConfigurationService
+ */
+
+/**
+ * The list of configuration rules.
+ *
+ * Within a type configuration,
+ * if all other rule ordering criteria are equal,
+ * the later configuration rules override the former configuration rules.
+ *
+ * @name rules
+ * @memberOf pentaho.type.spec.ITypeConfiguration#
+ * @type {pentaho.type.spec.ITypeConfigurationRule}
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfigurationRule.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfigurationRule.jsdoc
@@ -1,0 +1,61 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.ITypeConfigurationRule` interface describes
+ * a type configuration rule,
+ * used to configure one or more [value types]{@link pentaho.type.Value.Type} of
+ * the Pentaho Client Metadata Model.
+ *
+ * A configuration rule is part of a [type(s) configuration]{@link pentaho.type.spec.ITypeConfiguration}.
+ *
+ * @name pentaho.type.spec.ITypeConfigurationRule
+ * @interface
+ *
+ * @see pentaho.type.spec.ITypeConfiguration
+ */
+
+/**
+ * The priority of the type configuration rule.
+ *
+ * A rule's priority is the attribute that most influences its precedence order.
+ *
+ * @name priority
+ * @memberOf pentaho.type.spec.ITypeConfigurationRule#
+ * @type {number}
+ * @default 0
+ */
+
+/**
+ * The criteria map that determines when a rule is selected for a
+ * given type and context variables.
+ *
+ * When the map is unspecified,
+ * it is like every selection variable had been specified with a `null` value.
+ *
+ * @name select
+ * @memberOf pentaho.type.spec.ITypeConfigurationRule#
+ * @type {pentaho.type.spec.ITypeConfigurationRuleSelection}
+ */
+
+/**
+ * The actual configuration specification that
+ * is _applied_ to the selected value type(s).
+ *
+ * @name apply
+ * @memberOf pentaho.type.spec.ITypeConfigurationRule#
+ * @type {pentaho.type.spec.IValueTypeProto}
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfigurationRuleSelection.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/ITypeConfigurationRuleSelection.jsdoc
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.ITypeConfigurationRuleSelection` interface describes
+ * the criteria map that determines when a rule is selected for a
+ * given type and context variables.
+ *
+ * It is the type of the [select]{@link pentaho.type.ITypeConfigurationRule#select} attribute
+ * of a type configuration rule.
+ *
+ * Besides the [type]{@link pentaho.type.spec.ITypeConfigurationRuleSelection#type} property,
+ * this interface allows filtering on any of the [context variables]{@link pentaho.spec.IContextVars}.
+ *
+ * @name pentaho.type.spec.ITypeConfigurationRuleSelection
+ * @interface
+ *
+ * @see pentaho.type.spec.ITypeConfigurationRule
+ */
+
+/**
+ * The id or [ids]{@link pentaho.type.Type#id} of the value types that the rule applies to.
+ *
+ * When {@link Nully} or unspecified, it defaults to the root value type,
+ * [value]{@link pentaho.type.Value}.
+ *
+ * The specified id or ids may be standard
+ * [short ids]{@link pentaho.type.Type#shortId} or absolute.
+ *
+ * When an id does not contain any "/" character, it is considered a standard type and
+ * is taken relative to Pentaho's `"pentaho/type"` module.
+ * Otherwise, it is considered absolute.
+ *
+ * Note that relative AMD module ids, such as "./foo", are not supported.
+ *
+ * @name type
+ * @memberOf pentaho.type.spec.ITypeConfigurationRuleSelection#
+ * @type {?pentaho.type.spec.UContextVarFilter<string>}
+ * @default "value"
+ *
+ * @see pentaho.type.spec.UTypeReference
+ */
+
+/**
+ * The id or ids of the application that the rule applies to.
+ *
+ * @name application
+ * @memberOf pentaho.type.spec.ITypeConfigurationRuleSelection#
+ * @type {?pentaho.type.spec.UContextVarFilter<string>}
+ */
+
+/**
+ * The id or ids of the user that the rule applies to.
+ *
+ * @name user
+ * @memberOf pentaho.type.spec.ITypeConfigurationRuleSelection#
+ * @type {?pentaho.type.spec.UContextVarFilter<string>}
+ */
+
+/**
+ * The id or ids of the theme that the rule applies to.
+ *
+ * @name theme
+ * @memberOf pentaho.type.spec.ITypeConfigurationRuleSelection#
+ * @type {?pentaho.type.spec.UContextVarFilter<string>}
+ */
+
+/**
+ * The id or ids of the locale that the rule applies to.
+ *
+ * @name locale
+ * @memberOf pentaho.type.spec.ITypeConfigurationRuleSelection#
+ * @type {?pentaho.type.spec.UContextVarFilter<string>}
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/UContextVarFilter.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UContextVarFilter.jsdoc
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A `spec.UContextVarFilter` represents the union of JS types that can be used to
+ * filter the value of a [context variable]{@link pentaho.spec.IContextVars},
+ * in the [select]{@link pentaho.type.spec.ITypeConfigurationRule#select} attribute
+ * of a type configuration rule.
+ *
+ * A {@link Nully} filter, is equivalent to not filtering a variable.
+ * When unfiltered, any context variable value is matched.
+ *
+ * An array filter matches a context variable if any of the values in the array
+ * are the same exact value of the context variable.
+ *
+ * Any other value is assumed to be a single value, and matches the context variable
+ * if it is the same value.
+ *
+ * @typedef {Nully|any|Array.<any>} pentaho.type.spec.UContextVarFilter
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/UTypeReference.jsdoc
@@ -26,11 +26,10 @@
  * or a [temporary]{@link pentaho.type.SpecificationContext.isIdTemporary},
  * serialization-only id.
  *
- * If the id is permanent and does not contain any "/" character,
- * it is considered a standard type, and, thus,
- * is taken relative to Pentaho's `"pentaho/type"` module.
+ * When an id is permanent and does not contain any "/" character,
+ * it is considered a standard type and is taken relative to Pentaho's `"pentaho/type"` module.
  *
- * Note that relative AMD module ids, like, for example, `"./foo"`, are not supported.
+ * Note that relative AMD module ids, such as "./foo", are not supported.
  *
  * Example absolute, permanent id:
  * ```js


### PR DESCRIPTION
* Also, moved the several variable getters in Context to a new `vars` property,
  of type pentaho.IContextVars property.
* Created a pentaho.GlobalContextVars class that does the dirty work of defaulting
  context variables to the values of Pentaho System's global variables.
* Requires rebuild of the whole project due to require-js-cfg.js changes.

@pentaho/millenniumfalcon please review. This requires JsDocs review by @swagner8412.