### PR TITLE
[BACKLOG-6733] Moving pentaho.type.Context variables to a `vars` property of type pentaho.IContextVars property.

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -52,6 +52,7 @@
   requirePaths["pentaho/service"] = basePath + "/pentaho/service";
   requirePaths["pentaho/i18n"] = basePath + "/pentaho/i18n";
   requirePaths["pentaho/shim"] = basePath + "/pentaho/shim";
+  requirePaths["pentaho/GlobalContextVars"] = basePath + "/pentaho/GlobalContextVars";
 
   // AMD PLUGINS
   requirePaths["local"  ] = basePath + "/util/local";

--- a/package-res/resources/web/pentaho/GlobalContextVars.js
+++ b/package-res/resources/web/pentaho/GlobalContextVars.js
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "./lang/Base",
+  "./util/object",
+  "./util/arg"
+], function(Base, O, arg) {
+
+  "use strict";
+
+  /*global SESSION_NAME:false, SESSION_LOCALE:false, active_theme:false */
+
+  return Base.extend("pentaho.GlobalContextVars", {
+
+    /**
+     * @alias GlobalContextVars
+     * @memberOf pentaho
+     *
+     * @class
+     * @extends pentaho.lang.Base
+     * @implements pentaho.spec.IContextVars
+     *
+     * @classDesc The `GlobalContextVars` class implements a read-only
+     * [IContextVars]{@link pentaho.spec.IContextVars} whose variables default to the
+     * values of the Pentaho System's corresponding global variables.
+     *
+     * @constructor
+     * @description Creates a context variables object, optionally fixing some variables to the values
+     * specified in `contextVar`. Any absent or {@link Nully}-valued properties assume the values
+     * of the Pentaho System's corresponding global variables.
+     *
+     * @param {pentaho.spec.IContextVars} [contextVars] The input context variables' specification.
+     */
+    constructor: function(contextVars) {
+
+      // It's important that these are own value properties, and not getters,
+      // to mimic the semantics of plain objects, where only own properties are considered.
+
+      this.application = arg.optional(contextVars, "application") || getSysApp();
+      this.user        = arg.optional(contextVars, "user")        || getSysUser();
+      this.theme       = arg.optional(contextVars, "theme")       || getSysTheme();
+      this.locale      = arg.optional(contextVars, "locale")      || getSysLocale();
+
+      Object.freeze(this);
+    }
+  });
+
+  function getSysApp() {
+    // TODO: should try to find webcontext.js in scripts collection?
+    return null;
+  }
+
+  function getSysUser() {
+    return typeof SESSION_NAME !== "undefined" ? SESSION_NAME : null;
+  }
+
+  function getSysTheme() {
+    return typeof active_theme !== "undefined" ? active_theme : null;
+  }
+
+  function getSysLocale() {
+    return typeof SESSION_LOCALE !== "undefined" ? SESSION_LOCALE : null;
+  }
+});

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -21,6 +21,7 @@ define([
   "./standard",
   "./SpecificationContext",
   "./SpecificationScope",
+  "../GlobalContextVars",
   "../lang/Base",
   "../util/promise",
   "../util/arg",
@@ -28,7 +29,7 @@ define([
   "../util/object",
   "../util/fun"
 ], function(localRequire, module, Instance, bundle, standard, SpecificationContext, SpecificationScope,
-    Base, promiseUtil, arg, error, O, F) {
+    GlobalContextVars, Base, promiseUtil, arg, error, O, F) {
 
   "use strict";
 
@@ -149,19 +150,13 @@ define([
    *
    * @constructor
    * @description Creates a `Context` whose variables default to the Pentaho thin-client state variables.
-   * @param {object} [keyArgs] Keyword arguments.
-   * @param {string?} [keyArgs.container] The id of the container application.
-   * @param {string?} [keyArgs.user] The id of the user. Defaults to the current user.
-   * @param {string?} [keyArgs.theme] The id of the theme. Defaults to the current theme.
-   * @param {string?} [keyArgs.locale] The id of the locale. Defaults to the current locale.
+   * @param {pentaho.spec.IContextVars} [contextVars] The context variables' specification.
+   * When unspecified, it defaults to an instance of {@link pentaho.GlobalContextVars}.
    */
   var Context = Base.extend(/** @lends pentaho.type.Context# */{
 
-    constructor: function(keyArgs) {
-      this._container = arg.optional(keyArgs, "container") || getCurrentContainer();
-      this._user      = arg.optional(keyArgs, "user")      || getCurrentUser();
-      this._theme     = arg.optional(keyArgs, "theme")     || getCurrentTheme();
-      this._locale    = arg.optional(keyArgs, "locale")    || getCurrentLocale();
+    constructor: function(contextVars) {
+      this._vars = contextVars || new GlobalContextVars();
 
       // factory uid : Class.<pentaho.type.Value>
       this._byFactoryUid = {};
@@ -181,48 +176,15 @@ define([
       }, this);
     },
 
-    //region context variables
-
     /**
-     * Gets the id of the context's container application, if any.
+     * The context's variables.
      *
-     * @type {?string}
-     * @readonly
+     * @type {!pentaho.type.IContextVars}
+     * @readOnly
      */
-    get container() {
-      return this._container;
+    get vars() {
+      return this._vars;
     },
-
-    /**
-     * Gets the id of the context's user, if any.
-     *
-     * @type {?string}
-     * @readonly
-     */
-    get user() {
-      return this._user;
-    },
-
-    /**
-     * Gets the id of the context's theme, if any.
-     *
-     * @type {?string}
-     * @readonly
-     */
-    get theme() {
-      return this._theme;
-    },
-
-    /**
-     * Gets the id of the context's locale, if any.
-     *
-     * @type {?string}
-     * @readonly
-     */
-    get locale() {
-      return this._locale;
-    },
-    //endregion
 
     /**
      * Gets the **configured instance constructor** of a value type.
@@ -865,7 +827,7 @@ define([
     },
 
     _getConfig: function(id) {
-      // TODO: link to configuration service
+      // TODO: link to configuration service, passing this._vars
       return null;
     },
     //endregion
@@ -881,23 +843,6 @@ define([
   });
 
   return Context;
-
-  function getCurrentContainer() {
-    // TODO: should try to find webcontext.js in scripts collection?
-    return null;
-  }
-
-  function getCurrentUser() {
-    return typeof SESSION_NAME !== "undefined" ? SESSION_NAME : null;
-  }
-
-  function getCurrentTheme() {
-    return typeof active_theme !== "undefined" ? active_theme : null;
-  }
-
-  function getCurrentLocale() {
-    return typeof SESSION_LOCALE !== "undefined" ? SESSION_LOCALE : null;
-  }
 
   function getFactoryUid(factory) {
     return factory._fuid_ || (factory._fuid_ = _nextUid++);

--- a/test-js/unit/pentaho/GlobalContextVars.Spec.js
+++ b/test-js/unit/pentaho/GlobalContextVars.Spec.js
@@ -1,0 +1,166 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Must be executed out of strict scope
+var __global__ = this;
+
+define([
+  "pentaho/GlobalContextVars"
+], function(GlobalContextVars) {
+
+  "use strict";
+
+  /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false */
+
+  // These should really be writable, i.e. globalVar: true
+  /*global SESSION_NAME:true, active_theme:true, SESSION_LOCALE:true */
+
+  // Use alternate, promise-aware version of `it`.
+
+  describe("pentaho.GlobalContextVars -", function() {
+
+    it("is a function", function() {
+      expect(typeof GlobalContextVars).toBe("function");
+    });
+
+    describe("new GlobalContextVars(spec) -", function() {
+
+      it("should return a GlobalContextVars instance", function() {
+        var vars = new GlobalContextVars();
+        expect(vars instanceof GlobalContextVars).toBe(true);
+      });
+
+      describe("application -", function() {
+
+        it("should have a null value when unspecified and there is no current one", function() {
+          var vars = new GlobalContextVars();
+          expect(vars.application).toBe(null);
+        });
+
+        it("should have a null value when specified empty", function() {
+          var vars = new GlobalContextVars({application: ""});
+          expect(vars.application).toBe(null);
+        });
+
+        it("should respect a specified non-empty value", function() {
+          var vars = new GlobalContextVars({application: "FOO"});
+          expect(vars.application).toBe("FOO");
+        });
+      });
+
+      describe("user -", function() {
+        var _SESSION_NAME;
+
+        beforeEach(function() {
+          _SESSION_NAME = __global__.SESSION_NAME;
+          __global__.SESSION_NAME = undefined;
+        });
+
+        afterEach(function() {
+          __global__.SESSION_NAME = _SESSION_NAME;
+        });
+
+        it("should have a null value when unspecified and there is no current one", function() {
+          var vars = new GlobalContextVars();
+          expect(vars.user).toBe(null);
+        });
+
+        it("should have a null value when specified empty", function() {
+
+          var vars = new GlobalContextVars({user: ""});
+          expect(vars.user).toBe(null);
+        });
+
+        it("should respect a specified non-empty value", function() {
+          var vars = new GlobalContextVars({user: "FOO"});
+          expect(vars.user).toBe("FOO");
+        });
+
+        it("should default to the existing current one", function() {
+          __global__.SESSION_NAME = "ABC";
+          var vars = new GlobalContextVars();
+          expect(vars.user).toBe("ABC");
+        });
+      });
+
+      describe("theme -", function() {
+        var _active_theme;
+        beforeEach(function() {
+          _active_theme = __global__.active_theme;
+          __global__.active_theme = undefined;
+        });
+
+        afterEach(function() {
+          __global__.active_theme = _active_theme;
+        });
+
+        it("should have a null value when unspecified and there is no current one", function() {
+          var vars = new GlobalContextVars();
+          expect(vars.theme).toBe(null);
+        });
+
+        it("should have a null value when specified empty", function() {
+          var vars = new GlobalContextVars({theme: ""});
+          expect(vars.theme).toBe(null);
+        });
+
+        it("should respect a specified non-empty value", function() {
+          var vars = new GlobalContextVars({theme: "FOO"});
+          expect(vars.theme).toBe("FOO");
+        });
+
+        it("should default to the existing current one", function() {
+          __global__.active_theme = "ABC";
+          var vars = new GlobalContextVars();
+          expect(vars.theme).toBe("ABC");
+        });
+      });
+
+      describe("locale -", function() {
+        var _SESSION_LOCALE;
+        beforeEach(function() {
+          _SESSION_LOCALE = __global__.SESSION_LOCALE;
+          __global__.SESSION_LOCALE = undefined;
+        });
+
+        afterEach(function() {
+          SESSION_LOCALE = _SESSION_LOCALE;
+        });
+
+        it("should have a null value when unspecified and there is no current one", function() {
+          var vars = new GlobalContextVars();
+          expect(vars.locale).toBe(null);
+        });
+
+        it("should have a null value when specified empty", function() {
+          var vars = new GlobalContextVars({locale: ""});
+          expect(vars.locale).toBe(null);
+        });
+
+        it("should respect a specified non-empty value", function() {
+          var vars = new GlobalContextVars({locale: "FOO"});
+          expect(vars.locale).toBe("FOO");
+        });
+
+        it("should default to the existing current one", function() {
+          __global__.SESSION_LOCALE = "ABC";
+          var vars = new GlobalContextVars();
+          expect(vars.locale).toBe("ABC");
+        });
+      });
+    });
+  }); // pentaho.GlobalContextVars
+});

--- a/test-js/unit/pentaho/type/Context.Spec.js
+++ b/test-js/unit/pentaho/type/Context.Spec.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// Must be executed out of strict scope
-var __global__ = this;
-
 define([
   "pentaho/type/standard",
   "tests/test-utils"
@@ -25,9 +22,6 @@ define([
   "use strict";
 
   /*global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, Promise:false, spyOn:false*/
-
-  // These should really be writable, i.e. globalVar: true
-  /*global SESSION_NAME:true, active_theme:true, SESSION_LOCALE:true */
 
   // Use alternate, promise-aware version of `it`.
   var it = testUtils.itAsync;
@@ -49,169 +43,6 @@ define([
         return require.using(["pentaho/type/Context"], function(Context) {
           var context = new Context();
           expect(context instanceof Context).toBe(true);
-        });
-      });
-
-      describe("container -", function() {
-
-        it("should have a null value when unspecified and there is no current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context();
-            expect(context.container).toBe(null);
-          });
-        });
-
-        it("should have a null value when specified empty", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({container: ""});
-            expect(context.container).toBe(null);
-          });
-        });
-
-        it("should respect a specified non-empty value", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({container: "FOO"});
-            expect(context.container).toBe("FOO");
-          });
-        });
-      });
-
-      describe("user -", function() {
-        var _SESSION_NAME;
-
-        beforeEach(function() {
-          _SESSION_NAME = __global__.SESSION_NAME;
-          __global__.SESSION_NAME = undefined;
-        });
-
-        afterEach(function() {
-          __global__.SESSION_NAME = _SESSION_NAME;
-        });
-
-        it("should have a null value when unspecified and there is no current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context();
-            expect(context.user).toBe(null);
-          });
-        });
-
-        it("should have a null value when specified empty", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({user: ""});
-            expect(context.user).toBe(null);
-          });
-        });
-
-        it("should respect a specified non-empty value", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({user: "FOO"});
-            expect(context.user).toBe("FOO");
-          });
-        });
-
-        it("should default to the existing current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            __global__.SESSION_NAME = "ABC";
-            var context = new Context();
-            expect(context.user).toBe("ABC");
-          });
-        });
-      });
-
-      describe("theme -", function() {
-        var _active_theme;
-        beforeEach(function() {
-          _active_theme = __global__.active_theme;
-          __global__.active_theme = undefined;
-        });
-
-        afterEach(function() {
-          __global__.active_theme = _active_theme;
-        });
-
-        it("should have a null value when unspecified and there is no current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context();
-            expect(context.theme).toBe(null);
-          });
-        });
-
-        it("should have a null value when specified empty", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({theme: ""});
-            expect(context.theme).toBe(null);
-          });
-        });
-
-        it("should respect a specified non-empty value", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({theme: "FOO"});
-            expect(context.theme).toBe("FOO");
-          });
-        });
-
-        it("should default to the existing current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            __global__.active_theme = "ABC";
-            var context = new Context();
-            expect(context.theme).toBe("ABC");
-          });
-        });
-      });
-
-      describe("locale -", function() {
-        var _SESSION_LOCALE;
-        beforeEach(function() {
-          _SESSION_LOCALE = __global__.SESSION_LOCALE;
-          __global__.SESSION_LOCALE = undefined;
-        });
-
-        afterEach(function() {
-          SESSION_LOCALE = _SESSION_LOCALE;
-        });
-
-        it("should have a null value when unspecified and there is no current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context();
-            expect(context.locale).toBe(null);
-          });
-        });
-
-        it("should have a null value when specified empty", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({locale: ""});
-            expect(context.locale).toBe(null);
-          });
-        });
-
-        it("should respect a specified non-empty value", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            var context = new Context({locale: "FOO"});
-            expect(context.locale).toBe("FOO");
-          });
-        });
-
-        it("should default to the existing current one", function() {
-
-          return require.using(["pentaho/type/Context"], function(Context) {
-            __global__.SESSION_LOCALE = "ABC";
-            var context = new Context();
-            expect(context.locale).toBe("ABC");
-          });
         });
       });
     });


### PR DESCRIPTION
* Created a pentaho.GlobalContextVars class that does the dirty work of defaulting
  context variables to the values of Pentaho System's global variables.
* Requires rebuild of the whole project dues to require-js-cfg.js changes.

@pentaho/millenniumfalcon please review.