### PR TITLE
[SP-2634][BISERVER-13107] Query-driven textbox parameters defined as …

### DIFF
--- a/package-res/resources/web/prompting/pentaho-prompting-components.js
+++ b/package-res/resources/web/prompting/pentaho-prompting-components.js
@@ -16,8 +16,8 @@
 */
 
 define("common-ui/prompting/pentaho-prompting-components", ['common-ui/prompting/pentaho-prompting-bind', 'common-ui/prompting/pentaho-prompting-builders', 'cdf/cdf-module', "pentaho/common/TextButtonCombo", "dijit/registry", "dojo/on", "dojo/_base/lang",
-  "pentaho/common/Calendar","pentaho/common/DateTextBox", "dojo/number"],
-    function(_promptBind, _promptBuilders, _cdfModule, _TextButtonCombo, registry, on, lang, Calendar, DateTextBox, DojoNumber) {
+  "pentaho/common/Calendar","pentaho/common/DateTextBox"],
+    function(_promptBind, _promptBuilders, _cdfModule, _TextButtonCombo, registry, on, lang, Calendar, DateTextBox) {
   // Executes button.expression() in the scope of the button component (instead of the button)
   window.ScopedPentahoButtonComponent = BaseComponent.extend({
     viewReportButtonRegistered: false,
@@ -406,24 +406,6 @@ define("common-ui/prompting/pentaho-prompting-components", ['common-ui/prompting
         $.each(this.param.values, function(i, v) {
           if (v.selected) {
             initialValue = this.formatter ? this.formatter.format(this.transportFormatter.parse(v.label)) : v.label;
-
-            try {
-              if(isNaN(v.label) || Math.abs(v.label) == Infinity) {
-                valueParsed =  null;
-              } else {             
-                if (isNumberType(v.type)) {
-                  valueParsed = DojoNumber.format(v.label, {locale: SESSION_LOCALE.toLowerCase()});
-                } else {
-                  valueParsed = v.label;
-                }
-              }
-            } catch(e) {
-              valueParsed = v.label;
-            }
-
-            if(valueParsed != null){
-              initialValue = v.label = v.value = valueParsed;
-            } 
           }
         }.bind(this));
 

--- a/package-res/resources/web/test/prompting/promptingSpec.js
+++ b/package-res/resources/web/test/prompting/promptingSpec.js
@@ -15,10 +15,12 @@
  * Copyright 2015 Pentaho Corporation. All rights reserved.
  */
 
-define(["common-ui/prompting/pentaho-prompting-components", "dojo/number"], function(promptingComponents, dojoNumber) {
+define(["common-ui/prompting/pentaho-prompting-components"], function(promptingComponents) {
 
   describe("StaticAutocompleteBoxComponent.update()", function() {
 
+    var testInteger = "123456";
+    var testStringWithNumber = "123456 String";
     createCommonParameters = function(parameter, values) {
       return {
         parameter: parameter,
@@ -31,59 +33,48 @@ define(["common-ui/prompting/pentaho-prompting-components", "dojo/number"], func
     };
 
     it("should not try to parse a string", function() {
-      spyOn(dojoNumber, "format");
-
       var comp =  new promptingComponents.StaticAutocompleteBoxComponent();
-      $.extend(comp, createCommonParameters("1234String", {
+      $.extend(comp, createCommonParameters("StringParameter", {
         type: "java.lang.String",
-        label: "123456",
-        value: "123456"
+        label: testInteger,
+        value: testInteger
       }));
 
       comp.update();
 
-      expect(dojoNumber.format).not.toHaveBeenCalled();
-      expect(comp.param.values[0].label).toBe("123456");
-      expect(comp.param.values[0].value).toBe("123456");
+      expect(comp.param.values[0].label).toBe(testInteger);
+      expect(comp.param.values[0].value).toBe(testInteger);
     });
 
-    it("should try to parse a number", function() {
-      spyOn(dojoNumber, "format").andCallFake(function(p) {
-        // just make a returned value different from the parameter
-        return '_' + p;
-      });
-
+    it("should not try to parse a number", function() {
       var comp = new promptingComponents.StaticAutocompleteBoxComponent();
-      $.extend(comp, createCommonParameters("1234Integer", {
+      $.extend(comp, createCommonParameters("IntegerParameter", {
         type: "java.lang.Integer",
-        label: "123456",
-        value: "123456",
+        label: testInteger,
+        value: testInteger,
         selected: true
       }));
-      
+
       comp.update();
 
-      expect(dojoNumber.format).toHaveBeenCalled();
-      expect(comp.param.values[0].label).not.toBe("123456");
-      expect(comp.param.values[0].value).not.toBe('123456');
+      expect(comp.param.values[0].label).toBe(testInteger);
+      expect(comp.param.values[0].value).toBe(testInteger);
     });
 
     it("should keep string if failed to to parse a number", function() {
-      spyOn(dojoNumber, 'format').andThrow();
-
       var comp = new promptingComponents.StaticAutocompleteBoxComponent();
       $.extend(comp, createCommonParameters("1234Integer", {
         type: "java.lang.Integer",
-        label: "12qw",
-        value: "12qw",
+        label: testStringWithNumber,
+        value: testStringWithNumber,
         selected: true
       }));
 
       comp.update();
 
-      expect(comp.param.values[0].label).toBe("12qw");
-      expect(comp.param.values[0].label).toBe("12qw");
+      expect(comp.param.values[0].label).toBe(testStringWithNumber);
+      expect(comp.param.values[0].value).toBe(testStringWithNumber);
     });
 
-  })
+  });
 })


### PR DESCRIPTION
…Number are formatted as ##,### when screen reloads

- remove default formating by dojo