### PR TITLE
[SP-2651] Backport of BISERVER-13167 - Specifying locale parameter with dialekt in URL works incorrect (5.4 Suite)

### DIFF
--- a/package-res/resources/web/dojo/djConfig.js
+++ b/package-res/resources/web/dojo/djConfig.js
@@ -48,13 +48,23 @@
 
 // don't overwrite this if they've set dojoConfig ahead of time
 if(dojoConfig == 'undefined' || dojoConfig == undefined) {
-  var url = (window.location != window.parent.location) ? document.referrer: document.location.href;
   var dojoConfig = {
     disableFlashStorage: true, /* turn off flash storage for client-side caching */
-    locale: url.match(/locale=([\w\-]+)/) ? RegExp.$1 : "en" /* look for a locale=xx query string param, else default to 'en' */
+
+    /*
+    check if SESSION_LOCALE is in given in valid pattern (xx or xx_YY (ignoring case), which represents
+    locale with language and locale with language and dialect respectively)
+
+    If it is so, normalize it and use. Otherwise use default (en) locale.
+    */
+    locale: SESSION_LOCALE.match(/^[a-zA-Z]{2}_[a-zA-Z]{2}$|^[a-zA-Z]{2}$/) ? normalizeLocale(SESSION_LOCALE) : "en"
   };
 } else {
   if(dojoConfig['disableFlashStorage'] == 'undefined' || dojoConfig['disableFlashStorage'] == undefined) {
     dojoConfig.disableFlashStorage = true;
   }
 }
+
+function normalizeLocale(locale) {
+    return locale.replace("_", "-").toLowerCase();
+ }


### PR DESCRIPTION
- We can't depend on URL, when extracting locale, as in the moment when this script is executed url looks like this:  http://localhost:8080/pentaho/api/repos/pentaho-interactive-reporting/prpti.new?ts=1458641503424, and contains no information about locale.
And there is actually no need to extract url parameter each time, as we have a SESSION_LOCALE for this, that is always up-to-date.
- We make pattern more strict: a valid value of a locale parameter is "xx" (language only, no dialect) or "xx_YY" (language with dialect).  If this pattern is not met, we set locale to be 'en' by default.
-  Before setting locale parameter to dojoConfig object we normalize it according to dojo requirements.

@rfellows , could you please review it? It's a backport of https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/718