### PR TITLE
[BACKLOG-7611] Unable to cancel selection in a visualization

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
@@ -222,8 +222,8 @@ define([
     //region Helpers
 
     /** @inheritdoc */
-    _selectionChanged: function(newSelectionFilter, previousSelectionFilter) {
-      var dataFilter = newSelectionFilter; // || this.model.getv("selectionFilter") || new filter.Or();
+    _selectionChanged: function(newSelectionFilter) {
+      var dataFilter = newSelectionFilter;
       var selectedItems = dataFilter.apply(this.model.getv("data"));
 
       // Get information on the axes
@@ -1268,7 +1268,12 @@ define([
         .setData(this._dataView.toJsonCda())
         .render();
 
-      this._hackedRender();
+      this._updateSelections();
+    },
+
+    _updateSelections: function() {
+      this._selectionChanged(this.model.getv("selectionFilter"));
+      this._chart.updateSelections();
     },
 
     //region SELECTION

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
@@ -81,16 +81,15 @@ define([
         });
       }
 
-      //TODO: check why not working inside PDI
       var url = "http://www.google.com/search?as_q=\"" + queryValue + "\"";
       window.open(url, "_blank");
 
       logger.log("Google Search:" + url);
     },
 
-    _hackedRender: function() {
-      this._selectionChanged(this.model.getv("selectionFilter"), new filter.Or());
-      this._chart.renderInteractive();
+    _renderCore: function() {
+      this.base();
+
       this._renderCounter++; //BACKLOG-6739
     },
 


### PR DESCRIPTION
Removed TODO comment. It was left there by mistake because we confirmed that 'window.open' is working inside PDI.

@pentaho/millenniumfalcon please review