### PR TITLE
[SP-2652] Backport of BISERVER-12918 - the report parameter/prompt panel flashes when auto submit off (6.1 Suite)

### DIFF
--- a/package-res/resources/web/prompting/WidgetBuilder.js
+++ b/package-res/resources/web/prompting/WidgetBuilder.js
@@ -52,12 +52,12 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
       './builders/SubmitPanelBuilder', './builders/SubmitComponentBuilder', './builders/LabelBuilder',
       './builders/ErrorLabelBuilder', './builders/DropDownBuilder', './builders/RadioBuilder', './builders/CheckBuilder',
       './builders/MultiButtonBuilder', './builders/ListBuilder', './builders/DateInputBuilder',
-      './builders/ExternalInputBuilder', './builders/TextAreaBuilder',
+      './builders/ExternalInputBuilder', './builders/TextAreaBuilder', './builders/TextInputBuilder',
       './builders/StaticAutocompleteBoxBuilder'],
 
     function (PromptPanelBuilder, ParameterGroupPanelBuilder, ParameterPanelBuilder, SubmitPanelBuilder,
               SubmitComponentBuilder, LabelBuilder, ErrorLabelBuilder, DropDownBuilder, RadioBuilder, CheckBuilder,
-              MultiButtonBuilder, ListBuilder, DateInputBuilder, ExternalInputBuilder, TextAreaBuilder,
+              MultiButtonBuilder, ListBuilder, DateInputBuilder, ExternalInputBuilder, TextAreaBuilder, TextInputBuilder,
               StaticAutocompleteBoxBuilder) {
 
       return {
@@ -81,7 +81,8 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
           'filebrowser': new ExternalInputBuilder(),
           'external-input': new ExternalInputBuilder(),
           'multi-line': new TextAreaBuilder(),
-          'default': new StaticAutocompleteBoxBuilder()
+          'autocompletebox': new StaticAutocompleteBoxBuilder(),
+          'textbox': new TextInputBuilder()
         },
 
         /**
@@ -96,7 +97,14 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
          */
         _findBuilderFor: function (args, type) {
           type = type || (args.param && args.param.attributes ? args.param.attributes['parameter-render-type'] : null);
-          return this.mapping.hasOwnProperty(type) ? this.mapping[type] : this.mapping['default'];
+          if (this.mapping.hasOwnProperty(type)) {
+            if (type == "textbox" && args.param.list) {
+              type = "autocompletebox";
+            }
+          } else {
+            type = args.param.list ? "autocompletebox" : "textbox";
+          }
+          return this.mapping[type];
         },
 
         /**

--- a/test-js/unit/prompting/WidgetBuilderSpec.js
+++ b/test-js/unit/prompting/WidgetBuilderSpec.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  *
  */
-define(['common-ui/prompting/WidgetBuilder', 'common-ui/prompting/builders/PromptPanelBuilder'],  function (WidgetBuilder, PromptPanelBuilder) {
+define(['common-ui/prompting/WidgetBuilder', 'common-ui/prompting/parameters/Parameter'],  function (WidgetBuilder, Parameter) {
 
   describe("WidgetBuilder", function() {
 
-    it("should have mappings array", function() {       
+    it("should have mappings array", function() {
       expect(WidgetBuilder.mapping).toBeDefined();
     });
 
@@ -36,6 +36,31 @@ define(['common-ui/prompting/WidgetBuilder', 'common-ui/prompting/builders/Promp
       expect(panel.type).toEqual('ScrollingPromptPanelLayoutComponent');
       expect(buildPanelComponentsFn).toHaveBeenCalled();
       expect(panel.promptPanel).toBeDefined();
+    });
+
+    it("distinguishes textbox and autocompletebox properly", function() {
+      var promptPanel = jasmine.createSpyObj('promptPanel', ['generateWidgetGUID', 'getParameterName']);
+
+      var param = new Parameter(),
+          type = "textbox";
+      param.type = type;
+      param.list = false;
+      var args = {
+        param: param,
+        promptPanel: promptPanel
+      };
+      var panel = WidgetBuilder.build(args, type);
+      expect(panel.type).toEqual("TextInputComponent");
+
+      args.param.list = true;
+      panel = WidgetBuilder.build(args, type);
+      expect(panel.type).toEqual("StaticAutocompleteBoxComponent");
+
+      args.param.type = "";
+      args.param.list = false;
+      type = "";
+      panel = WidgetBuilder.build(args, type);
+      expect(panel.type).toEqual("TextInputComponent");
     });
 
   });


### PR DESCRIPTION
@pamval, @diogofscmariano, @jvelasques could you please review?

UPD: js tests passed successfully on my local machine: https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/765#issuecomment-216277246

Used cherry-picks:
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/549/commits/b996eb5eedaf58e1f65edd681d6247ecef5adc87
[SP-2652] Backport of BISERVER-12918 - the report parameter/prompt panel flashes when auto submit off (6.1 Suite)
- add _areParamsDifferent() as an additional check for values equality
- change _changeComponentsByDiff() logic: do not call _areParamsDifferent() if it is clear, that update is needed
- add tests for new changes

Conflicts:
	package-res/resources/web/prompting/PromptPanel.js
	test-js/unit/prompting/PromptPanelSpec.js

https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/651/commits/d7d9cc38a115fa7ad6ea57f288b65eb16927ce3a
[SP-2652] Backport of BISERVER-12918 - the report parameter/prompt panel flashes when auto submit off (6.1 Suite)

https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/651/commits/0da35256947c5387293ea957ad44bc7d80e6edd9
[SP-2652] Backport of BISERVER-12918 - improved unit test

https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/705/commits/328e83c18edad19417e8122c4ad11de2d53a03dc
[SP-2652] Backport of BISERVER-12918 - _areParamsDifferent should also compare String arrays

Conflicts:
	package-res/resources/web/prompting/PromptPanel.js

https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/723/commits/ed73e79ce99457354c0154e1839733d128cde5f7
[SP-2652] Backport of BISERVER-12918 - Added text input back in cases we dont need an autocomplete component. Tests updated accordingly

https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/731/commits/890b41694f8945407dc6c0a5d5df8f0fa8d897ff
[SP-2652] Backport of BISERVER-12918 - Removed default case and handled it properly based on if the param is a list or not, basically the same if it is a textbox, just like it was before. Tests updated accordingly