### PR TITLE
[BACKLOG-7614] Prevent data and selectionFilter properties from visual/base

### DIFF
--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -795,16 +795,22 @@ define([
 
       //region serialization
       toSpecInContext: function(keyArgs) {
-        if(!keyArgs) keyArgs = {};
+
+        keyArgs = keyArgs ? Object.create(keyArgs) : {};
 
         var spec;
         var includeType = !!keyArgs.includeType;
         var useArray = !includeType && keyArgs.preferPropertyArray;
+        var omitProps;
         if(useArray) {
           spec = [];
         } else {
           spec = {};
           if(includeType) spec._ = this.type.toRefInContext(keyArgs);
+          omitProps = keyArgs.omitProps;
+
+          // Do not propagate to child values
+          keyArgs.omitProps = null;
         }
 
         var includeDefaults = keyArgs.includeDefaults;
@@ -819,6 +825,9 @@ define([
           /*jshint validthis:true*/
 
           var name = propType.name;
+
+          if(omitProps && O.hasOwn(omitProps, name)) return;
+
           var value = this._values[name];
           if(includeDefaults || !areEqual(propType.value, value)) {
             // Determine if value spec must contain the type inline

--- a/package-res/resources/web/pentaho/type/value.js
+++ b/package-res/resources/web/pentaho/type/value.js
@@ -206,13 +206,27 @@ define([
        * @param {boolean} [keyArgs.omitFormatted=false] - Omits the formatted value
        * on [Simple]{@link pentaho.type.Simple} values' specifications.
        *
-       * @param {boolean} [keyArgs.includeDefaults=false] - Includes the value of all properties of
-       * [Complex]{@link pentaho.type.Complex} values, even when equal to their default values.
-       *
        * @param {boolean} [keyArgs.preferPropertyArray=false] - Indicates that, if possible,
        * array form is used for [Complex]{@link pentaho.type.Complex} values' specifications.
        *
        * The array form of a complex value cannot be used when its type must be inlined.
+       *
+       * @param {boolean} [keyArgs.includeDefaults=false] - When `true`, all of the properties of
+       * [Complex]{@link pentaho.type.Complex} values are serialized.
+       * When `false`, the default, only properties whose value is different from their default value
+       * are serialized.
+       *
+       * Only applies to complex values that are serialized in object form.
+       * In array form, all of the properties of complex values are serialized independently of their value.
+       *
+       * @param {Object} [keyArgs.omitProps] - An object whose _own_ property names are the names of
+       * the properties of the current complex type to omit from the serialization.
+       *
+       * Only applies when a complex is output in object form.
+       * In array form, all properties are output whatever their value.
+       *
+       * This argument only applies to complex values and
+       * is not passed through to the values of their properties.
        *
        * @return {!pentaho.type.spec.UInstance} A specification of this value.
        */

--- a/package-res/resources/web/pentaho/visual/base/model.js
+++ b/package-res/resources/web/pentaho/visual/base/model.js
@@ -64,207 +64,228 @@ define([
      * @param {pentaho.visual.base.spec.IModel} modelSpec A plain object containing the model specification.
      */
     var Model = Complex.extend(/** @lends pentaho.visual.base.Model# */{
-        //region Event Flows Handling
-        /**
-         * Modifies the current selection filter based on an input filter and on a selection mode.
-         *
-         * This action is the entry point for user-driven modifications of the current selection filter.
-         * For example, if the user clicked a bar in a bar chart or drew a rectangle over a set of bars in a bar chart.
-         *
-         * The event ["will:select"]{@link pentaho.visual.base.events.WillSelect}
-         * is first emitted.
-         * Its event listeners can be attributed a _priority_
-         * and can be regarded as operations in a processing pipeline that are allowed to:
-         * - cancel the event
-         * - replace the input filter
-         * - replace the selection mode
-         *
-         * Afterwards, the current selection filter is updated.
-         * If the modification of the current selection filter is successful, the event
-         * ["did:select"]{@link pentaho.visual.base.events.DidSelect} is emitted.
-         *
-         * Any rejection (due to an event cancelation or due to an invalid selection mode)
-         * leads to the emission of the
-         * ["rejected:select"]{@link pentaho.visual.base.events.RejectedSelect}.
-         *
-         * @param {!pentaho.data.filter.AbstractFilter} inputDataFilter - A filter representing
-         * the data set which will be used to modify the current selection filter.
-         * @param {?object} keyArgs - Keyword arguments.
-         * @param {!function} keyArgs.selectionMode - A function that computes a new selection filter,
-         * taking into account the current selection filter and an input `dataFilter`.
-         *
-         * @return {pentaho.lang.ActionResult}
-         * If unsuccessful, the `error` property describes what originated the error.
-         * If successful,  the `error` property is `null` and the `value` property contains the updated current selection filter.
-         *
-         * @fires "will:select"
-         * @fires "did:select"
-         * @fires "rejected:select"
-         *
-         * @see pentaho.visual.base.types.selectionModes
-         */
-        selectAction: function(inputDataFilter, keyArgs) {
-          var selectionMode = O.getOwn(keyArgs, "selectionMode") || this.getv("selectionMode");
-          var will = new WillSelect(this, inputDataFilter, selectionMode);
-          return this._doAction(this._doSelect, will, DidSelect, RejectedSelect);
-        },
+      //region Event Flows Handling
+      /**
+       * Modifies the current selection filter based on an input filter and on a selection mode.
+       *
+       * This action is the entry point for user-driven modifications of the current selection filter.
+       * For example, if the user clicked a bar in a bar chart or drew a rectangle over a set of bars in a bar chart.
+       *
+       * The event ["will:select"]{@link pentaho.visual.base.events.WillSelect}
+       * is first emitted.
+       * Its event listeners can be attributed a _priority_
+       * and can be regarded as operations in a processing pipeline that are allowed to:
+       * - cancel the event
+       * - replace the input filter
+       * - replace the selection mode
+       *
+       * Afterwards, the current selection filter is updated.
+       * If the modification of the current selection filter is successful, the event
+       * ["did:select"]{@link pentaho.visual.base.events.DidSelect} is emitted.
+       *
+       * Any rejection (due to an event cancelation or due to an invalid selection mode)
+       * leads to the emission of the
+       * ["rejected:select"]{@link pentaho.visual.base.events.RejectedSelect}.
+       *
+       * @param {!pentaho.data.filter.AbstractFilter} inputDataFilter - A filter representing
+       * the data set which will be used to modify the current selection filter.
+       * @param {?object} keyArgs - Keyword arguments.
+       * @param {!function} keyArgs.selectionMode - A function that computes a new selection filter,
+       * taking into account the current selection filter and an input `dataFilter`.
+       *
+       * @return {pentaho.lang.ActionResult}
+       * If unsuccessful, the `error` property describes what originated the error.
+       * If successful,  the `error` property is `null` and the `value` property contains the updated current selection filter.
+       *
+       * @fires "will:select"
+       * @fires "did:select"
+       * @fires "rejected:select"
+       *
+       * @see pentaho.visual.base.types.selectionModes
+       */
+      selectAction: function(inputDataFilter, keyArgs) {
+        var selectionMode = O.getOwn(keyArgs, "selectionMode") || this.getv("selectionMode");
+        var will = new WillSelect(this, inputDataFilter, selectionMode);
+        return this._doAction(this._doSelect, will, DidSelect, RejectedSelect);
+      },
 
-        /**
-         * Modifies the current selection.
-         *
-         * @param {pentaho.visual.base.events.WillSelect} will - The "will:select" event object.
-         * @return {ActionResult} The result object.
-         * @protected
-         */
-        _doSelect: function(will){
-          var currentSelectionFilter = this.getv("selectionFilter");
-          var selectionMode = will.selectionMode || this.getv("selectionMode");
+      /**
+       * Modifies the current selection.
+       *
+       * @param {pentaho.visual.base.events.WillSelect} will - The "will:select" event object.
+       * @return {ActionResult} The result object.
+       * @protected
+       */
+      _doSelect: function(will){
+        var currentSelectionFilter = this.getv("selectionFilter");
+        var selectionMode = will.selectionMode || this.getv("selectionMode");
 
-          var newSelectionFilter;
-          try {
-            newSelectionFilter = selectionMode.call(this, currentSelectionFilter, will.dataFilter);
-          } catch(e) {
-            return ActionResult.reject(e);
-          }
-
-          return this.set("selectionFilter", newSelectionFilter); //setting to null assigns the default value
-        },
-
-        /**
-         * Executes an action when the user interacts with a visual element, normally by double clicking it.
-         *
-         * The flow starts by emitting the event {@link pentaho.visual.base.events.WillExecute|"will:execute"}.
-         * Its event listeners can be attributed a _priority_
-         * and can be regarded as operations in a processing pipeline that are allowed to:
-         * - cancel the event
-         * - replace the input data filter
-         * - change the [doExecute]{@link pentaho.visual.base.Model.Meta} action
-         *
-         * Any rejection (due to an event cancellation or due to an invalid `doExecute` action)
-         * emits the event {@link pentaho.visual.base.events.RejectedSelect|"rejected:execute"}.
-         *
-         * @param {!pentaho.data.filter.AbstractFilter} inputDataFilter - A filter representing the data set of
-         * the visual element which the user interacted with.
-         *
-         * @return {pentaho.lang.ActionResult}
-         * If unsuccessful, the `error` property describes what originated the error.
-         * If successful,  the `error` property is `null`.
-         * In either case no value is returned.
-         *
-         * @fires "will:execute"
-         * @fires "did:execute"
-         * @fires "rejected:execute"
-         *
-         */
-        executeAction: function(inputDataFilter, keyArgs) {
-          var doExecute = O.getOwn(keyArgs, "doExecute") || this.getv("doExecute");
-          var will = new WillExecute(this, inputDataFilter, doExecute);
-          return this._doAction(this._doExecute, will, DidExecute, RejectedExecute);
-        },
-
-        /**
-         * Runs the `doExecute` action and returns a [result]{@link pentaho.lang.ActionResult} object.
-         *
-         * @param {pentaho.visual.base.events.WillExecute} will - The "will:execute" event object.
-         * @return {ActionResult} The result object.
-         * @protected
-         */
-        _doExecute: function(will){
-          if(!will.doExecute)
-            return ActionResult.reject(bundle.structured.error.action.notDefined);
-
-          var result;
-          try {
-            result = will.doExecute.call(this, will.dataFilter);
-          } catch(e) {
-            return ActionResult.reject(e);
-          }
-          return result && result.isRejected ? result : ActionResult.fulfill();
-        },
-
-        /**
-         * Executes the will/did/rejected event loop associated with a given action.
-         *
-         * @param {function} coreAction - The action to be executed.
-         * @param {pentaho.visual.base.events.Will} willEvent - The "will:" event object.
-         * @param {function} DidEvent - The constructor of the "did:" event.
-         * @param {function} RejectedEvent - The constructor of the "rejected:" event.
-         * @return {pentaho.lang.ActionResult} The result object.
-         * @protected
-         */
-        _doAction: function(coreAction, willEvent, DidEvent, RejectedEvent) {
-          if(this._hasListeners(willEvent.type))
-            this._emitSafe(willEvent);
-
-          var result = willEvent.isCanceled ? ActionResult.reject(willEvent.cancelReason) : coreAction.call(this, willEvent);
-
-          if(result.error) {
-            if(this._hasListeners(RejectedEvent.type)) {
-              this._emitSafe(new RejectedEvent(this, result.error, willEvent));
-            }
-          } else {
-            if(this._hasListeners(DidEvent.type)) {
-              this._emitSafe(new DidEvent(this, result.value, willEvent));
-            }
-          }
-          return result;
-        },
-        //endregion
-
-        type:  /** @lends pentaho.visual.base.Model.Meta# */{
-          id: "pentaho/visual/base",
-          view: "View",
-          isAbstract: true,
-          props: [
-            {
-              name: "width",
-              type: "number",
-              isRequired: true
-            },
-            {
-              name: "height",
-              type: "number",
-              isRequired: true
-            },
-            {
-              name: "isInteractive",
-              type: "boolean",
-              value: true
-            },
-            {
-              name: "data",
-              type: "object",
-              isRequired: true
-            },
-            {
-              name: "selectionFilter",
-              type: "object",
-              value: new filter.Or(),
-              isRequired: true
-            },
-            {
-              name: "selectionMode",
-              type: {
-                base: "function",
-                cast: function(f) {
-                  if(typeof f === "string" && selectionModes.hasOwnProperty(f))
-                    return selectionModes[f];
-
-                  // TODO: must default to eval if string
-                  return f;
-                }
-              },
-              value: selectionModes.REPLACE,
-              isRequired: true
-            },
-            {
-              name: "doExecute",
-              type: "function"
-            }
-          ]
+        var newSelectionFilter;
+        try {
+          newSelectionFilter = selectionMode.call(this, currentSelectionFilter, will.dataFilter);
+        } catch(e) {
+          return ActionResult.reject(e);
         }
-      })
-      .implement({type: bundle.structured});
+
+        return this.set("selectionFilter", newSelectionFilter); //setting to null assigns the default value
+      },
+
+      /**
+       * Executes an action when the user interacts with a visual element, normally by double clicking it.
+       *
+       * The flow starts by emitting the event {@link pentaho.visual.base.events.WillExecute|"will:execute"}.
+       * Its event listeners can be attributed a _priority_
+       * and can be regarded as operations in a processing pipeline that are allowed to:
+       * - cancel the event
+       * - replace the input data filter
+       * - change the [doExecute]{@link pentaho.visual.base.Model.Meta} action
+       *
+       * Any rejection (due to an event cancellation or due to an invalid `doExecute` action)
+       * emits the event {@link pentaho.visual.base.events.RejectedSelect|"rejected:execute"}.
+       *
+       * @param {!pentaho.data.filter.AbstractFilter} inputDataFilter - A filter representing the data set of
+       * the visual element which the user interacted with.
+       *
+       * @return {pentaho.lang.ActionResult}
+       * If unsuccessful, the `error` property describes what originated the error.
+       * If successful,  the `error` property is `null`.
+       * In either case no value is returned.
+       *
+       * @fires "will:execute"
+       * @fires "did:execute"
+       * @fires "rejected:execute"
+       *
+       */
+      executeAction: function(inputDataFilter, keyArgs) {
+        var doExecute = O.getOwn(keyArgs, "doExecute") || this.getv("doExecute");
+        var will = new WillExecute(this, inputDataFilter, doExecute);
+        return this._doAction(this._doExecute, will, DidExecute, RejectedExecute);
+      },
+
+      /**
+       * Runs the `doExecute` action and returns a [result]{@link pentaho.lang.ActionResult} object.
+       *
+       * @param {pentaho.visual.base.events.WillExecute} will - The "will:execute" event object.
+       * @return {ActionResult} The result object.
+       * @protected
+       */
+      _doExecute: function(will){
+        if(!will.doExecute)
+          return ActionResult.reject(bundle.structured.error.action.notDefined);
+
+        var result;
+        try {
+          result = will.doExecute.call(this, will.dataFilter);
+        } catch(e) {
+          return ActionResult.reject(e);
+        }
+        return result && result.isRejected ? result : ActionResult.fulfill();
+      },
+
+      /**
+       * Executes the will/did/rejected event loop associated with a given action.
+       *
+       * @param {function} coreAction - The action to be executed.
+       * @param {pentaho.visual.base.events.Will} willEvent - The "will:" event object.
+       * @param {function} DidEvent - The constructor of the "did:" event.
+       * @param {function} RejectedEvent - The constructor of the "rejected:" event.
+       * @return {pentaho.lang.ActionResult} The result object.
+       * @protected
+       */
+      _doAction: function(coreAction, willEvent, DidEvent, RejectedEvent) {
+        if(this._hasListeners(willEvent.type))
+          this._emitSafe(willEvent);
+
+        var result = willEvent.isCanceled ? ActionResult.reject(willEvent.cancelReason) : coreAction.call(this, willEvent);
+
+        if(result.error) {
+          if(this._hasListeners(RejectedEvent.type)) {
+            this._emitSafe(new RejectedEvent(this, result.error, willEvent));
+          }
+        } else {
+          if(this._hasListeners(DidEvent.type)) {
+            this._emitSafe(new DidEvent(this, result.value, willEvent));
+          }
+        }
+        return result;
+      },
+      //endregion
+
+      //region serialization
+      toSpecInContext: function(keyArgs) {
+
+        if(keyArgs && keyArgs.isJson) {
+          keyArgs = keyArgs ? Object.create(keyArgs) : {};
+
+          var omitProps = keyArgs.omitProps;
+          keyArgs.omitProps = omitProps = omitProps ? Object.create(omitProps) : {};
+
+          // TODO: Add keyword arguments to serialize data/interaction when desired.
+          // Only isJson serialization does not work with the values of these properties
+          // due to the circular dependencies they contain.
+
+          omitProps.data = true;
+          omitProps.selectionFilter = true;
+        }
+
+        return this.base(keyArgs);
+      },
+      //endregion
+
+      type:  /** @lends pentaho.visual.base.Model.Meta# */{
+        id: "pentaho/visual/base",
+        view: "View",
+        isAbstract: true,
+        props: [
+          {
+            name: "width",
+            type: "number",
+            isRequired: true
+          },
+          {
+            name: "height",
+            type: "number",
+            isRequired: true
+          },
+          {
+            name: "isInteractive",
+            type: "boolean",
+            value: true
+          },
+          {
+            name: "data",
+            type: "object",
+            isRequired: true
+          },
+          {
+            name: "selectionFilter",
+            type: "object",
+            value: new filter.Or(),
+            isRequired: true
+          },
+          {
+            name: "selectionMode",
+            type: {
+              base: "function",
+              cast: function(f) {
+                if(typeof f === "string" && selectionModes.hasOwnProperty(f))
+                  return selectionModes[f];
+
+                // TODO: must default to eval if string
+                return f;
+              }
+            },
+            value: selectionModes.REPLACE,
+            isRequired: true
+          },
+          {
+            name: "doExecute",
+            type: "function"
+          }
+        ]
+      }
+    })
+    .implement({type: bundle.structured});
 
     return Model;
 

--- a/test-js/unit/pentaho/visual/base/model.Spec.js
+++ b/test-js/unit/pentaho/visual/base/model.Spec.js
@@ -1,756 +1,820 @@
 define([
-    "pentaho/type/Context",
-    "pentaho/visual/base",
-    "pentaho/data/filter",
-    "pentaho/visual/base/types/selectionModes",
-    "pentaho/lang/UserError",
-    "pentaho/visual/base/events/WillSelect",
-    "pentaho/visual/base/events/DidSelect",
-    "pentaho/visual/base/events/RejectedSelect",
-    "pentaho/visual/base/events/WillExecute",
-    "pentaho/visual/base/events/DidExecute",
-    "pentaho/visual/base/events/RejectedExecute"
-  ], function(Context, modelFactory, filter, selectionModes, UserError,
-              WillSelect, DidSelect, RejectedSelect,
-              WillExecute, DidExecute, RejectedExecute) {
-    "use strict";
+  "pentaho/type/Context",
+  "pentaho/visual/base",
+  "pentaho/data/filter",
+  "pentaho/visual/base/types/selectionModes",
+  "pentaho/lang/UserError",
+  "pentaho/visual/base/events/WillSelect",
+  "pentaho/visual/base/events/DidSelect",
+  "pentaho/visual/base/events/RejectedSelect",
+  "pentaho/visual/base/events/WillExecute",
+  "pentaho/visual/base/events/DidExecute",
+  "pentaho/visual/base/events/RejectedExecute"
+], function(Context, modelFactory, filter, selectionModes, UserError,
+            WillSelect, DidSelect, RejectedSelect,
+            WillExecute, DidExecute, RejectedExecute) {
+  "use strict";
 
-    describe("pentaho/visual/base", function() {
-      var context;
-      var Model;
-      var dataSpec;
+  describe("pentaho/visual/base", function() {
+    var context;
+    var Model;
+    var dataSpec;
 
+    beforeEach(function() {
+      context = new Context();
+      Model = context.get(modelFactory);
+      var data = {
+        model: [
+          {name: "country", type: "string", label: "Country"},
+          {name: "sales", type: "number", label: "Sales"}
+        ],
+        rows: [
+          {c: [{v: "Portugal"}, {v: 12000}]},
+          {c: [{v: "Ireland"}, {v: 6000}]}
+        ]
+      };
+      dataSpec = {
+        v: data
+      };
+    });
+
+    it("can be instantiated with a well-formed spec", function() {
+      expect(function() {
+        return new Model({
+          width: 1,
+          height: 1,
+          isInteractive: false,
+          data: dataSpec
+        });
+      }).not.toThrowError();
+    });
+
+    it("can be instantiated without arguments", function() {
+      expect(function() {
+        return new Model();
+      }).not.toThrowError();
+    });
+
+    it("cannot instantiate a modelSpec if one of its members has a value of the wrong type", function() {
+      [{
+        width: "nope",
+        height: 1,
+        isInteractive: false,
+        data: dataSpec
+      }, {
+        width: 1,
+        height: "nope",
+        isInteractive: false,
+        data: dataSpec
+      }, {
+        width: 1,
+        height: 1,
+        isInteractive: false,
+        data: {}
+      }].forEach(function(spec) {
+        expect(function() {
+          return new Model(spec);
+        }).toThrow();
+      });
+    });
+
+    describe("events - ", function() {
+      var model;
       beforeEach(function() {
-        context = new Context();
-        Model = context.get(modelFactory);
-        var data = {
-          model: [
-            {name: "country", type: "string", label: "Country"},
-            {name: "sales", type: "number", label: "Sales"}
-          ],
-          rows: [
-            {c: [{v: "Portugal"}, {v: 12000}]},
-            {c: [{v: "Ireland"}, {v: 6000}]}
-          ]
-        };
-        dataSpec = {
-          v: data
-        };
+        model = new Model();
       });
 
-      it("can be instantiated with a well-formed spec", function() {
-        expect(function() {
-          return new Model({
-            width: 1,
-            height: 1,
-            isInteractive: false,
-            data: dataSpec
-          });
-        }).not.toThrowError();
+      it("should have a default selectionFilter", function() {
+        var selectionFilter = model.getv("selectionFilter");
+
+        expect(selectionFilter).toBeDefined();
+        expect(selectionFilter instanceof filter.AbstractFilter).toBe(true);
       });
 
-      it("can be instantiated without arguments", function() {
-        expect(function() {
-          return new Model();
-        }).not.toThrowError();
+      it("should have a default selectionMode", function() {
+        var selectionMode = model.getv("selectionMode");
+
+        expect(selectionMode).toBeDefined();
+        expect(typeof selectionMode).toBe("function");
       });
 
-      it("cannot instantiate a modelSpec if one of its members has a value of the wrong type", function() {
-        [{
-          width: "nope",
-          height: 1,
-          isInteractive: false,
-          data: dataSpec
-        }, {
-          width: 1,
-          height: "nope",
-          isInteractive: false,
-          data: dataSpec
-        }, {
-          width: 1,
-          height: 1,
-          isInteractive: false,
-          data: {}
-        }].forEach(function(spec) {
-          expect(function() {
-            return new Model(spec);
-          }).toThrow();
-        });
-      });
+      describe("selectAction - ", function() {
+        var newSelection;
 
-      describe("events - ", function() {
-        var model;
+        var listeners;
+
         beforeEach(function() {
-          model = new Model();
+          newSelection = new filter.Or();
+
+          listeners = jasmine.createSpyObj('listeners', [
+            'willSelect', 'willSelectSecond',
+            'didSelect',
+            'rejectedSelect',
+            'didChangeSelection'
+          ]);
         });
 
-        it("should have a default selectionFilter", function() {
-          var selectionFilter = model.getv("selectionFilter");
-
-          expect(selectionFilter).toBeDefined();
-          expect(selectionFilter instanceof filter.AbstractFilter).toBe(true);
-        });
-
-        it("should have a default selectionMode", function() {
-          var selectionMode = model.getv("selectionMode");
-
-          expect(selectionMode).toBeDefined();
-          expect(typeof selectionMode).toBe("function");
-        });
-
-        describe("selectAction - ", function() {
-          var newSelection;
-
-          var listeners;
-
+        describe("default - ", function() {
           beforeEach(function() {
-            newSelection = new filter.Or();
+            model.on("will:select", listeners.willSelect);
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
 
-            listeners = jasmine.createSpyObj('listeners', [
-              'willSelect', 'willSelectSecond',
-              'didSelect',
-              'rejectedSelect',
-              'didChangeSelection'
-            ]);
+            model.on("did:change", listeners.didChangeSelection);
+
+            model.selectAction(newSelection);
           });
 
-          describe("default - ", function() {
-            beforeEach(function() {
-              model.on("will:select", listeners.willSelect);
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection);
-            });
-
-            it("should call the will select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should call the did select listener", function() {
-              expect(listeners.didSelect).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).toHaveBeenCalled();
-            });
+          it("should call the will select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
           });
 
-          describe("default - no listeners (performance check) - ", function() {
-            beforeEach(function() {
-              spyOn(model, "_emitSafe");
-
-              model.selectAction(newSelection);
-            });
-
-            it("should not call _emitSafe function", function() {
-              expect(model._emitSafe).not.toHaveBeenCalled();
-            });
+          it("should call the did select listener", function() {
+            expect(listeners.didSelect).toHaveBeenCalled();
           });
 
-          describe("custom selectionMode through keyArgs - ", function() {
-            var selectionMode;
-            beforeEach(function() {
-              selectionMode = jasmine.createSpy('selectionMode');
-
-              model.on("will:select", listeners.willSelect);
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection, {selectionMode: selectionMode});
-            });
-
-            it("should call the custom selectionMode function", function() {
-              expect(selectionMode).toHaveBeenCalled();
-            });
-
-            it("should call the will select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should call the did select listener", function() {
-              expect(listeners.didSelect).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).toHaveBeenCalled();
-            });
+          it("should not call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).not.toHaveBeenCalled();
           });
 
-          describe("change selection in will event - ", function() {
-            var alternativeSelection;
-            var selectionMode;
-            beforeEach(function() {
-              alternativeSelection = new filter.And();
-
-              selectionMode = jasmine.createSpy('selectionMode');
-
-              model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
-                willEvent.dataFilter = alternativeSelection;
-              }));
-              model.on("will:select", listeners.willSelectSecond);
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection, {selectionMode: selectionMode});
-            });
-
-            it("should call the custom selectionMode function", function() {
-              expect(selectionMode).toHaveBeenCalled();
-            });
-
-            it("should call the first will select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should call the second will select listener", function() {
-              expect(listeners.willSelectSecond).toHaveBeenCalled();
-              expect(listeners.willSelectSecond.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
-            });
-
-            it("should call the did select listener", function() {
-              expect(listeners.didSelect).toHaveBeenCalled();
-              expect(listeners.didSelect.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
-            });
-
-            it("should not call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).toHaveBeenCalled();
-            });
-          });
-
-          describe("custom selectionMode through will event - ", function() {
-            var selectionMode;
-            beforeEach(function() {
-              selectionMode = jasmine.createSpy('selectionMode');
-
-              model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
-                willEvent.selectionMode = selectionMode;
-              }));
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection);
-            });
-
-            it("should call the custom selectionMode function", function() {
-              expect(selectionMode).toHaveBeenCalled();
-            });
-
-            it("should call the will select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should call the did select listener", function() {
-              expect(listeners.didSelect).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).toHaveBeenCalled();
-            });
-          });
-
-          [
-            {label: "no reason", reason: undefined, message: "canceled"},
-            {label: "string reason", reason: "Just cancel it!", message: "Just cancel it!"},
-            {label: "User error reason", reason: new UserError("My error"), message: "My error"}
-          ].forEach(function(motive) {
-              describe("canceled on will - " + motive.label, function() {
-                var selectionMode;
-                beforeEach(function() {
-                  selectionMode = jasmine.createSpy('selectionMode');
-
-                  model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
-                    willEvent.cancel(motive.reason);
-                  }));
-                  model.on("will:select", listeners.willSelectSecond);
-                  model.on("did:select", listeners.didSelect);
-                  model.on("rejected:select", listeners.rejectedSelect);
-
-                  model.on("did:change", listeners.didChangeSelection);
-
-                  model.selectAction(newSelection, {selectionMode: selectionMode});
-                });
-
-                it("should not reach the selectionMode function", function() {
-                  expect(selectionMode).not.toHaveBeenCalled();
-                });
-
-                it("should call the first will select listener", function() {
-                  expect(listeners.willSelect).toHaveBeenCalled();
-                });
-
-                it("should not call the second will select listener", function() {
-                  expect(listeners.willSelectSecond).not.toHaveBeenCalled();
-                });
-
-                it("should not call the did select listener", function() {
-                  expect(listeners.didSelect).not.toHaveBeenCalled();
-                });
-
-                it("should call the rejected select listener", function() {
-                  expect(listeners.rejectedSelect).toHaveBeenCalled();
-
-                  var reason = listeners.rejectedSelect.calls.mostRecent().args[0];
-                  expect(reason instanceof RejectedSelect).toBe(true);
-                  expect(reason.error instanceof UserError).toBe(true);
-                  expect(reason.error.message).toBe(motive.message);
-                });
-
-                it("should not call the did change selection listener", function() {
-                  expect(listeners.didChangeSelection).not.toHaveBeenCalled();
-                });
-              });
-            }
-          );
-
-          describe("exception on will - ", function() {
-            var selectionMode;
-            beforeEach(function() {
-              selectionMode = jasmine.createSpy('selectionMode');
-
-              model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
-                throw new Error("non-user error");
-              }));
-              model.on("will:select", listeners.willSelectSecond);
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection, {selectionMode: selectionMode});
-            });
-
-            it("should reach the selectionMode function", function() {
-              expect(selectionMode).toHaveBeenCalled();
-            });
-
-            it("should call the first will:select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should call the second will:select listener", function() {
-              expect(listeners.willSelectSecond).toHaveBeenCalled();
-            });
-
-            it("should call the did select listener", function() {
-              expect(listeners.didSelect).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).toHaveBeenCalled();
-            });
-          });
-
-          describe("exception on selectionMode - ", function() {
-            var errorMsg = "non-user error";
-            var selectionMode;
-            beforeEach(function() {
-              selectionMode = jasmine.createSpy('selectionMode').and.callFake(function(willEvent) {
-                throw new Error(errorMsg);
-              });
-
-              model.on("will:select", listeners.willSelect);
-              model.on("did:select", listeners.didSelect);
-              model.on("rejected:select", listeners.rejectedSelect);
-
-              model.on("did:change", listeners.didChangeSelection);
-
-              model.selectAction(newSelection, {selectionMode: selectionMode});
-            });
-
-            it("should reach the selectionMode function", function() {
-              expect(selectionMode).toHaveBeenCalled();
-            });
-
-            it("should call the will select listener", function() {
-              expect(listeners.willSelect).toHaveBeenCalled();
-            });
-
-            it("should not call the did select listener", function() {
-              expect(listeners.didSelect).not.toHaveBeenCalled();
-            });
-
-            it("should call the rejected select listener", function() {
-              expect(listeners.rejectedSelect).toHaveBeenCalled();
-
-              var reason = listeners.rejectedSelect.calls.mostRecent().args[0];
-              expect(reason instanceof RejectedSelect).toBe(true);
-              expect(reason.error instanceof Error).toBe(true);
-              expect(reason.error.message).toBe(errorMsg);
-            });
-
-            it("should not call the did change selection listener", function() {
-              expect(listeners.didChangeSelection).not.toHaveBeenCalled();
-            });
+          it("should call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).toHaveBeenCalled();
           });
         });
 
-        describe("executeAction - ", function() {
-          var newSelection;
-
-          var listeners;
-
+        describe("default - no listeners (performance check) - ", function() {
           beforeEach(function() {
-            newSelection = new filter.Or();
+            spyOn(model, "_emitSafe");
 
-            listeners = jasmine.createSpyObj('listeners', [
-              'willExecute', 'willExecuteSecond',
-              'didExecute',
-              'rejectedExecute'
-            ]);
+            model.selectAction(newSelection);
           });
 
-          describe("default - ", function() {
-            beforeEach(function() {
-              model.on("will:execute", listeners.willExecute);
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
+          it("should not call _emitSafe function", function() {
+            expect(model._emitSafe).not.toHaveBeenCalled();
+          });
+        });
 
-              model.executeAction(newSelection);
-            });
+        describe("custom selectionMode through keyArgs - ", function() {
+          var selectionMode;
+          beforeEach(function() {
+            selectionMode = jasmine.createSpy('selectionMode');
 
-            it("should call the will execute listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
+            model.on("will:select", listeners.willSelect);
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
 
-            it("should not call the did execute listener", function() {
-              expect(listeners.didExecute).not.toHaveBeenCalled();
-            });
+            model.on("did:change", listeners.didChangeSelection);
 
-            it("should call the rejected execute listener", function() {
-              expect(listeners.rejectedExecute).toHaveBeenCalled();
-
-              var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
-              expect(reason instanceof RejectedExecute).toBe(true);
-              expect(reason.error instanceof UserError).toBe(true);
-              expect(reason.error.message).toBe("Action is not defined");
-            });
+            model.selectAction(newSelection, {selectionMode: selectionMode});
           });
 
-          describe("default - no listeners (performance check) - ", function() {
-            beforeEach(function() {
-              spyOn(model, "_emitSafe");
-
-              model.executeAction(newSelection);
-            });
-
-            it("should not call _emitSafe function", function() {
-              expect(model._emitSafe).not.toHaveBeenCalled();
-            });
+          it("should call the custom selectionMode function", function() {
+            expect(selectionMode).toHaveBeenCalled();
           });
 
-          describe("custom doExecute through keyArgs - ", function() {
-            var doExecute;
-            beforeEach(function() {
-              doExecute = jasmine.createSpy('doExecute');
-
-              model.on("will:execute", listeners.willExecute);
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
-
-              model.executeAction(newSelection, {doExecute: doExecute});
-            });
-
-            it("should call the custom doExecute function", function() {
-              expect(doExecute).toHaveBeenCalled();
-            });
-
-            it("should call the will execute listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
-
-            it("should call the did execute listener", function() {
-              expect(listeners.didExecute).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected execute listener", function() {
-              expect(listeners.rejectedExecute).not.toHaveBeenCalled();
-            });
+          it("should call the will select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
           });
 
-          describe("change selection in will event - ", function() {
-            var alternativeSelection;
-            var doExecute;
-            beforeEach(function() {
-              alternativeSelection = new filter.And();
-
-              doExecute = jasmine.createSpy('doExecute');
-
-              model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
-                willEvent.dataFilter = alternativeSelection;
-              }));
-              model.on("will:execute", listeners.willExecuteSecond);
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
-
-              model.executeAction(newSelection, {doExecute: doExecute});
-            });
-
-            it("should call the custom doExecute function", function() {
-              expect(doExecute).toHaveBeenCalled();
-            });
-
-            it("should call the first will execute listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
-
-            it("should call the second will execute listener", function() {
-              expect(listeners.willExecuteSecond).toHaveBeenCalled();
-              expect(listeners.willExecuteSecond.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
-            });
-
-            it("should call the did execute listener", function() {
-              expect(listeners.didExecute).toHaveBeenCalled();
-              expect(listeners.didExecute.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
-            });
-
-            it("should not call the rejected execute listener", function() {
-              expect(listeners.rejectedExecute).not.toHaveBeenCalled();
-            });
+          it("should call the did select listener", function() {
+            expect(listeners.didSelect).toHaveBeenCalled();
           });
 
-          describe("custom doExecute through will event - ", function() {
-            var doExecute;
-            beforeEach(function() {
-              doExecute = jasmine.createSpy('doExecute');
-
-              model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
-                willEvent.doExecute = doExecute;
-              }));
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
-
-              model.executeAction(newSelection);
-            });
-
-            it("should call the custom doExecute function", function() {
-              expect(doExecute).toHaveBeenCalled();
-            });
-
-            it("should call the will execute listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
-
-            it("should call the did execute listener", function() {
-              expect(listeners.didExecute).toHaveBeenCalled();
-            });
-
-            it("should not call the rejected execute listener", function() {
-              expect(listeners.rejectedExecute).not.toHaveBeenCalled();
-            });
+          it("should not call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).not.toHaveBeenCalled();
           });
 
-          [
-            {label: "no reason", reason: undefined, message: "canceled"},
-            {label: "string reason", reason: "Just cancel it!", message: "Just cancel it!"},
-            {label: "User error reason", reason: new UserError("My error"), message: "My error"}
-          ].forEach(function(motive) {
-              describe("canceled on will - " + motive.label, function() {
-                var doExecute;
-                beforeEach(function() {
-                  doExecute = jasmine.createSpy('doExecute');
+          it("should call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).toHaveBeenCalled();
+          });
+        });
 
-                  model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
-                    willEvent.cancel(motive.reason);
-                  }));
-                  model.on("will:execute", listeners.willExecuteSecond);
-                  model.on("did:execute", listeners.didExecute);
-                  model.on("rejected:execute", listeners.rejectedExecute);
+        describe("change selection in will event - ", function() {
+          var alternativeSelection;
+          var selectionMode;
+          beforeEach(function() {
+            alternativeSelection = new filter.And();
 
-                  model.executeAction(newSelection, {doExecute: doExecute});
-                });
+            selectionMode = jasmine.createSpy('selectionMode');
 
-                it("should not reach the doExecute function", function() {
-                  expect(doExecute).not.toHaveBeenCalled();
-                });
+            model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
+              willEvent.dataFilter = alternativeSelection;
+            }));
+            model.on("will:select", listeners.willSelectSecond);
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
 
-                it("should call the first will execute listener", function() {
-                  expect(listeners.willExecute).toHaveBeenCalled();
-                });
+            model.on("did:change", listeners.didChangeSelection);
 
-                it("should not call the second will execute listener", function() {
-                  expect(listeners.willExecuteSecond).not.toHaveBeenCalled();
-                });
-
-                it("should not call the did execute listener", function() {
-                  expect(listeners.didExecute).not.toHaveBeenCalled();
-                });
-
-                it("should call the rejected execute listener", function() {
-                  expect(listeners.rejectedExecute).toHaveBeenCalled();
-
-                  var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
-                  expect(reason instanceof RejectedExecute).toBe(true);
-                  expect(reason.error instanceof UserError).toBe(true);
-                  expect(reason.error.message).toBe(motive.message);
-                });
-              });
-            }
-          );
-
-          describe("exception on will - ", function() {
-            var doExecute;
-            beforeEach(function() {
-              doExecute = jasmine.createSpy('doExecute');
-
-              model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
-                throw new Error("non-user error");
-              }));
-              model.on("will:execute", listeners.willExecuteSecond);
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
-
-              model.executeAction(newSelection, {doExecute: doExecute});
-            });
-
-            it("should reach the doExecute function", function() {
-              expect(doExecute).toHaveBeenCalled();
-            });
-
-            it("should call the first 'will:execute' listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
-
-            it("should call the second 'will:execute' listener", function() {
-              expect(listeners.willExecuteSecond).toHaveBeenCalled();
-            });
-
-            it("should call the 'did:execute' listener", function() {
-              expect(listeners.didExecute).toHaveBeenCalled();
-            });
-
-            it("should not call the 'rejected:execute' listener", function() {
-              expect(listeners.rejectedExecute).not.toHaveBeenCalled();
-            });
+            model.selectAction(newSelection, {selectionMode: selectionMode});
           });
 
-          describe("exception on doExecute - ", function() {
-            var errorMsg = "non-user error";
-            var doExecute;
-            beforeEach(function() {
-              doExecute = jasmine.createSpy('doExecute').and.callFake(function(willEvent) {
-                throw new Error(errorMsg);
+          it("should call the custom selectionMode function", function() {
+            expect(selectionMode).toHaveBeenCalled();
+          });
+
+          it("should call the first will select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
+          });
+
+          it("should call the second will select listener", function() {
+            expect(listeners.willSelectSecond).toHaveBeenCalled();
+            expect(listeners.willSelectSecond.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
+          });
+
+          it("should call the did select listener", function() {
+            expect(listeners.didSelect).toHaveBeenCalled();
+            expect(listeners.didSelect.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
+          });
+
+          it("should not call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).not.toHaveBeenCalled();
+          });
+
+          it("should call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).toHaveBeenCalled();
+          });
+        });
+
+        describe("custom selectionMode through will event - ", function() {
+          var selectionMode;
+          beforeEach(function() {
+            selectionMode = jasmine.createSpy('selectionMode');
+
+            model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
+              willEvent.selectionMode = selectionMode;
+            }));
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
+
+            model.on("did:change", listeners.didChangeSelection);
+
+            model.selectAction(newSelection);
+          });
+
+          it("should call the custom selectionMode function", function() {
+            expect(selectionMode).toHaveBeenCalled();
+          });
+
+          it("should call the will select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
+          });
+
+          it("should call the did select listener", function() {
+            expect(listeners.didSelect).toHaveBeenCalled();
+          });
+
+          it("should not call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).not.toHaveBeenCalled();
+          });
+
+          it("should call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).toHaveBeenCalled();
+          });
+        });
+
+        [
+          {label: "no reason", reason: undefined, message: "canceled"},
+          {label: "string reason", reason: "Just cancel it!", message: "Just cancel it!"},
+          {label: "User error reason", reason: new UserError("My error"), message: "My error"}
+        ].forEach(function(motive) {
+            describe("canceled on will - " + motive.label, function() {
+              var selectionMode;
+              beforeEach(function() {
+                selectionMode = jasmine.createSpy('selectionMode');
+
+                model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
+                  willEvent.cancel(motive.reason);
+                }));
+                model.on("will:select", listeners.willSelectSecond);
+                model.on("did:select", listeners.didSelect);
+                model.on("rejected:select", listeners.rejectedSelect);
+
+                model.on("did:change", listeners.didChangeSelection);
+
+                model.selectAction(newSelection, {selectionMode: selectionMode});
               });
 
-              model.on("will:execute", listeners.willExecute);
-              model.on("did:execute", listeners.didExecute);
-              model.on("rejected:execute", listeners.rejectedExecute);
+              it("should not reach the selectionMode function", function() {
+                expect(selectionMode).not.toHaveBeenCalled();
+              });
 
-              model.executeAction(newSelection, {doExecute: doExecute});
+              it("should call the first will select listener", function() {
+                expect(listeners.willSelect).toHaveBeenCalled();
+              });
+
+              it("should not call the second will select listener", function() {
+                expect(listeners.willSelectSecond).not.toHaveBeenCalled();
+              });
+
+              it("should not call the did select listener", function() {
+                expect(listeners.didSelect).not.toHaveBeenCalled();
+              });
+
+              it("should call the rejected select listener", function() {
+                expect(listeners.rejectedSelect).toHaveBeenCalled();
+
+                var reason = listeners.rejectedSelect.calls.mostRecent().args[0];
+                expect(reason instanceof RejectedSelect).toBe(true);
+                expect(reason.error instanceof UserError).toBe(true);
+                expect(reason.error.message).toBe(motive.message);
+              });
+
+              it("should not call the did change selection listener", function() {
+                expect(listeners.didChangeSelection).not.toHaveBeenCalled();
+              });
+            });
+          }
+        );
+
+        describe("exception on will - ", function() {
+          var selectionMode;
+          beforeEach(function() {
+            selectionMode = jasmine.createSpy('selectionMode');
+
+            model.on("will:select", listeners.willSelect.and.callFake(function(willEvent) {
+              throw new Error("non-user error");
+            }));
+            model.on("will:select", listeners.willSelectSecond);
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
+
+            model.on("did:change", listeners.didChangeSelection);
+
+            model.selectAction(newSelection, {selectionMode: selectionMode});
+          });
+
+          it("should reach the selectionMode function", function() {
+            expect(selectionMode).toHaveBeenCalled();
+          });
+
+          it("should call the first will:select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
+          });
+
+          it("should call the second will:select listener", function() {
+            expect(listeners.willSelectSecond).toHaveBeenCalled();
+          });
+
+          it("should call the did select listener", function() {
+            expect(listeners.didSelect).toHaveBeenCalled();
+          });
+
+          it("should not call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).not.toHaveBeenCalled();
+          });
+
+          it("should call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).toHaveBeenCalled();
+          });
+        });
+
+        describe("exception on selectionMode - ", function() {
+          var errorMsg = "non-user error";
+          var selectionMode;
+          beforeEach(function() {
+            selectionMode = jasmine.createSpy('selectionMode').and.callFake(function(willEvent) {
+              throw new Error(errorMsg);
             });
 
-            it("should reach the doExecute function", function() {
-              expect(doExecute).toHaveBeenCalled();
-            });
+            model.on("will:select", listeners.willSelect);
+            model.on("did:select", listeners.didSelect);
+            model.on("rejected:select", listeners.rejectedSelect);
 
-            it("should call the will execute listener", function() {
-              expect(listeners.willExecute).toHaveBeenCalled();
-            });
+            model.on("did:change", listeners.didChangeSelection);
 
-            it("should not call the did execute listener", function() {
-              expect(listeners.didExecute).not.toHaveBeenCalled();
-            });
+            model.selectAction(newSelection, {selectionMode: selectionMode});
+          });
 
-            it("should call the rejected execute listener", function() {
-              expect(listeners.rejectedExecute).toHaveBeenCalled();
+          it("should reach the selectionMode function", function() {
+            expect(selectionMode).toHaveBeenCalled();
+          });
 
-              var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
-              expect(reason instanceof RejectedExecute).toBe(true);
-              expect(reason.error instanceof Error).toBe(true);
-              expect(reason.error.message).toBe(errorMsg);
-            });
+          it("should call the will select listener", function() {
+            expect(listeners.willSelect).toHaveBeenCalled();
+          });
+
+          it("should not call the did select listener", function() {
+            expect(listeners.didSelect).not.toHaveBeenCalled();
+          });
+
+          it("should call the rejected select listener", function() {
+            expect(listeners.rejectedSelect).toHaveBeenCalled();
+
+            var reason = listeners.rejectedSelect.calls.mostRecent().args[0];
+            expect(reason instanceof RejectedSelect).toBe(true);
+            expect(reason.error instanceof Error).toBe(true);
+            expect(reason.error.message).toBe(errorMsg);
+          });
+
+          it("should not call the did change selection listener", function() {
+            expect(listeners.didChangeSelection).not.toHaveBeenCalled();
           });
         });
       });
 
-      describe("validates a model spec - ", function() {
+      describe("executeAction - ", function() {
+        var newSelection;
 
-        function specValidityShouldBe(spec, bool) {
-          if (arguments.length !== 2) {
-            throw Error("specValidityShouldBe was not invoked properly");
+        var listeners;
+
+        beforeEach(function() {
+          newSelection = new filter.Or();
+
+          listeners = jasmine.createSpyObj('listeners', [
+            'willExecute', 'willExecuteSecond',
+            'didExecute',
+            'rejectedExecute'
+          ]);
+        });
+
+        describe("default - ", function() {
+          beforeEach(function() {
+            model.on("will:execute", listeners.willExecute);
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
+
+            model.executeAction(newSelection);
+          });
+
+          it("should call the will execute listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should not call the did execute listener", function() {
+            expect(listeners.didExecute).not.toHaveBeenCalled();
+          });
+
+          it("should call the rejected execute listener", function() {
+            expect(listeners.rejectedExecute).toHaveBeenCalled();
+
+            var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
+            expect(reason instanceof RejectedExecute).toBe(true);
+            expect(reason.error instanceof UserError).toBe(true);
+            expect(reason.error.message).toBe("Action is not defined");
+          });
+        });
+
+        describe("default - no listeners (performance check) - ", function() {
+          beforeEach(function() {
+            spyOn(model, "_emitSafe");
+
+            model.executeAction(newSelection);
+          });
+
+          it("should not call _emitSafe function", function() {
+            expect(model._emitSafe).not.toHaveBeenCalled();
+          });
+        });
+
+        describe("custom doExecute through keyArgs - ", function() {
+          var doExecute;
+          beforeEach(function() {
+            doExecute = jasmine.createSpy('doExecute');
+
+            model.on("will:execute", listeners.willExecute);
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
+
+            model.executeAction(newSelection, {doExecute: doExecute});
+          });
+
+          it("should call the custom doExecute function", function() {
+            expect(doExecute).toHaveBeenCalled();
+          });
+
+          it("should call the will execute listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should call the did execute listener", function() {
+            expect(listeners.didExecute).toHaveBeenCalled();
+          });
+
+          it("should not call the rejected execute listener", function() {
+            expect(listeners.rejectedExecute).not.toHaveBeenCalled();
+          });
+        });
+
+        describe("change selection in will event - ", function() {
+          var alternativeSelection;
+          var doExecute;
+          beforeEach(function() {
+            alternativeSelection = new filter.And();
+
+            doExecute = jasmine.createSpy('doExecute');
+
+            model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
+              willEvent.dataFilter = alternativeSelection;
+            }));
+            model.on("will:execute", listeners.willExecuteSecond);
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
+
+            model.executeAction(newSelection, {doExecute: doExecute});
+          });
+
+          it("should call the custom doExecute function", function() {
+            expect(doExecute).toHaveBeenCalled();
+          });
+
+          it("should call the first will execute listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should call the second will execute listener", function() {
+            expect(listeners.willExecuteSecond).toHaveBeenCalled();
+            expect(listeners.willExecuteSecond.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
+          });
+
+          it("should call the did execute listener", function() {
+            expect(listeners.didExecute).toHaveBeenCalled();
+            expect(listeners.didExecute.calls.mostRecent().args[0].dataFilter).toBe(alternativeSelection);
+          });
+
+          it("should not call the rejected execute listener", function() {
+            expect(listeners.rejectedExecute).not.toHaveBeenCalled();
+          });
+        });
+
+        describe("custom doExecute through will event - ", function() {
+          var doExecute;
+          beforeEach(function() {
+            doExecute = jasmine.createSpy('doExecute');
+
+            model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
+              willEvent.doExecute = doExecute;
+            }));
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
+
+            model.executeAction(newSelection);
+          });
+
+          it("should call the custom doExecute function", function() {
+            expect(doExecute).toHaveBeenCalled();
+          });
+
+          it("should call the will execute listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should call the did execute listener", function() {
+            expect(listeners.didExecute).toHaveBeenCalled();
+          });
+
+          it("should not call the rejected execute listener", function() {
+            expect(listeners.rejectedExecute).not.toHaveBeenCalled();
+          });
+        });
+
+        [
+          {label: "no reason", reason: undefined, message: "canceled"},
+          {label: "string reason", reason: "Just cancel it!", message: "Just cancel it!"},
+          {label: "User error reason", reason: new UserError("My error"), message: "My error"}
+        ].forEach(function(motive) {
+            describe("canceled on will - " + motive.label, function() {
+              var doExecute;
+              beforeEach(function() {
+                doExecute = jasmine.createSpy('doExecute');
+
+                model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
+                  willEvent.cancel(motive.reason);
+                }));
+                model.on("will:execute", listeners.willExecuteSecond);
+                model.on("did:execute", listeners.didExecute);
+                model.on("rejected:execute", listeners.rejectedExecute);
+
+                model.executeAction(newSelection, {doExecute: doExecute});
+              });
+
+              it("should not reach the doExecute function", function() {
+                expect(doExecute).not.toHaveBeenCalled();
+              });
+
+              it("should call the first will execute listener", function() {
+                expect(listeners.willExecute).toHaveBeenCalled();
+              });
+
+              it("should not call the second will execute listener", function() {
+                expect(listeners.willExecuteSecond).not.toHaveBeenCalled();
+              });
+
+              it("should not call the did execute listener", function() {
+                expect(listeners.didExecute).not.toHaveBeenCalled();
+              });
+
+              it("should call the rejected execute listener", function() {
+                expect(listeners.rejectedExecute).toHaveBeenCalled();
+
+                var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
+                expect(reason instanceof RejectedExecute).toBe(true);
+                expect(reason.error instanceof UserError).toBe(true);
+                expect(reason.error.message).toBe(motive.message);
+              });
+            });
           }
-          var model = new Model(spec);
-          if (bool) {
-            expect(model.validate()).toBeNull();
-          } else {
-            expect(model.validate()).not.toBeNull();
-          }
-        }
+        );
 
-        function validSpec(spec) {
-          specValidityShouldBe(spec, true);
-        }
+        describe("exception on will - ", function() {
+          var doExecute;
+          beforeEach(function() {
+            doExecute = jasmine.createSpy('doExecute');
 
-        function invalidSpec(spec) {
-          specValidityShouldBe(spec, false);
-        }
+            model.on("will:execute", listeners.willExecute.and.callFake(function(willEvent) {
+              throw new Error("non-user error");
+            }));
+            model.on("will:execute", listeners.willExecuteSecond);
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
 
-        it("a model spec is valid if all (declared) properties (required and optional) are properly defined", function() {
-          validSpec({
-            width: 1,
-            height: 1,
-            isInteractive: false,
-            data: dataSpec
+            model.executeAction(newSelection, {doExecute: doExecute});
+          });
+
+          it("should reach the doExecute function", function() {
+            expect(doExecute).toHaveBeenCalled();
+          });
+
+          it("should call the first 'will:execute' listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should call the second 'will:execute' listener", function() {
+            expect(listeners.willExecuteSecond).toHaveBeenCalled();
+          });
+
+          it("should call the 'did:execute' listener", function() {
+            expect(listeners.didExecute).toHaveBeenCalled();
+          });
+
+          it("should not call the 'rejected:execute' listener", function() {
+            expect(listeners.rejectedExecute).not.toHaveBeenCalled();
           });
         });
 
-        it("a model spec is valid if all required properties are defined", function() {
-          validSpec({
-            width: 1,
-            height: 1,
-            data: dataSpec
+        describe("exception on doExecute - ", function() {
+          var errorMsg = "non-user error";
+          var doExecute;
+          beforeEach(function() {
+            doExecute = jasmine.createSpy('doExecute').and.callFake(function(willEvent) {
+              throw new Error(errorMsg);
+            });
+
+            model.on("will:execute", listeners.willExecute);
+            model.on("did:execute", listeners.didExecute);
+            model.on("rejected:execute", listeners.rejectedExecute);
+
+            model.executeAction(newSelection, {doExecute: doExecute});
+          });
+
+          it("should reach the doExecute function", function() {
+            expect(doExecute).toHaveBeenCalled();
+          });
+
+          it("should call the will execute listener", function() {
+            expect(listeners.willExecute).toHaveBeenCalled();
+          });
+
+          it("should not call the did execute listener", function() {
+            expect(listeners.didExecute).not.toHaveBeenCalled();
+          });
+
+          it("should call the rejected execute listener", function() {
+            expect(listeners.rejectedExecute).toHaveBeenCalled();
+
+            var reason = listeners.rejectedExecute.calls.mostRecent().args[0];
+            expect(reason instanceof RejectedExecute).toBe(true);
+            expect(reason.error instanceof Error).toBe(true);
+            expect(reason.error.message).toBe(errorMsg);
           });
         });
+      });
+    });
 
-        it("a model spec is invalid if at least one required property is omitted", function() {
-          invalidSpec();
-          invalidSpec({});
-          invalidSpec({
-            width: 1
-          });
-          invalidSpec({
-            width: 1,
-            height: 1
-          });
-          invalidSpec({
-            width: 1,
-            height: 1,
-            isInteractive: true //optional
-          });
+    describe("validates a model spec - ", function() {
+
+      function specValidityShouldBe(spec, bool) {
+        if (arguments.length !== 2) {
+          throw Error("specValidityShouldBe was not invoked properly");
+        }
+        var model = new Model(spec);
+        if (bool) {
+          expect(model.validate()).toBeNull();
+        } else {
+          expect(model.validate()).not.toBeNull();
+        }
+      }
+
+      function validSpec(spec) {
+        specValidityShouldBe(spec, true);
+      }
+
+      function invalidSpec(spec) {
+        specValidityShouldBe(spec, false);
+      }
+
+      it("a model spec is valid if all (declared) properties (required and optional) are properly defined", function() {
+        validSpec({
+          width: 1,
+          height: 1,
+          isInteractive: false,
+          data: dataSpec
         });
+      });
 
+      it("a model spec is valid if all required properties are defined", function() {
+        validSpec({
+          width: 1,
+          height: 1,
+          data: dataSpec
+        });
+      });
+
+      it("a model spec is invalid if at least one required property is omitted", function() {
+        invalidSpec();
+        invalidSpec({});
+        invalidSpec({
+          width: 1
+        });
+        invalidSpec({
+          width: 1,
+          height: 1
+        });
+        invalidSpec({
+          width: 1,
+          height: 1,
+          isInteractive: true //optional
+        });
       });
 
     });
 
-  }
-)
-;
+    describe("toJSON", function() {
+      it("should not serialize the `data` property", function() {
+        var model = new Model({
+          width: 1,
+          height: 1,
+          isInteractive: false,
+          data: {v: {}}
+        });
+
+        expect(!!model.get("data")).toBe(true);
+
+        var json = model.toJSON();
+
+        expect(json instanceof Object).toBe(true);
+        expect("data" in json).toBe(false);
+      });
+
+      it("should not serialize the `selectionFilter` property", function() {
+        var model = new Model({
+          width: 1,
+          height: 1,
+          selectionFilter: {v: {}},
+          isInteractive: false
+        });
+
+        expect(!!model.get("selectionFilter")).toBe(true);
+
+        var json = model.toJSON();
+
+        expect(json instanceof Object).toBe(true);
+        expect("selectionFilter" in json).toBe(false);
+      });
+    });
+
+    describe("toSpec", function() {
+      it("should serialize the `data` property", function() {
+        var model = new Model({
+          width:  1,
+          height: 1,
+          isInteractive: false,
+          data: {v: {}}
+        });
+
+        expect(!!model.get("data")).toBe(true);
+
+        var json = model.toSpec();
+
+        expect(json instanceof Object).toBe(true);
+        expect("data" in json).toBe(true);
+      });
+
+      it("should not serialize the `selectionFilter` property", function() {
+        var model = new Model({
+          width: 1,
+          height: 1,
+          selectionFilter: {v: {}},
+          isInteractive: false
+        });
+
+        expect(!!model.get("selectionFilter")).toBe(true);
+
+        var json = model.toSpec();
+
+        expect(json instanceof Object).toBe(true);
+        expect("selectionFilter" in json).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
to be included in toJSON. Added `toSpec({omitProps})` map to complexes.

@pentaho/millenniumfalcon please review.