### PR TITLE
[BACKLOG-7551] Check the content of a value before setting it for an update change

### DIFF
--- a/package-res/resources/web/pentaho/type/changes/ListChangeset.js
+++ b/package-res/resources/web/pentaho/type/changes/ListChangeset.js
@@ -249,7 +249,7 @@ define([
           var repeated = O.hasOwn(setKeys, key);
 
           if((existing = O.getOwn(keys, key))) {
-            if(update && existing !== elem) {
+            if(update && existing !== elem && !existing.equalsContent(elem)) {
               setKeys[key] = 2;
             } else {
               setKeys[key] = 1;

--- a/package-res/resources/web/pentaho/type/element.js
+++ b/package-res/resources/web/pentaho/type/element.js
@@ -50,6 +50,17 @@ define([
      * @description Creates an element instance.
      */
     var Element = Value.extend("pentaho.type.Element", {
+
+      //@override
+      /**
+       * Determines if a given value, of the same type, represents the same entity with the same content.
+       *
+       * @param {!pentaho.type.Value} other - A value to test for equality.
+       */
+      equalsContent: function(other) {
+        return false;
+      },
+
       type: /** @lends pentaho.type.Element.Type# */{
 
         id: module.id,

--- a/package-res/resources/web/pentaho/type/simple.js
+++ b/package-res/resources/web/pentaho/type/simple.js
@@ -194,6 +194,24 @@ define([
         return this._value.toString();
       },
 
+      /**
+       * Determines if a given value, of the same type, represents the same entity with the same content.
+       *
+       * The given value **must** be of the same concrete type (or the result is undefined).
+       *
+       * If two values are equal, they must have an equal [key]{@link pentaho.type.Simple#key},
+       * [value]{@link pentaho.type.Simple#value}, [formatted value]{@link pentaho.type.Simple#formatted}.
+       *
+       * @param {!pentaho.type.Simple} other - A simple value to test for equality.
+       * @return {boolean} `true` if the given simple value is equal to this one, `false`, otherwise.
+       */
+      equalsContent: function(other) {
+        if(!this.equals(other)) return false;
+
+        // TODO: generic metadata
+        return this._value === other._value && this._formatted === other._formatted;
+      },
+
       //region configuration
       /**
        * Configures this simple value with a given configuration.

--- a/test-js/unit/pentaho/type/changes/ListChangeset.Spec.js
+++ b/test-js/unit/pentaho/type/changes/ListChangeset.Spec.js
@@ -231,18 +231,17 @@ define([
 
         it("for two existing elements, a non-existent element " +
            "(with the first, second and fourth arguments set to `true`), " +
-           " should append an `Add`, a `Move` and an `Update` to the changeset", function() {
+           " should only append an `Add` and a `Move` to the changeset " +
+           "when the list is composed of simple values", function() {
           var list = new NumberList([1, 2, 3, 4]);
           changeset = new ListChangeset(list);
 
           changeset._set([5, 2], true, true, false, true);
 
-          expect(changeset.changes.length).toBe(3);
+          expect(changeset.changes.length).toBe(2);
           expect(changeset.changes[0].type).toBe("add");
           expect(changeset.changes[1].type).toBe("move");
-          expect(changeset.changes[2].type).toBe("update");
         });
-
       }); //endregion #_removeAt
 
       // region #_remove


### PR DESCRIPTION
This is to prevent simple values from being updated, when in reality their content (value, formatted) didn't change.

To escape the need to use 'instanceof' and because we still didn't tackle the Update issue, for now I implemented a default method in element.js that always returns `false`.

Also noticed that a complex value most likely will never be updated with our current implementation of the list algorithm, because when two complex values have the same `key`, even though their content might have changed the object is the same, making the test `existing !== elem` return `true` instead of `false`.

@pentaho/millenniumfalcon please review