### PR TITLE
[BACKLOG-9339] - 'Error parsing parameter information' when inputting…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -350,13 +350,20 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
           } else {
             switch (paramType) {
               case "java.lang.String": // Used upper case to eliminate UPPER() post-process formula influence on the strings comparison
-                return paramValue.toUpperCase() != paramSelectedValue.toUpperCase();
+                if(!_.isArray(paramSelectedValue)) {
+                  return paramValue.toUpperCase() != paramSelectedValue.toUpperCase();
+                } else {
+                  return paramValue != paramSelectedValue;
+                }
               case "java.sql.Date": // Set time to zero to eliminate its influence on the days comparison
                 return (new Date(paramValue).setHours(0,0,0,0)) != (new Date(paramSelectedValue).setHours(0,0,0,0));
               default:
                 return paramValue != paramSelectedValue;
             }
           }
+        }
+        if(_.isArray(paramSelectedValue) && paramSelectedValue.length == 0) {
+          return true;
         }
 
         return paramValue != paramSelectedValue;

--- a/package-res/resources/web/prompting/parameters/ParameterValidator.js
+++ b/package-res/resources/web/prompting/parameters/ParameterValidator.js
@@ -69,8 +69,8 @@ define(['cdf/lib/Base'],
           }
         } else {
           for(var k=0; k<currentParameter.values.length; k++) {
-            if(untrustedValue == currentParameter.values[k].value) {
-              currentParameter.values[k].selected = true;              
+            if(untrustedValue[0] == currentParameter.values[k].value) {
+              currentParameter.values[k].selected = true;
               break;
             }
           }
@@ -113,7 +113,7 @@ define(['cdf/lib/Base'],
             currentParameter.values[k].selected = false;
           }
           // all validations passed, set values
-          setSelectedValue(paramDefn, currentParameter, untrustedValue);
+          setSelectedValue(paramDefn, currentParameter, values);
         },
 
         checkParametersErrors: function (paramDefn) {

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -1306,6 +1306,8 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
                 doTest('a', 'a ', stringType, true);
                 doTest('a', '1', stringType, true);
+                doTest('a', [], stringType, true);
+                doTest('', [], stringType, true);
 
                 doTest(null, null, stringType, false);
                 doTest(undefined, null, stringType, false);


### PR DESCRIPTION
… invalid data in the text box parameter

Additional check added in order to avoid exception at this point: paramSelectedValue.toUpperCase().