### PR TITLE
[BACKLOG-10019] Casting date and number values in google data tables.

### DIFF
--- a/package-res/resources/web/pentaho/data/Cell.js
+++ b/package-res/resources/web/pentaho/data/Cell.js
@@ -87,7 +87,7 @@ define([
     constructor: function(spec) {
       if(spec == null) {
         this.value = null;
-      } else if(typeof spec !== "object") {
+      } else if(typeof spec !== "object" || spec.constructor !== Object) {
         this.value = spec;
       } else {
         this.value = spec.v;
@@ -115,12 +115,7 @@ define([
      * @readonly
      */
     get key() {
-      var v = this.v;
-      if(v == null) return "";
-
-      if(v instanceof Member) return v.key;
-
-      return v.toString();
+      return this._key;
     },
     // endregion
 
@@ -164,14 +159,26 @@ define([
     },
 
     set value(v) {
+      var a = this.attribute;
+      v = a.cast(v);
+
+      var k;
       if(v == null) {
         this.v = null; // undefined to null normalization
+        k = "";
       } else {
         // auto-create member
-        if(this.attribute.isDiscrete)
-          this.attribute.members.getOrAdd(v);
+        if(a.isDiscrete) {
+          var m = a.members.getOrAdd(typeof v === "object" ? {v: v} : v);
+          k = m.key;
+        } else {
+          k = v.toString();
+        }
+
         this.v = v;
       }
+
+      this._key = k;
     },
 
     /**

--- a/package-res/resources/web/pentaho/data/Member.js
+++ b/package-res/resources/web/pentaho/data/Member.js
@@ -21,6 +21,8 @@ define([
   "../util/error"
 ], function(OfAttribute, Base, Annotatable, arg, error) {
 
+  var _nextGuid = 1;
+
   var Member = Base.extend("pentaho.data.Member", /** @lends pentaho.data.Member# */{
     /**
      * @alias Member
@@ -102,13 +104,14 @@ define([
     /**
      * Gets the key of the member.
      *
-     * The key of a member is the string representation of its value.
+     * The key of a member is the string representation of its value, or,
+     * when the latter is an object, an automatically generated identifier.
      *
      * @type string
      * @readonly
      */
     get key() {
-      return this.v.toString();
+      return this._key;
     },
     // endregion
 
@@ -153,6 +156,7 @@ define([
     set value(v) {
       if(v == null) throw error.argInvalid("value", "Cannot be nully.");
       this.v = v;
+      this._key = (typeof v === "object") ? ("_mid_" + (_nextGuid++)) : v.toString();
     },
 
     /**

--- a/package-res/resources/web/pentaho/data/_AbstractTable.js
+++ b/package-res/resources/web/pentaho/data/_AbstractTable.js
@@ -15,11 +15,22 @@
  */
 define([
   "../lang/Base",
-  "./_ElementMock"
-], function(Base, ElementMock) {
+  "./_ElementMock",
+  "./AtomicTypeName"
+], function(Base, ElementMock, AtomicTypeName) {
 
   // NOTE: most of this class is actually documented in ITableReadOnly.jsdoc and ITable.jsdoc.
   // While the latter shape the implementation, they are not publicized.
+
+  // Map of DataTable types to CDA lowercase colType
+  // CDA column types (method getColTypes)
+  // github.com/webdetails/cda/blob/master/core/src/main/java/pt/webdetails/cda/exporter/AbstractExporter.java#L47
+
+  var COLTYPE_DT_CDA = {};
+  COLTYPE_DT_CDA[AtomicTypeName.NUMBER] = "numeric";
+  COLTYPE_DT_CDA[AtomicTypeName.STRING] = "string";
+  COLTYPE_DT_CDA[AtomicTypeName.DATE] = "date";
+  COLTYPE_DT_CDA[AtomicTypeName.BOOLEAN] = "boolean";
 
   /**
    * @name AbstractTable
@@ -326,12 +337,9 @@ define([
   }
 
   function writeCdaColType(colType) {
-    /* eshint default-case: 0 */
-    switch(colType) {
-      case "string": return "STRING";
-      case "number": return "NUMERIC";
-    }
+    if(!COLTYPE_DT_CDA.hasOwnProperty(colType))
+      throw new Error("Unsupported data type");
 
-    throw new Error("Unsupported data type");
+    return COLTYPE_DT_CDA[colType];
   }
 });

--- a/package-res/resources/web/pentaho/data/_Table.js
+++ b/package-res/resources/web/pentaho/data/_Table.js
@@ -19,13 +19,21 @@ define([
   "./Model",
   "./_plain/Table",
   "./_cross/Table",
+  "./AtomicTypeName",
   "../util/arg"
-], function(AbstractTable, Model, PlainTable, CrossTable, arg) {
+], function(AbstractTable, Model, PlainTable, CrossTable, AtomicTypeName, arg) {
 
   // Map of CDA lowercase colType to DataTable type
+  // CDA column types (method AbstractExporter.getColTypes)
+  // github.com/webdetails/cda/blob/master/core/src/main/java/pt/webdetails/cda/exporter/AbstractExporter.java#L47
+
   var COLTYPE_CDA_DT = {
-    "numeric": "number",
-    "integer": "number"
+    "numeric": AtomicTypeName.NUMBER,
+    "integer": AtomicTypeName.NUMBER,
+    "blob":    AtomicTypeName.STRING,
+    "string":  AtomicTypeName.STRING,
+    "boolean": AtomicTypeName.BOOLEAN,
+    "date":    AtomicTypeName.DATE
   };
 
   var Table = AbstractTable.extend("pentaho.data.Table", /** @lends pentaho.data.Table# */{
@@ -163,6 +171,11 @@ define([
     /** @inheritdoc */
     getValue: function(rowIndex, colIndex) {
       return this.implem.getValue(rowIndex, colIndex);
+    },
+
+    /** @inheritdoc */
+    getValueKey: function(rowIndex, colIndex) {
+      return this.implem.getValueKey(rowIndex, colIndex);
     },
 
     /** @inheritdoc */

--- a/package-res/resources/web/pentaho/data/_TableView.js
+++ b/package-res/resources/web/pentaho/data/_TableView.js
@@ -224,6 +224,11 @@ define([
     },
 
     /** @inheritdoc */
+    getValueKey: function(rowIndex, colIndex) {
+      return this._source.getValueKey(this.getSourceRowIndex(rowIndex), this.getSourceColumnIndex(colIndex));
+    },
+
+    /** @inheritdoc */
     getFormattedValue: function(rowIndex, colIndex) {
       return this._source.getFormattedValue(this.getSourceRowIndex(rowIndex), this.getSourceColumnIndex(colIndex));
     },

--- a/package-res/resources/web/pentaho/data/_cross/Table.js
+++ b/package-res/resources/web/pentaho/data/_cross/Table.js
@@ -495,6 +495,10 @@ define([
       return this.getCell(rowIndex, colIndex).value;
     },
 
+    getValueKey: function(rowIndex, colIndex) {
+      return this.getCell(rowIndex, colIndex).key;
+    },
+
     getFormattedValue: function(rowIndex, colIndex) {
       return this.getCell(rowIndex, colIndex).toString();
     },

--- a/package-res/resources/web/pentaho/data/_doc/ITableReadOnly.jsdoc
+++ b/package-res/resources/web/pentaho/data/_doc/ITableReadOnly.jsdoc
@@ -105,6 +105,21 @@
  */
 
 /**
+ * Gets the key of the value of a cell, given its row and column indexes.
+ *
+ * When a cell contains the `null` value, its key is the empty string, `""`.
+ * When a cell is discrete (and is not `null`), its key is that of its referent.
+ * Otherwise, the key is the result of calling its value's `toString` method.
+ *
+ * @name pentaho.data.AbstractTable#getValueKey
+ * @method
+ * @abstract
+ * @param {number} rowIndex The row index (zero-based).
+ * @param {number} colIndex The column index (zero-based).
+ * @return {string} The key of the cell's value.
+ */
+
+/**
  * Gets the formatted value _property_ of a cell, given its row and column indexes.
  *
  * This method returns the string representation of the value of the cell's `f` property,

--- a/package-res/resources/web/pentaho/data/_plain/Table.js
+++ b/package-res/resources/web/pentaho/data/_plain/Table.js
@@ -71,6 +71,10 @@ define([
       return this.getCell(rowIndex, colIndex).value;
     },
 
+    getValueKey: function(rowIndex, colIndex) {
+      return this.getCell(rowIndex, colIndex).key;
+    },
+
     getFormattedValue: function(rowIndex, colIndex) {
       return this.getCell(rowIndex, colIndex).toString();
     },

--- a/package-res/resources/web/pentaho/type/date.js
+++ b/package-res/resources/web/pentaho/type/date.js
@@ -16,8 +16,9 @@
 define([
   "module",
   "./simple",
+  "../util/date",
   "../i18n!types"
-], function(module, simpleFactory, bundle) {
+], function(module, simpleFactory, date, bundle) {
 
   "use strict";
 
@@ -57,7 +58,7 @@ define([
         id: module.id,
 
         cast: function(v) {
-          return (v instanceof Date) ? v : new Date(v);
+          return date.parseDateEcma262v7(v);
         }
       }
     }).implement(/** @lends pentaho.type.Date# */{

--- a/package-res/resources/web/pentaho/util/date.js
+++ b/package-res/resources/web/pentaho/util/date.js
@@ -1,0 +1,171 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function() {
+  "use strict";
+
+  // ECMA-262-7.0 / ISO-8601 format
+
+  // 0 - full string
+  // 1 - year
+  // 2 -   [month]
+  // 3 -     [day]
+  // 4 - [time]
+  // 5 - [timezone]
+  var RE_ECMA_DATE = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?(?:T([\d\:\.]+))?([Z+\-][\d:]*)?$/;
+
+  // 0 - full string
+  // 1 -  hours
+  // 2 -    [minutes]
+  // 3 -       [seconds]
+  // 4 -          [milliseconds]
+  var RE_ECMA_TIME = /^(\d{2})\:(\d{2})(?:\:(\d{2})(?:\.(\d{3}))?)?$/;
+
+  // 0 - full string
+  // 1 - Z
+  // or
+  // 2 - +/-
+  // 3 - hour
+  // 4 - minutes
+  var RE_ECMA_TIMEZONE = /^(?:(Z)|(?:([+\-])(\d{2})\:(\d{2})))$/;
+
+  /**
+   * The `date` namespace contains utility functions for
+   * handling with dates.
+   *
+   * @namespace
+   * @memberOf pentaho.util
+   * @amd pentaho/util/date
+   * @private
+   */
+  var date = {
+    /**
+     * Parses a date string according to the simplified ISO-8601 format,
+     * as defined by ECMA-262, version 7.
+     *
+     * For more information on the format,
+     * see
+     * {@link http://www.ecma-international.org/ecma-262/7.0/#sec-date-time-string-format}.
+     *
+     * When and if ever the implementations of `Date.parse` of supported browsers work as specified,
+     * most of the code in this function can delegate to it.
+     *
+     * @param {number|string|Date} s The text to parse; or, the number of milliseconds; or, a date instance.
+     * @return {?Date} A date instance or `null`, when invalid.
+     */
+    parseDateEcma262v7: function(s) {
+      if(s == null) return null;
+      switch(typeof s) {
+        case "number": return new Date(s);
+        case "object": return (s instanceof Date) ? s : null;
+        case "string": break;
+        default: return null;
+      }
+
+      // ECMA-262-7.0 / ISO-8601 format
+      var m = RE_ECMA_DATE.exec(s);
+      if(!m) return null;
+
+      // 0 - full string
+      // 1 - year
+      // 2 -   [month]
+      // 3 -     [day]
+      // 4 - [time]
+      // 5 - [timezone]
+      var date = [Number(m[1]), Number(m[2] || "1") - 1, Number(m[3] || "1")];
+      var time;
+
+      // Parse time.
+      if(m[4]) {
+        time = parseTime(m[4]);
+
+        // Invalid time string?
+        if(!time) return null;
+      } else {
+        time = [0, 0, 0, 0];
+      }
+
+      // Date & time components
+      var comps = date.concat(time);
+
+      // Is Timezone specified?
+      var utcOffset;
+      if(m[5]) {
+        utcOffset = parseTimeZone(m[5]);
+
+        // Invalid Timezone string?
+        if(!utcOffset) return null;
+
+        // Account for UTC offset.
+        comps[3] -= utcOffset[0];
+        comps[4] -= utcOffset[1];
+      } else {
+        // Is date and time? It is UTC.
+        // Is date only? It is local time (utcOffset === undefined).
+        if(m[4]) utcOffset = [0, 0];
+
+        //else d = new Date(Number(m[1]), Number(m[2] || "1") - 1, Number(m[3] || "1"));
+      }
+
+      var d = utcOffset
+          ? new Date(Date.UTC(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]))
+          : new Date(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]);
+
+      return isNaN(d.getTime()) ? null : d;
+    }
+  };
+
+  function parseTimeZone(zone) {
+    // 0 - full string
+    // 1 - Z
+    // or
+    // 2 - +/-
+    // 3 - hour
+    // 4 - minutes
+    var m = RE_ECMA_TIMEZONE.exec(zone);
+    if(!m) return null;
+
+    var offset = [0, 0];
+    if(!m[1]) {
+      var sign = m[2] === "+" ? 1 : -1;
+      if(m[3]) offset[0] = sign * Number(m[3]);
+      if(m[4]) offset[1] = sign * Number(m[4]);
+    }
+
+    return offset;
+  }
+
+  function parseTime(time) {
+    // 0 - full string
+    // 1 -  hours
+    // 2 -    [minutes]
+    // 3 -       [seconds]
+    // 4 -          [milliseconds]
+    var m = RE_ECMA_TIME.exec(time);
+    if(!m) return null;
+
+    var time = [Number(m[1]), Number(m[2]), 0, 0];
+    if(m[3]) {
+      time[2] = Number(m[3]);
+      if(m[4]) {
+        time[3] = Number(m[4]);
+      }
+    }
+
+    return time;
+  }
+
+  return date;
+});

--- a/test-js/unit/pentaho/data/AttributeSpec.js
+++ b/test-js/unit/pentaho/data/AttributeSpec.js
@@ -109,6 +109,11 @@ define([
         attr = expectAttribute({name: "test", type: "booLean"});
         expect(attr.type).toBe("boolean");
       });
+
+      it("should convert datetime to date", function() {
+        var attr = expectAttribute({name: "test", type: "DateTime"});
+        expect(attr.type).toBe("date");
+      });
     });
 
     describe("#isDiscrete", function() {

--- a/test-js/unit/pentaho/util/date.Spec.js
+++ b/test-js/unit/pentaho/util/date.Spec.js
@@ -1,0 +1,234 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/util/date"
+], function(date) {
+
+  "use strict";
+
+  var global = window;
+
+  describe("pentaho.util.date", function() {
+
+    it("is defined", function() {
+      expect(date instanceof Object).toBe(true);
+    });
+
+    describe(".parseDateEcma262v7(s)", function() {
+
+      it("should return null if s is null", function() {
+        expect(date.parseDateEcma262v7(null)).toBe(null);
+      });
+
+      it("should return null if s is undefined", function() {
+        expect(date.parseDateEcma262v7(undefined)).toBe(null);
+      });
+
+      it("should return a Date of corresponding given milliseconds number", function() {
+        var d1 = new Date();
+        var d2 = date.parseDateEcma262v7(d1.getTime());
+
+        expect(d2 instanceof Date).toBe(true);
+        expect(d2.getTime()).toBe(d1.getTime());
+      });
+
+      it("should return a given Date instance, unmodified", function() {
+        var d1 = new Date();
+        var ms1 = d1.getTime();
+        var d2 = date.parseDateEcma262v7(d1);
+
+        expect(d2).toBe(d1);
+        expect(d1.getTime()).toBe(ms1);
+      });
+
+      describe("when called with a string", function() {
+        var OriginalDate;
+
+        beforeEach(function() {
+          // Intercept the global Date constructor.
+
+          OriginalDate = global.Date;
+          global.Date = jasmine.createSpy().and.callFake(function() {
+            switch(arguments.length) {
+              case 1: return new OriginalDate(arguments[0]);
+              case 7: return new OriginalDate(
+                  arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6]);
+              default: throw new Error("Not supported by mock function.");
+            }
+          });
+
+          global.Date.UTC = jasmine.createSpy().and.callFake(function() {
+            return OriginalDate.UTC.apply(OriginalDate, arguments);
+          });
+        });
+
+        afterEach(function() {
+          global.Date = OriginalDate;
+        });
+
+        function itLocal(s, comps) {
+          // Fix month
+          var comps2 = comps.slice();
+          comps2[1] += 1;
+
+          it("should parse '" + s + "' as Local time [" + comps2 + "]", function() {
+            var d = date.parseDateEcma262v7(s);
+
+            expect(global.Date)
+                .toHaveBeenCalledWith(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]);
+
+            var t = new OriginalDate(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]);
+            expect(d.getTime()).toBe(t.getTime());
+          });
+        }
+
+        function itUTC(s, comps) {
+          // Fix month
+          var comps2 = comps.slice();
+          comps2[1] += 1;
+
+          it("should parse '" + s + "' as UTC time [" + comps2 + "]", function() {
+            var d = date.parseDateEcma262v7(s);
+
+            expect(global.Date.UTC)
+                .toHaveBeenCalledWith(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]);
+
+            var t = new OriginalDate(
+                OriginalDate.UTC(comps[0], comps[1], comps[2], comps[3], comps[4], comps[5], comps[6]));
+            expect(d.getTime()).toBe(t.getTime());
+          });
+        }
+
+        function itFailsWith(s, explain) {
+          it("should return null if given '" + s + "' - " + explain, function() {
+            var d = date.parseDateEcma262v7(s);
+            expect(d).toBe(null);
+          });
+        }
+
+        describe("when no timezone is specified", function() {
+
+          describe("when given a date-only string", function() {
+
+            itLocal("2016", [2016, 0, 1, 0, 0, 0, 0]);
+            itLocal("2016-02", [2016, 1, 1, 0, 0, 0, 0]);
+            itLocal("2016-02-02", [2016, 1, 2, 0, 0, 0, 0]);
+          });
+
+          describe("when given a date and time string", function() {
+
+            itUTC("2016T20:30:40.333", [2016, 0, 1, 20, 30, 40, 333]);
+            itUTC("2016-02T20:30:40.333", [2016, 1, 1, 20, 30, 40, 333]);
+            itUTC("2016-02-02T20:30:40.333", [2016, 1, 2, 20, 30, 40, 333]);
+            itUTC("2016-02-02T20:30", [2016, 1, 2, 20, 30, 0, 0]);
+          });
+        });
+
+        describe("when a Z timezone is specified", function() {
+
+          describe("when given a date-only string", function() {
+
+            itUTC("2016Z", [2016, 0, 1, 0, 0, 0, 0]);
+            itUTC("2016-02Z", [2016, 1, 1, 0, 0, 0, 0]);
+            itUTC("2016-02-02Z", [2016, 1, 2, 0, 0, 0, 0]);
+          });
+
+          describe("when given a date and time string", function() {
+
+            itUTC("2016T20:30:40.333Z", [2016, 0, 1, 20, 30, 40, 333]);
+            itUTC("2016-02T20:30:40.333Z", [2016, 1, 1, 20, 30, 40, 333]);
+            itUTC("2016-02-02T20:30:40.333Z", [2016, 1, 2, 20, 30, 40, 333]);
+            itUTC("2016-02-02T20:30Z", [2016, 1, 2, 20, 30, 0, 0]);
+          });
+        });
+
+        describe("when an UTC relative, +HH:mm, timezone is specified", function() {
+
+          describe("when given a date-only string", function() {
+
+            itUTC("2016+01:00", [2016, 0, 1, -1, 0, 0, 0]);
+            itUTC("2016-02+01:00", [2016, 1, 1, -1, 0, 0, 0]);
+            itUTC("2016-02-02+01:00", [2016, 1, 2, -1, 0, 0, 0]);
+
+            itUTC("2016+01:30", [2016, 0, 1, -1, -30, 0, 0]);
+            itUTC("2016-02+01:30", [2016, 1, 1, -1, -30, 0, 0]);
+            itUTC("2016-02-02+01:30", [2016, 1, 2, -1, -30, 0, 0]);
+          });
+
+          describe("when given a date and time string", function() {
+
+            itUTC("2016T10:20:30.444+01:00", [2016, 0, 1, 10 - 1, 20, 30, 444]);
+            itUTC("2016-02T10:20:30.444+01:00", [2016, 1, 1, 10 - 1, 20, 30, 444]);
+            itUTC("2016-02-02T10:20:30.444+01:00", [2016, 1, 2, 10 - 1, 20, 30, 444]);
+
+            itUTC("2016-02-02T10:20+01:00", [2016, 1, 2, 10 - 1, 20, 0, 0]);
+            itUTC("2016-02-02T10:20:30+01:00", [2016, 1, 2, 10 - 1, 20, 30, 0]);
+
+            itUTC("2016-02-02T20:30+01:00", [2016, 1, 2, 20 - 1, 30, 0, 0]);
+
+            itUTC("2016T10:20:30.444+01:30", [2016, 0, 1, 10 - 1, 20 - 30, 30, 444]);
+            itUTC("2016-02T10:20:30.444+01:30", [2016, 1, 1, 10 - 1, 20 - 30, 30, 444]);
+            itUTC("2016-02-02T10:20:30.444+01:30", [2016, 1, 2, 10 - 1, 20 - 30, 30, 444]);
+          });
+        });
+
+        describe("when an UTC relative, -HH:mm, timezone is specified", function() {
+
+          describe("when given a date-only string", function() {
+
+            // This combination would be ambiguous with year or year-month dates.
+
+            itUTC("2016-02-02-01:00", [2016, 1, 2, +1, 0, 0, 0]);
+            itUTC("2016-02-02-01:30", [2016, 1, 2, +1, +30, 0, 0]);
+          });
+
+          describe("when given a date and time string", function() {
+
+            itUTC("2016T10:20:30.444-01:00", [2016, 0, 1, 10 + 1, 20, 30, 444]);
+            itUTC("2016-02T10:20:30.444-01:00", [2016, 1, 1, 10 + 1, 20, 30, 444]);
+            itUTC("2016-02-02T10:20:30.444-01:00", [2016, 1, 2, 10 + 1, 20, 30, 444]);
+
+            itUTC("2016-02-02T10:20-01:00", [2016, 1, 2, 10 + 1, 20, 0, 0]);
+            itUTC("2016-02-02T10:20:30-01:00", [2016, 1, 2, 10 + 1, 20, 30, 0]);
+
+            itUTC("2016-02-02T20:30-01:00", [2016, 1, 2, 20 + 1, 30, 0, 0]);
+
+            itUTC("2016T10:20:30.444-01:30", [2016, 0, 1, 10 + 1, 20 + 30, 30, 444]);
+            itUTC("2016-02T10:20:30.444-01:30", [2016, 1, 1, 10 + 1, 20 + 30, 30, 444]);
+            itUTC("2016-02-02T10:20:30.444-01:30", [2016, 1, 2, 10 + 1, 20 + 30, 30, 444]);
+          });
+        });
+
+        describe("when given an invalid string", function() {
+
+          itFailsWith("2016-01-01Z0", "an invalid Z timezone");
+          itFailsWith("2016-01-01+01:1", "an invalid +hh:mm timezone");
+          itFailsWith("2016-01-01+01:22.000", "an invalid +hh:mm timezone");
+          itFailsWith("2016-01-01-01:2", "an invalid -hh:mm timezone");
+
+          itFailsWith("20160101", "a date with no separator");
+
+          itFailsWith("2016-01-01T", "an invalid time");
+          itFailsWith("2016-01-01T01", "an invalid time");
+          itFailsWith("2016-01-01T0101", "a time with no separator");
+
+          itFailsWith("T01:01", "a time-only date");
+          itFailsWith("01:01", "a time-only date");
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Supporting Google "datetime" type as an alias to type "date"
Implemented an "as close as possible/needed" ECMA-262 v7 Date.parse in pentaho/util/date.
Changed pentaho/type/date to use the new cross-browser safe date parse function.

Related with https://github.com/pentaho/pentaho-det/pull/266.

@pentaho/millenniumfalcon please review.