### PR TITLE
[BACKLOG-9342][BACKLOG-10514] Fixed CCC wrapper's column reordering b…

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return Base.extend({
-    constructor: function(chart, axisId, gems) {
+    constructor: function(chart, axisId, mais) {
       this.chart = chart;
       this.id = axisId;
 
@@ -30,34 +30,39 @@ define([
       // Only bound roles will have an entry in this set
       this.boundRoles = {}; // roleId -> true
 
-      this.gems = gems;
-      this.depth = gems.length;
-      gems.forEach(function(gem) {
-        // Overwrite axis id with corresponding Axis instance
-        gem.axis = this;
+      /**
+       * @type {MappingAttributeInfo[]}
+       */
+      this.mais = mais;
 
-        this.boundRoles[gem.role] = true;
+      this.depth = mais.length;
+      mais.forEach(function(mai) {
+        // Overwrite axis id with corresponding Axis instance
+        mai.axis = this;
+
+        this.boundRoles[mai.role] = true;
       }, this);
     },
 
     defaultRole: null,
 
     buildHtmlTooltip: function(lines, complex, context) {
-     this.gems.forEach(function(gem, index) {
-       if(gem.cccDimName) this._buildGemHtmlTooltip(lines, complex, context, gem, index);
-     }, this);
+      this.mais.forEach(function(mai, index) {
+        if(mai.cccDimName)
+          this._buildMaiHtmlTooltip(lines, complex, context, mai, index);
+      }, this);
     },
 
-    _buildGemHtmlTooltip: function(lines, complex, context, gem, index) {
-     // Multi-chart formulas are not shown in the tooltip.
-     // They're on the small chart's title.
-     if(gem.role !== this.chart._multiRole) {
-       var atom = complex.atoms[gem.cccDimName];
-       if(!atom.dimension.type.isHidden && (!complex.isTrend || atom.value != null)) {
-         // ex: "Line: Ships"
-         lines.push(def.html.escape(gem.label) + ": " + def.html.escape(atom.label));
-       }
-     }
+    _buildMaiHtmlTooltip: function(lines, complex, context, mai, index) {
+      // Multi-chart formulas are not shown in the tooltip.
+      // They're on the small chart's title.
+      if(mai.role !== this.chart._multiRole) {
+        var atom = complex.atoms[mai.cccDimName];
+        if(!atom.dimension.type.isHidden && (!complex.isTrend || atom.value != null)) {
+          // ex: "Line: Ships"
+          lines.push(def.html.escape(mai.label) + ": " + def.html.escape(atom.label));
+        }
+      }
     },
 
     complexToFilter: function() {

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/AbstractAxis.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return Base.extend({
-    constructor: function(chart, axisId, mais) {
+    constructor: function(chart, axisId, mappingAttrInfos) {
       this.chart = chart;
       this.id = axisId;
 
@@ -33,34 +33,34 @@ define([
       /**
        * @type {MappingAttributeInfo[]}
        */
-      this.mais = mais;
+      this.mappingAttrInfos = mappingAttrInfos;
 
-      this.depth = mais.length;
-      mais.forEach(function(mai) {
+      this.depth = mappingAttrInfos.length;
+      mappingAttrInfos.forEach(function(maInfo) {
         // Overwrite axis id with corresponding Axis instance
-        mai.axis = this;
+        maInfo.axis = this;
 
-        this.boundRoles[mai.role] = true;
+        this.boundRoles[maInfo.role] = true;
       }, this);
     },
 
     defaultRole: null,
 
     buildHtmlTooltip: function(lines, complex, context) {
-      this.mais.forEach(function(mai, index) {
-        if(mai.cccDimName)
-          this._buildMaiHtmlTooltip(lines, complex, context, mai, index);
+      this.mappingAttrInfos.forEach(function(maInfo, index) {
+        if(maInfo.cccDimName)
+          this._buildMappingAttrInfoHtmlTooltip(lines, complex, context, maInfo, index);
       }, this);
     },
 
-    _buildMaiHtmlTooltip: function(lines, complex, context, mai, index) {
+    _buildMappingAttrInfoHtmlTooltip: function(lines, complex, context, maInfo, index) {
       // Multi-chart formulas are not shown in the tooltip.
       // They're on the small chart's title.
-      if(mai.role !== this.chart._multiRole) {
-        var atom = complex.atoms[mai.cccDimName];
+      if(maInfo.role !== this.chart._multiRole) {
+        var atom = complex.atoms[maInfo.cccDimName];
         if(!atom.dimension.type.isHidden && (!complex.isTrend || atom.value != null)) {
           // ex: "Line: Ships"
-          lines.push(def.html.escape(mai.label) + ": " + def.html.escape(atom.label));
+          lines.push(def.html.escape(maInfo.label) + ": " + def.html.escape(atom.label));
         }
       }
     },

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
@@ -24,17 +24,17 @@ define([
 
     return {
         // Axis factory method
-        create: function(chart, axisId, gems, keyArgs) {
+        create: function(chart, axisId, mais, keyArgs) {
             var AxisClass;
 
             switch(axisId) {
-                case "row":     AxisClass = RowAxis;     break;
-                case "column":  AxisClass = ColumnAxis;  break;
+                case "row": AxisClass = RowAxis; break;
+                case "column": AxisClass = ColumnAxis; break;
                 case "measure": AxisClass = MeasureAxis; break;
                 default: throw new Error("Undefined axis value '" + axisId + "'.");
             }
 
-            return new AxisClass(chart, axisId, gems, keyArgs);
+            return new AxisClass(chart, axisId, mais, keyArgs);
         }
     };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/Axis.js
@@ -24,7 +24,7 @@ define([
 
     return {
         // Axis factory method
-        create: function(chart, axisId, mais, keyArgs) {
+        create: function(chart, axisId, mappingAttrInfos, keyArgs) {
             var AxisClass;
 
             switch(axisId) {
@@ -34,7 +34,7 @@ define([
                 default: throw new Error("Undefined axis value '" + axisId + "'.");
             }
 
-            return new AxisClass(chart, axisId, mais, keyArgs);
+            return new AxisClass(chart, axisId, mappingAttrInfos, keyArgs);
         }
     };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
@@ -23,16 +23,16 @@ define([
   "use strict";
 
   return AbstractAxis.extend({
-    _nonMultiGemFilter: function(gem) {
-      return gem.role !== this.chart._multiRole;
+    _nonMultiMaiFilter: function(mai) {
+      return mai.role !== this.chart._multiRole;
     },
 
-    _isNullMember: function(complex, gem) {
-      var atom = complex.atoms[gem.cccDimName];
+    _isNullMember: function(complex, mai) {
+      var atom = complex.atoms[mai.cccDimName];
       return util.isNullMember(atom.value);
     },
 
-    _buildGemHtmlTooltip: function(lines, complex, context, gem, index) {
+    _buildMaiHtmlTooltip: function(lines, complex, context, mai, index) {
       /*
        * Multi-chart formulas are not shown in the tooltip
        * They're on the small chart's title.
@@ -42,8 +42,8 @@ define([
        * Using the scene's group, preferably, because the datum (here the complex) may have dimensions
        * that are null in the groups' own atoms.
        */
-      if(this._nonMultiGemFilter(gem) &&
-         !(this.chart._hideNullMembers && this._isNullMember(context.scene.group || complex, gem))) {
+      if(this._nonMultiMaiFilter(mai) &&
+         !(this.chart._hideNullMembers && this._isNullMember(context.scene.group || complex, mai))) {
         this.base.apply(this, arguments);
       }
     },
@@ -54,14 +54,14 @@ define([
       var context = this.chart.context;
       var IsEqual;
 
-      this.getSelectionGems().each(function(gem) {
-        var atom = complex.atoms[gem.cccDimName];
+      this.getSelectionMais().each(function(mai) {
+        var atom = complex.atoms[mai.cccDimName];
         var value = atom.value == null ? atom.rawValue : atom.value;
 
         if(value != null) {
           if(!IsEqual) IsEqual = context.get("pentaho/type/filter/isEqual");
 
-          var operand = new IsEqual({property: gem.name, value: {_: "string", v: value}});
+          var operand = new IsEqual({property: mai.name, value: {_: "string", v: value}});
           filter = filter ? filter.and(operand) : operand;
         }
       });
@@ -69,9 +69,9 @@ define([
       return filter;
     },
 
-    getSelectionGems: function() {
-      return def.query(this.gems)
-          .where(function(gem) { return !gem.isMeasureDiscrim; }, this);
+    getSelectionMais: function() {
+      return def.query(this.mais)
+          .where(function(mai) { return !mai.isMeasureDiscrim; }, this);
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/DiscreteAxis.js
@@ -23,16 +23,16 @@ define([
   "use strict";
 
   return AbstractAxis.extend({
-    _nonMultiMaiFilter: function(mai) {
-      return mai.role !== this.chart._multiRole;
+    _nonMultiMappingAttrInfoFilter: function(maInfo) {
+      return maInfo.role !== this.chart._multiRole;
     },
 
-    _isNullMember: function(complex, mai) {
-      var atom = complex.atoms[mai.cccDimName];
+    _isNullMember: function(complex, maInfo) {
+      var atom = complex.atoms[maInfo.cccDimName];
       return util.isNullMember(atom.value);
     },
 
-    _buildMaiHtmlTooltip: function(lines, complex, context, mai, index) {
+    _buildMappingAttrInfoHtmlTooltip: function(lines, complex, context, maInfo, index) {
       /*
        * Multi-chart formulas are not shown in the tooltip
        * They're on the small chart's title.
@@ -42,8 +42,8 @@ define([
        * Using the scene's group, preferably, because the datum (here the complex) may have dimensions
        * that are null in the groups' own atoms.
        */
-      if(this._nonMultiMaiFilter(mai) &&
-         !(this.chart._hideNullMembers && this._isNullMember(context.scene.group || complex, mai))) {
+      if(this._nonMultiMappingAttrInfoFilter(maInfo) &&
+         !(this.chart._hideNullMembers && this._isNullMember(context.scene.group || complex, maInfo))) {
         this.base.apply(this, arguments);
       }
     },
@@ -54,14 +54,14 @@ define([
       var context = this.chart.context;
       var IsEqual;
 
-      this.getSelectionMais().each(function(mai) {
-        var atom = complex.atoms[mai.cccDimName];
+      this.getSelectionMappingAttrInfos().each(function(maInfo) {
+        var atom = complex.atoms[maInfo.cccDimName];
         var value = atom.value == null ? atom.rawValue : atom.value;
 
         if(value != null) {
           if(!IsEqual) IsEqual = context.get("pentaho/type/filter/isEqual");
 
-          var operand = new IsEqual({property: mai.name, value: {_: "string", v: value}});
+          var operand = new IsEqual({property: maInfo.name, value: {_: "string", v: value}});
           filter = filter ? filter.and(operand) : operand;
         }
       });
@@ -69,9 +69,9 @@ define([
       return filter;
     },
 
-    getSelectionMais: function() {
-      return def.query(this.mais)
-          .where(function(mai) { return !mai.isMeasureDiscrim; }, this);
+    getSelectionMappingAttrInfos: function() {
+      return def.query(this.mappingAttrInfos)
+          .where(function(maInfo) { return !maInfo.isMeasureDiscrim; }, this);
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
@@ -25,32 +25,32 @@ define([
 
     defaultRole: "measures",
 
-    _buildMaiHtmlTooltip: function(lines, complex, context, mai/* , index*/) {
+    _buildMappingAttrInfoHtmlTooltip: function(lines, complex, context, maInfo/* , index*/) {
       /*
        * When using measure discriminator column,
        * only the "active" measure in "complex"
        * is placed in the tooltip.
        */
       if(this.chart._isGenericMeasureMode &&
-         mai.isMeasureGeneric &&
-         mai.name !== complex.atoms[this.chart.GENERIC_MEASURE_DISCRIM_DIM_NAME].value) {
+         maInfo.isMeasureGeneric &&
+         maInfo.name !== complex.atoms[this.chart.GENERIC_MEASURE_DISCRIM_DIM_NAME].value) {
         return;
       }
 
       // Obtain the dimension assigned to the role
-      var cccDimName = mai.cccDimName;
+      var cccDimName = maInfo.cccDimName;
       var atom = complex.atoms[cccDimName];
       if(!atom.dimension.type.isHidden && (!complex.isTrend || atom.value != null)) {
         // ex: "MaiLabel (RoleDesc): 200 (10%)"
-        var tooltipLine = def.html.escape(mai.label);
+        var tooltipLine = def.html.escape(maInfo.label);
 
         // Role description
-        if(this.chart._noRoleInTooltipMeasureRoles[mai.role] !== true)
-          tooltipLine += " (" + def.html.escape(mai.role) + ")";
+        if(this.chart._noRoleInTooltipMeasureRoles[maInfo.role] !== true)
+          tooltipLine += " (" + def.html.escape(maInfo.role) + ")";
 
         tooltipLine += ": " + def.html.escape(this._getAtomLabel(atom, context));
 
-        if(!this.chart._tooltipHidePercentageForPercentMais || !mai.isPercent) {
+        if(!this.chart._tooltipHidePercentageOnPercentAttributes || !maInfo.isPercent) {
           var valuePct = this._getAtomPercent(atom, context);
           if(valuePct != null)
             tooltipLine += " (" + def.html.escape("" + valuePct) + ")";

--- a/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
+++ b/package-res/resources/web/pentaho/visual/ccc/_axes/MeasureAxis.js
@@ -23,64 +23,34 @@ define([
 
   return AbstractAxis.extend({
 
-    constructor: function(chart, axisId, gems) {
-
-      this.base(chart, axisId, gems);
-
-      /* There can be one special CCC dimension into which
-       * the attributes of one or more measure roles are mapped.
-       *
-       * e.g.:
-       *
-       *   visual role  -> CCC dim group/name
-       *   -----------------------------
-       *   "measures"      "value"
-       *   "measuresLine"  "value"
-       *
-       * Each of the visual roles may support more than one attribute.
-       *
-       * In the end, if more than one measure attribute is mapped to the same
-       * CCC dimension group, either multiple CCC dimensions are created,
-       * one for each of the attributes (e.g.: value, value2, value3...)
-       * or a measure discriminator column is added to distinguish
-       * which of the measure attributes is in the single CCC dimension (e.g.: "value").
-       *
-       * To activate the measure discriminator mode, a chart class has to specify the
-       * prototype property `_genericMeasureCccDimName` with the name of the special CCC dimension.
-       *
-       * When multiple dimensions are created and multiple source roles exist,
-       * the source roles are sorted alphabetically and the within role attribute order is preserved.
-       */
-    },
-
     defaultRole: "measures",
 
-    _buildGemHtmlTooltip: function(lines, complex, context, gem/*, index*/) {
+    _buildMaiHtmlTooltip: function(lines, complex, context, mai/* , index*/) {
       /*
        * When using measure discriminator column,
        * only the "active" measure in "complex"
        * is placed in the tooltip.
        */
-      var measureDiscrimGem = this.chart.measureDiscrimGem;
-      if(measureDiscrimGem &&
-         gem.isMeasureGeneric &&
-         gem.name !== complex.atoms[measureDiscrimGem.cccDimName].value) {
+      if(this.chart._isGenericMeasureMode &&
+         mai.isMeasureGeneric &&
+         mai.name !== complex.atoms[this.chart.GENERIC_MEASURE_DISCRIM_DIM_NAME].value) {
         return;
       }
 
       // Obtain the dimension assigned to the role
-      var cccDimName = gem.cccDimName, atom = complex.atoms[cccDimName];
+      var cccDimName = mai.cccDimName;
+      var atom = complex.atoms[cccDimName];
       if(!atom.dimension.type.isHidden && (!complex.isTrend || atom.value != null)) {
-        // ex: "GemLabel (RoleDesc): 200 (10%)"
-        var tooltipLine = def.html.escape(gem.label);
+        // ex: "MaiLabel (RoleDesc): 200 (10%)"
+        var tooltipLine = def.html.escape(mai.label);
 
         // Role description
-        if(this.chart._noRoleInTooltipMeasureRoles[gem.role] !== true)
-          tooltipLine += " (" + def.html.escape(gem.role) + ")";
+        if(this.chart._noRoleInTooltipMeasureRoles[mai.role] !== true)
+          tooltipLine += " (" + def.html.escape(mai.role) + ")";
 
         tooltipLine += ": " + def.html.escape(this._getAtomLabel(atom, context));
 
-        if(!this.chart._tooltipHidePercentageForPercentGems || !gem.isPercent) {
+        if(!this.chart._tooltipHidePercentageForPercentMais || !mai.isPercent) {
           var valuePct = this._getAtomPercent(atom, context);
           if(valuePct != null)
             tooltipLine += " (" + def.html.escape("" + valuePct) + ")";
@@ -104,7 +74,7 @@ define([
 
         } else if(complex.isTrend) {
           suffix = "(" + this.chart.options.trendLabel + ")";
-          //bundle.get("tooltip.dim.interpolation." + complex.trendType);
+          // bundle.get("tooltip.dim.interpolation." + complex.trendType);
         }
 
         if(suffix) tooltipLine += " " + suffix;
@@ -129,19 +99,19 @@ define([
 
     _getAtomPercent: function(atom, context) {
       if(context) {
-        var cccChart = context.chart,
-            data = cccChart.data,
-            cccDimName = atom.dimension.name,
-            visRoles = context.panel.visualRolesOf(cccDimName, /*includeChart*/true);
+        var cccChart = context.chart;
+        var data = cccChart.data;
+        var cccDimName = atom.dimension.name;
+        var visRoles = context.panel.visualRolesOf(cccDimName, /* includeChart: */true);
 
         if(visRoles && visRoles.some(function(r) { return r.isPercent; })) {
-          var group = context.scene.group, dim = (group || data).dimensions(cccDimName),
-              pct = group ? dim.percentOverParent({visible: true}) : dim.percent(atom.value);
+          var group = context.scene.group;
+          var dim = (group || data).dimensions(cccDimName);
+          var pct = group ? dim.percentOverParent({visible: true}) : dim.percent(atom.value);
 
           return dim.type.format().percent()(pct);
         }
       }
     }
   });
-
 });

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
@@ -26,34 +26,44 @@ define([
   "pentaho/util/logger",
   "pentaho/visual/color/utils",
   "pentaho/visual/color/paletteRegistry",
+  "pentaho/visual/role/level",
   "pentaho/data/TableView",
   "./ViewDemo",
   "pentaho/i18n!view"
 ], function(View, selectionModes,
             def, pvc, cdo, pv, Axis,
             util, O, logger, visualColorUtils, visualPaletteRegistry,
-            DataView, ViewDemo, bundle) {
+            measurementLevelFactory, DataView, ViewDemo, bundle) {
 
   "use strict";
 
   /* global alert:false, cv:false */
 
-  var ruleStrokeStyle = "#808285",  // "#D8D8D8",  // #f0f0f0
-      lineStrokeStyle = "#D1D3D4",  // "#D1D3D4"; //"#A0A0A0"; // #D8D8D8",// #f0f0f0
-      extensionBlacklist = {
-        "compatVersion": 1,
-        "interactive": 1,
-        "isMultiValued": 1,
-        "seriesInRows": 1,
-        "crosstabMode": 1,
-        "width": 1,
-        "height": 1,
-        "canvas": 1,
-        "readers": 1,
-        "visualRoles": 1,
-        "extensionPoints": 1,
-        "dataCategoriesCount": 1
-      };
+  var ruleStrokeStyle = "#808285";  // "#D8D8D8",  // #f0f0f0
+  var lineStrokeStyle = "#D1D3D4";  // "#D1D3D4"; //"#A0A0A0"; // #D8D8D8",// #f0f0f0
+  var extensionBlacklist = {
+    "compatVersion": 1,
+    "interactive": 1,
+    "isMultiValued": 1,
+    "measuresIndexes": 1,
+    "multiChartIndexes": 1,
+    "measuresInColumns": 1,
+    "dataMeasuresInColumns": 1,
+    "ignoreMetadataLabels": 1,
+    "dataIgnoreMetadataLabels": 1,
+    "typeCheckingMode": 1,
+    "dataTypeCheckingMode": 1,
+    "seriesInRows": 1,
+    "crosstabMode": 1,
+    "width": 1,
+    "height": 1,
+    "canvas": 1,
+    "readers": 1,
+    "visualRoles": 1,
+    "extensionPoints": 1,
+    "categoriesCount": 1,
+    "dataCategoriesCount": 1
+  };
 
   function legendShapeColorProp(scene) {
     return scene.isOn() ? scene.color : pvc.toGrayScale(scene.color);
@@ -124,6 +134,7 @@ define([
     seriesInRows: false,
 
     // Data
+    dataTypeCheckingMode: "none",
     ignoreNulls: false,
     groupedLabelSep: "~",
 
@@ -149,17 +160,41 @@ define([
 
     // Default mapping from gembarId to CCC dimension group.
     // From requirement visual roles to CCC visual roles...
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "multi": "multiChart",
       "columns": "series",
       "rows": "category",
       "measures": "value"
     },
 
-    // Set to the name of the CCC dimension (group) which should trigger the addition
-    // of a measure discriminator column to distinguish among multiple attributes
-    // mapped to a single CCC dimension.
-    _genericMeasureCccDimName: null,
+    /* There can be one special CCC dimension into which
+     * the attributes of one or more Viz measure roles are mapped.
+     *
+     * e.g.:
+     *
+     *   Viz Visual Role  -> Generic Measure CCC Visual Role
+     *   ---------------------------------------------------
+     *   "measures"          "value"
+     *   "measuresLine"      "value"
+     *
+     * Each of the Viz visual roles may support more than one attribute.
+     *
+     * In the end, if more than one measure attribute were mapped to the same
+     * CCC visual role, either multiple CCC dimensions would be created,
+     * one for each of the attributes (e.g.: value, value2, value3...)
+     * or - the current solution - an auxiliary measure discriminator dimension is added to
+     * distinguish which of the measure attributes is in the CCC visual role (e.g.: "value").
+     *
+     * To activate the measure discriminator mode, a chart class has to specify the
+     * prototype property `_genericMeasureCccVisualRole` with the name of the target CCC visual role.
+     *
+     * When multiple source roles exist,
+     * these are sorted alphabetically and the within role attribute order is preserved.
+     */
+    _genericMeasureCccVisualRole: null,
+
+    GENERIC_MEASURE_DIM_NAME: "__GENERIC_MEASURE__",
+    GENERIC_MEASURE_DISCRIM_DIM_NAME: "__GENERIC_MEASURE_DISCRIM__",
 
     _keyAxesIds: ["column", "row"],
     _axesIds: ["column", "row", "measure"],
@@ -168,8 +203,8 @@ define([
     // Essentially, those measures that are represented by cartesian axes...
     _noRoleInTooltipMeasureRoles: {"measures": true},
 
-    // Do not show percentage value in front of a "percent measure" gem.
-    _tooltipHidePercentageForPercentGems: false,
+    // Do not show percentage value in front of a "percent measure" mai.
+    _tooltipHidePercentageForPercentMais: false,
 
     // The name of the role that represents the "multi-chart" concept.
     _multiRole: "multi",
@@ -188,8 +223,6 @@ define([
       // Ensure we have a plain data table
       // TODO: with nulls preserved, because of order...
       this._dataView = this._dataTable.toPlainTable();
-
-      this._visualMap = this._invVisualMap = this._dataView = null;
 
       // ----------
 
@@ -241,12 +274,12 @@ define([
       // Get information on the axes
       var props = def.query(this._keyAxesIds)
             .selectMany(function(axisId) {
-              return this.axes[axisId].getSelectionGems();
+              return this.axes[axisId].getSelectionMais();
             }, this)
-            .select(function(gem) {
+            .select(function(mai) {
               return {
-                ordinal: gem.attr.ordinal,
-                cccDimName: gem.cccDimName
+                ordinal: mai.attr.ordinal,
+                cccDimName: mai.cccDimName
               };
             })
             .array();
@@ -256,14 +289,14 @@ define([
       var alreadyIn = {};
       for(var k = 0, N = selectedItems.getNumberOfRows(); k < N; k++) {
 
-        // jshint -W083
+        /* eslint no-loop-func: 0 */
         var datumFilterSpec = props.reduce(function(datumFilter, prop) {
           var value = selectedItems.getValue(k, prop.ordinal);
           datumFilter[prop.cccDimName] = value;
           return datumFilter;
         }, {});
 
-        //Prevent repeated terms
+        // Prevent repeated terms.
         var key = specToKey(datumFilterSpec);
         if(!O.hasOwn(alreadyIn, key)) {
           alreadyIn[key] = true;
@@ -283,6 +316,7 @@ define([
         var key = entries.map(function(entry) {
           return entry + ":" + spec[entry];
         }).join(",");
+
         return key;
       }
     },
@@ -304,7 +338,7 @@ define([
       var model = this.model;
 
       // Store the current selections
-      this._selections = null; // drawSpec.highlights; // TODO: hookup model selections?
+      this._selections = null; // TODO: hookup model selections?
 
       // Recursively inherit this class' shared options
       var options = this.options = def.create(this._options);
@@ -312,8 +346,7 @@ define([
         options,
         "canvas", this.domContainer,
         "height", model.height || 400,
-        "width",  model.width || 400,
-        "dimensionGroups", {},
+        "width", model.width || 400,
         "dimensions", {},
         "visualRoles", {},
         "readers", [],
@@ -322,91 +355,16 @@ define([
     // endregion
 
     // region VISUAL MAP
-    _getVisualMap: function() {
-      return this._visualMap || (this._visualMap = this._buildVisualMap());
-    },
-
-    _buildVisualMap: function() {
-      var model = this.model,
-          visualMap = {};
-
-      Object.keys(this._roleToCccDimGroup)
-          .forEach(function(roleName) {
-            if(this[roleName]) {
-              var mapping = model.get(roleName);
-
-              /* jshint laxbreak:true*/
-              visualMap[roleName] = mapping
-                  ? mapping.attributes.toArray(function(mappingAttr) { return mappingAttr.name; })
-                  : [];
-            }
-          }, this._roleToCccDimGroup);
-
-      return visualMap;
-    },
-
-    _getInverseVisualMap: function() {
-      return this._invVisualMap || (this._invVisualMap = this._buildInverseVisualMap());
-    },
-
-    _buildInverseVisualMap: function() {
-      var invVisualMap = {},
-          visualMap = this._getVisualMap();
-      Object.keys(visualMap).forEach(function(roleName) {
-        visualMap[roleName].forEach(function(attrName) {
-          def.array.lazy(invVisualMap, attrName).push(roleName);
-        });
-      });
-      return invVisualMap;
-    },
-
-    _getFirstRoleOfAttribute: function(attrName) {
-      var roles = def.getOwn(this._getInverseVisualMap(), attrName);
-      return roles && roles.length ? roles[0] : null;
-    },
-
-    _getCccDimGroupOfRole: function(roleName) {
-      return (def.getOwn(this._roleToCccDimGroup, roleName) ||
-      def.assert("Role '" + roleName + "' is not defined."));
-    },
-
-    _getAttributeInfoByName: function(attrName, assertExists) {
-      return def.getOwn(this._gemsMap, attrName) ||
-        (assertExists ? def.assert("Undefined attribute of name: '" + attrName + "'") : null);
-    },
-
-    _getAttributeInfosOfRole: function(roleName) {
-      return def.getOwn(this._getVisualMapInfo(), roleName);
-    },
-
-    _getRolesByCccDimGroup: function() {
-      return this._rolesByCccDimGroup ||
-        (this._rolesByCccDimGroup = this._buildRolesByCccDimGroup());
-    },
-
-    _buildRolesByCccDimGroup: function() {
-      var rolesByCccDimGroup = def.query(Object.keys(this._roleToCccDimGroup))
-            .multipleIndex(function(roleName) { return this[roleName]; }, this._roleToCccDimGroup);
-
-      // Must have a stable order for laying out multiple roles that map to a single CCC dimension group.
-      Object.keys(rolesByCccDimGroup).forEach(function(cccDimGroup) {
-        rolesByCccDimGroup[cccDimGroup].sort();
-      });
-
-      return rolesByCccDimGroup;
-    },
-
-    _getVisualMapInfo: function() {
-      return this._visualMapInfo;
+    _getMappingAttrInfosByRole: function(roleName) {
+      return def.getOwn(this._visualMapInfo, roleName);
     },
 
     _getRoleDepth: function(roleName, includeMeasureDiscrim) {
-      var depth = 0,
-          ais = this._getAttributeInfosOfRole(roleName);
-      if(ais) {
-        depth = ais.length;
-        if(!includeMeasureDiscrim && this.measureDiscrimGem &&
-          this.measureDiscrimGem.role === roleName) {
+      var depth = 0;
+      var mais = this._getMappingAttrInfosByRole(roleName);
+      if(mais) {
+        depth = mais.length;
+        if(!includeMeasureDiscrim && this._isGenericMeasureMode && this._genericMeasureDiscrimMai.role === roleName) {
           depth -= 1;
         }
       }
@@ -415,7 +373,34 @@ define([
     },
 
     _isRoleBound: function(roleName) {
-      return !!this._getAttributeInfosOfRole(roleName);
+      return !!this._getMappingAttrInfosByRole(roleName);
+    },
+
+    _isRoleQualitative: function(roleName) {
+      if(this._isGenericMeasureRole(roleName)) return false;
+
+      var mapping = this.model.get(roleName);
+      if(mapping.attributes.length > 1) return true;
+
+      var MeasurementLevel = this.context.get(measurementLevelFactory);
+      var level = this.model.get(roleName).levelEffective;
+      return !level || MeasurementLevel.type.isQualitative(level);
+    },
+
+    _isGenericMeasureRole: function(roleName) {
+      var cccGenericRoleName = this._genericMeasureCccVisualRole;
+      return !!cccGenericRoleName && def.getOwn(this._roleToCccRole, roleName) === cccGenericRoleName;
+    },
+
+    _getGenericMeasureRoleNames: function() {
+      var cccRole = this._genericMeasureCccVisualRole;
+      return (cccRole && def.getOwn(this._rolesByCccVisualRole, cccRole)) || [];
+    },
+
+    _selectGenericMeasureMappingAttrInfos: function() {
+      return def.query(this._getGenericMeasureRoleNames())
+          .selectMany(this._getMappingAttrInfosByRole, this)
+          .where(def.notNully);
     },
     // endregion
 
@@ -485,13 +470,11 @@ define([
         value = model.legendPosition;
         if(value) options.legendPosition = value;
 
-
         if(model.legendSize)
           options.legendFont = util.readFontModel(model, "legend");
       }
 
-
-      value = model.getv("lineWidth", /*sloppy:*/true);
+      value = model.getv("lineWidth", /* sloppy: */true);
       if(value != null) {
         options.line_lineWidth = value;
         var radius = 3 + 6 * (value / 8); // 1 -> 8 => 3 -> 9,
@@ -501,123 +484,254 @@ define([
         options.plot2Dot_shapeSize  = options.dot_shapeSize;
       }
 
-      value = model.getv("maxChartsPerRow", /*sloppy:*/true);
+      value = model.getv("maxChartsPerRow", /* sloppy: */true);
       if(value != null)
         options.multiChartColumnsMax = value;
 
-      value = model.getv("multiChartRangeScope", /*sloppy:*/true);
+      value = model.getv("multiChartRangeScope", /* sloppy: */true);
       if(value) options.numericAxisDomainScope = value;
 
-      value = model.getv("emptyCellMode", /*sloppy:*/true);
+      value = model.getv("emptyCellMode", /* sloppy: */true);
       if(value) this._setNullInterpolationMode(options, value);
 
-      value = model.getv("sizeByNegativesMode", /*sloppy:*/true);
+      value = model.getv("sizeByNegativesMode", /* sloppy: */true);
       options.sizeAxisUseAbs = value === "useAbs";
     },
 
     _initData: function() {
-      var dataTable = this._dataTable,
+      var dataTable = this._dataTable;
+      var attributes = dataTable.model.attributes;
 
-          // axisId -> AttributeInfo[]
-          axesGemsInfo = {
-            row: [],
-            column: [],
-            measure: []
-          },
+      var genericMeasuresCount = 0;
+      var genericMeasureCccVisualRole = this._genericMeasureCccVisualRole;
 
-          // attrName -> AttributeInfo
-          gemsMap = {},
+      // Multiple ways to store and index MappingAttributeInfo...
+      var mappingAttrInfos = [];
 
-          // roleName -> attr-name[]
-          visualMap = this._getVisualMap(),
+      // axisId -> MappingAttributeInfo[]
+      var mappingAttrInfosByAxisId = {
+        row:     [],
+        column:  [],
+        measure: []
+      };
 
-          // roleName -> AttributeInfo[]
-          visualMapInfo = {},
+      // mappingAttrName -> MappingAttributeInfo
+      var mappingAttrInfosByName = {};
 
-          genericMeasuresCount = 0;
+      // roleName -> MappingAttributeInfo[]
+      var visualMapInfo = {};
 
-      // Create attribute infos for each attribute in the data table.
+      // ----
+
+      // roleName -> attrName[]
+      var visualMap = {};
+
+      // attrName -> roleName[]
+      var invVisualMap = {};
+
+      var rolesByCccVisualRole = {};
+
+      // ----
+
+      /**
+       * Registers a mapping attribute info.
+       *
+       * @param {MappingAttributeInfo} mappingAttrInfo The mapping attribure info to add.
+       * @return {MappingAttributeInfo} The same as `mappingAttrInfo`.
+       */
+      var addMappingAttrInfo = function(mappingAttrInfo) {
+
+        // Complete
+        var isMeasureGeneric = !!genericMeasureCccVisualRole &&
+            (mappingAttrInfo.cccRole === genericMeasureCccVisualRole);
+
+        mappingAttrInfo.isMeasureGeneric = isMeasureGeneric;
+
+        // Not final; see below. When genericMeasuresCount.length > 1,
+        // all isMeasureGeneric mappingAttrInfo will share a single CCC dimension.
+        mappingAttrInfo.cccDimName = mappingAttrInfo.name;
+
+        // Store/Index in multiple ways
+        mappingAttrInfos.push(mappingAttrInfo);
+
+        if(isMeasureGeneric) genericMeasuresCount++;
+
+        mappingAttrInfosByName[mappingAttrInfo.name] = mappingAttrInfo;
+
+        mappingAttrInfosByAxisId[mappingAttrInfo.axis].push(mappingAttrInfo);
+
+        var roleName = mappingAttrInfo.role;
+        def.array.lazy(visualMapInfo, roleName).push(mappingAttrInfo);
+
+        var attr = mappingAttrInfo.attr;
+        if(attr) def.array.lazy(invVisualMap, attr.name).push(roleName);
+
+        return mappingAttrInfo;
+      };
+
+      // ----
+      // Phase 1 - Determine the AxisId of each data table column.
+
+      // An Attribute can only belong to one axis.
+      // attrName -> axisId
+      var axisIdByAttrName = {};
+
+      var indexAttributeByAxis = function(axisId, attr) {
+        var attrName = attr.name;
+        if(!def.hasOwn(axisIdByAttrName, attrName))
+          axisIdByAttrName[attrName] = axisId;
+      };
+
       if(dataTable.isCrossTable) {
-        var crossLayout = dataTable.implem.layout,
-            addStructPos = function(axisId, structPos) {
-              addAxisAttribute.call(this, axisId, structPos.attribute);
-            };
+        // The axis of an attribute is tied to the first cross-tab layout role where the attribute participates
+        // Ideally, an attribute would either be in one of rows, columns or measures...
+        var crossLayout = dataTable.implem.layout;
 
-        crossLayout.rows.forEach(addStructPos.bind(this, "row"));
-        crossLayout.cols.forEach(addStructPos.bind(this, "column"));
-        crossLayout.meas.forEach(addStructPos.bind(this, "measure"));
+        var addStructurePosition = function(axisId, structPos) {
+          indexAttributeByAxis(axisId, structPos.attribute);
+        };
+
+        crossLayout.rows.forEach(addStructurePosition.bind(this, "row"));
+        crossLayout.cols.forEach(addStructurePosition.bind(this, "column"));
+        crossLayout.meas.forEach(addStructurePosition.bind(this, "measure"));
       } else {
         // Table in plain layout
-        var C = dataTable.getNumberOfColumns(),
-            j = -1;
+        var C = dataTable.getNumberOfColumns();
+        var j = -1;
         while(++j < C) {
           var attr = dataTable.getColumnAttribute(j);
-          addAxisAttribute.call(this, attr.isDiscrete ? "row" : "measure", attr);
+          indexAttributeByAxis(/* axisId */attr.type !== "number" ? "row" : "measure", attr);
         }
       }
 
-      function addAxisAttribute(axisId, attr) {
-        // Is this attribute mapped to any role?
-        // Note: it can be an automatically provided property of a mapped attribute
-        //   (e.g.: for a "location" geo role attribute,
-        //   Analyzer automatically adds "latitude" and "longitude" attributes)
+      // ----
+      // Phase 2 - Build MappingAttributeInfo part 1...
 
-        /* jshint validthis:true*/
+      // For each visual role mapping attribute,
+      // build a corresponding "visual role mapping attribute info", pointing to the corresponding
+      // data table attribute.
 
-        var attrName = attr.name,
-            roleName = this._getFirstRoleOfAttribute(attrName);
-        if(roleName) {
-          var cccDimGroup = this._getCccDimGroupOfRole(roleName),
-              roleAttrNames = visualMap[roleName],
-              roleOrdinal = roleAttrNames.indexOf(attrName),
-              attrInfo = {
-                attr: attr,
+      // NOTE: ignoring unmapped attributes like the GEO ones that Analyzer automatically adds:
+      // "latitude" and "longitude". For now this is ok, but when the GeoMap viz gets converted to VizAPI3,
+      // we'll have to see if these columns should be explicitly mapped or be provided as part of
+      // a GEO entity's sub-properties.
 
-                name: attr.name,
-                label: attr.label || attr.name,
-                isPercent: !!attr.isPercent,
+      // NOTE: ignoring the fact that Analyzer sometimes does not send visual role mapped attributes due to
+      // "max rows" configurations. Limiting the number of rows is acceptable, but not the number of columns...
 
-                role: roleName,
-                cccDimGroup: cccDimGroup,
-                cccDimName: undefined,
-                axis: axisId,
-                isMeasureGeneric: (cccDimGroup === this._genericMeasureCccDimName),
-                isMeasureDiscrim: false
-              };
+      // NOTE: an attribute may be consumed by more than one visual role,
+      // and still CCC dimensions are created for each mapping attribute info.
+      // This is because, otherwise, we would not be able to specify valueType and isDiscrete differently
+      // for different visual roles...
 
-          if(attrInfo.isMeasureGeneric) genericMeasuresCount++;
+      this.model.type.eachVisualRole(function(propType) {
+        var roleName = propType.name;
+        var mapping  = this.model.get(roleName);
 
-          gemsMap[attrInfo.name] = attrInfo;
-          axesGemsInfo[axisId].push(attrInfo);
+        if(mapping.isMapped) {
+          var cccRoleName = this._roleToCccRole[roleName];
+          if(cccRoleName)
+            def.array.lazy(rolesByCccVisualRole, cccRoleName).push(roleName);
 
-          /* Note that, in general, and apart from the attrName to AttributeInfo conversion,
-           * `visualMapInfo` is a subset of `visualMap`.
-           * This is because due to row/column number limits,
-           * the data service may, for example, omit some of the requested measures
-           * (see Analyzer's `maxValues` visual type property).
-           */
-          var roleAttrInfos = visualMapInfo[roleName] ||
-                (visualMapInfo[roleName] = new Array(roleAttrNames.length));
+          visualMap[roleName] = mapping.attributes.toArray(function(mappingAttr, mappingAttrIndex) {
+            var attrName = mappingAttr.name;
+            var attr = attributes.get(attrName);
+            var axisId = axisIdByAttrName[attrName];
 
-          // We later take care of clearing the gaps caused by missing attributes (i).
-          roleAttrInfos[roleOrdinal] = attrInfo;
+            // Create an intelligible MappingAttrInfo id.
+            // The "_" prefix prevents CCC auto binding to visual roles.
+            var name = "_" + roleName + "_" + (mappingAttrIndex + 1);
+
+            addMappingAttrInfo({
+              name:  name,
+              label: attr.label || attrName,
+
+              role: roleName,
+              mapping: mapping,
+              mappingAttr: mappingAttr,
+
+              attr: attr,
+
+              isPercent: !!attr.isPercent,
+
+              cccRole: cccRoleName,
+
+              axis: axisId,
+              isMeasureDiscrim: false
+            });
+
+            return attrName;
+          }, this);
         }
-      }
+      }, this);
 
-      // (i) Clear gaps caused by missing attributes.
-      Object.keys(visualMapInfo).forEach(function(roleName) {
-        def.array.removeIf(visualMapInfo[roleName], def.falsy);
+      // ----
+      // Phase 3 - 2nd passage stuff
+
+      // Must have a stable order for laying out multiple roles that map to a single CCC dimension group.
+      Object.keys(rolesByCccVisualRole).forEach(function(cccRoleName) {
+        rolesByCccVisualRole[cccRoleName].sort();
       });
 
-      this._gemsMap = gemsMap;
+      // Generic Measure Mode?
+      var isGenericMeasureMode = this._isGenericMeasureMode = genericMeasuresCount > 1;
+      if(isGenericMeasureMode) {
+        this._genericMeasureDiscrimMai = this._createGenericMeasureDiscriminator();
+        addMappingAttrInfo(this._genericMeasureDiscrimMai);
+      } else {
+        this._genericMeasureDiscrimMai = null;
+      }
+
+      var cccDims = this.options.dimensions;
+      var cccVisualRoles = this.options.visualRoles;
+      var addToCCCVisualRole = function(cccRoleName, cccDimName) {
+        var cccRole = def.lazy(cccVisualRoles, cccRoleName);
+        def.array.lazy(cccRole, "dimensions").push(cccDimName);
+      };
+      var MeasurementLevel = this.context.get(measurementLevelFactory);
+
+      // Configure the generic measure visual role
+      if(isGenericMeasureMode)
+        addToCCCVisualRole(genericMeasureCccVisualRole, this.GENERIC_MEASURE_DIM_NAME);
+
+      // mappingAttrInfos is filled above, in visual role mapping attribute order;
+      // this enables its use for configuring the CCC visual roles.
+      mappingAttrInfos.forEach(function(mai) {
+
+        // i) Fix CCC dim names of generic measures if there is more than one.
+        var isMeasureGeneric = isGenericMeasureMode && mai.isMeasureGeneric;
+        if(isMeasureGeneric)
+          mai.cccDimName = this.GENERIC_MEASURE_DIM_NAME;
+
+        if(mai.cccDimName) {
+          // Exclude measure discriminator
+          if(mai.attr) {
+            // ii) Configure CCC dimension options.
+            var cccDim = def.lazy(cccDims, mai.cccDimName);
+            cccDim.valueType  = this._getAttributeCccValueType(mai.attr);
+            cccDim.isDiscrete = this._isRoleQualitative(mai.role);
+            if(cccDim.valueType === Date) {
+              // Change the default formatter to use JavaScript's default serialization.
+              // Affects tooltips and discrete axes.
+              cccDim.formatter = function(v) { return v == null ? "" : v.toString(); };
+            }
+          }
+
+          // iii) Add to corresponding CCC visual role
+          if(!isMeasureGeneric) addToCCCVisualRole(mai.cccRole, mai.cccDimName);
+        }
+      }, this);
+
+      // Publish the created stores/indexes
+      this._mappingAttrInfos = mappingAttrInfos;
+      this._mappingAttrInfoByName = mappingAttrInfosByName;
+      this._visualMap = visualMap;
       this._visualMapInfo = visualMapInfo;
+      this._invVisualMap = invVisualMap;
+      this._rolesByCccVisualRole = rolesByCccVisualRole;
       this._genericMeasuresCount = genericMeasuresCount;
-      this.measureDiscrimGem = null;
 
-      var hasDiscrim = genericMeasuresCount > 1;
-      if(hasDiscrim) this._addGenericMeasureDiscriminator();
-
-      this._initAxes(axesGemsInfo);
+      this._initAxes(mappingAttrInfosByAxisId);
     },
 
     /**
@@ -637,48 +751,56 @@ define([
      * * and the ability to have different formatting per measure attribute, as there is
      *   a single CCC dimension that holds the values of all measure attributes, is lost.
      *   The formatting configuration of the first measure in the measure role is used.
+     *
+     * @return {MappingAttrInfo} The created generic measure discriminator.
+     * @private
      */
-    _addGenericMeasureDiscriminator: function() {
+    _createGenericMeasureDiscriminator: function() {
       // In which of the discrete axes should we add the discriminator to?
       // To the first whose defaultRole is mapped to a ccc dim group.
       // (not all vizs have/use both axis; see Pie chart, for example).
-      var roleToCccDimGroup = this._roleToCccDimGroup,
-          attrInfo = tryCreateInAxis("column") || tryCreateInAxis("row") ||
+      var me = this;
+      var roleToCccVisualRole = this._roleToCccRole;
+      return tryCreateInAxis("column") || tryCreateInAxis("row") ||
             def.assert("Need a mapped discrete axis to hold the measure discriminator.");
-
-      this.measureDiscrimGem = attrInfo;
-
-      def.array.lazy(this._visualMapInfo, attrInfo.role).push(attrInfo);
-
-      this._gemsMap[attrInfo.name] = attrInfo;
 
       // ----
 
       function tryCreateInAxis(axisId) {
         // DefaultRole of axis
         var roleName = axisId + "s";
-
-        var cccDimGroup = def.getOwn(roleToCccDimGroup, roleName);
-        return cccDimGroup && createAttributeInfo(axisId, roleName, cccDimGroup);
+        var cccRoleName = def.getOwn(roleToCccVisualRole, roleName);
+        if(cccRoleName)
+          return createAttributeInfo(axisId, roleName, cccRoleName);
       }
 
-      function createAttributeInfo(axisId, roleName, cccDimGroup) {
-        // Has no data table attribute to map to.
+      function createAttributeInfo(axisId, roleName, cccRoleName) {
         return {
-          attr: null,
-          name: "__MeasureDiscrim__",
-          label: "Measure discriminator",
+          name: me.GENERIC_MEASURE_DISCRIM_DIM_NAME,
+          label: "Generic Measure Discriminator",
           role: roleName,
-          cccDimGroup: cccDimGroup,
-          cccDimName: undefined,
+          mapping: null,
+          mappingAttr: null,
+          attr: null,
+          isPercent: false,
+          cccRole: cccRoleName,
           axis: axisId,
-          isMeasureGeneric: false,
           isMeasureDiscrim: true
         };
       }
     },
 
-    _initAxes: function(axesGemsInfo) {
+    _getAttributeCccValueType: function(attr) {
+      /* eslint default-case: 0 */
+      switch(attr.type) {
+        case "string": return String;
+        case "number": return Number;
+        case "date": return Date;
+      }
+      return null; // any
+    },
+
+    _initAxes: function(mappingAttrInfosByAxisId) {
       // 1. Create axes.
 
       // axisId -> Axis
@@ -686,30 +808,24 @@ define([
 
       // Order is not relevant.
       this._axesIds.forEach(function(axisId) {
-        this.axes[axisId] = Axis.create(this, axisId, axesGemsInfo[axisId]);
+        this.axes[axisId] = Axis.create(this, axisId, mappingAttrInfosByAxisId[axisId]);
       }, this);
 
       // 2. Ensure we have a plain data table
       // TODO: with nulls preserved, because of order...
       this._dataView = this._dataTable.toPlainTable();
 
-      // 3. Remove _unmapped_ attributes and reorder attributes of the plain data table.
+      // 3. Hide columns not bound to visual roles and reorder attributes of the plain data table.
       this._transformData();
 
-      // 4. Assign a CCC dimension name to each attribute info.
-      this._assignCccDimensions();
-
-      // 5. Configure CCC readers
-      this._configureCccReaders();
-
-      // 6. Determine if there are any multi-chart playing roles
+      // 4. Determine if there are any multi-chart playing roles
       // (ignoring the measure discrim, if any)
+      // TODO: refactor this check by using the model directly? Would not need to account for measure discrim...
       var hasMulti = false;
       if(this._multiRole) {
-        var mais = this._getAttributeInfosOfRole(this._multiRole);
+        var mais = this._getMappingAttrInfosByRole(this._multiRole);
         if(mais)
-          hasMulti = !this.measureDiscrimGem ||
-            mais.some(function(mai) { return !mai.isMeasureDiscrim; });
+          hasMulti = !this._isGenericMeasureMode || mais.some(function(mai) { return !mai.isMeasureDiscrim; });
       }
       this._hasMultiChartColumns = hasMulti;
     },
@@ -720,102 +836,92 @@ define([
      * Gets array of _mapped_ column indexes of the plain table to set in a data view.
      *
      * Column reordering serves two purposes:
-     * 1. All generic measures are placed last to satisfy the crosstab/generic measure discriminator scenario
+     * 1. All generic measures are placed last to satisfy the cross-tab/generic measure discriminator scenario
      * 2. All measures are placed last so that CCC doesn't reorder the "logical row", discrete columns first
-     */
-    _transformData: function() {
-      var mappedColumnIndexesDiscrete = [],
-          mappedColumnIndexesContinuous = [],
-          C = this._dataView.getNumberOfColumns(),
-          j = -1;
-
-      while(++j < C) {
-        var ai = this._getAttributeInfoByName(this._dataView.getColumnAttribute(j).name);
-        if(ai) {
-          if(ai.attr.isDiscrete)
-            mappedColumnIndexesDiscrete.push(j);
-          else
-            mappedColumnIndexesContinuous.push(j);
-        }
-      }
-
-      this._dataView = new DataView(this._dataView);
-      this._dataView.setSourceColumns(mappedColumnIndexesDiscrete.concat(mappedColumnIndexesContinuous));
-
-      // Set CCC cross-tab mode and categories count
-      // for proper logical row construction.
-      if((this.options.crosstabMode = !!this.measureDiscrimGem)) {
-        this.options.dataCategoriesCount = mappedColumnIndexesDiscrete.length;
-      } else {
-        // Not relevant, as every position is mapped in readers,
-        // and this only serves to split discrete columns among
-        // series and categories.
-        this.options.dataCategoriesCount = null;
-      }
-    },
-
-    /**
-     * Assign a CCC dimension name to each attribute info.
      *
-     * (CCC Dim Group)     1-->oo     (Role)     1-->oo    (AttributeInfo)
-     *                       |                     |
-     *               rolesByCccDimGroup       visualMapInfo
-     */
-    _assignCccDimensions: function() {
-      var rolesByCccDimGroup = this._getRolesByCccDimGroup(),
-          visualMapInfo = this._visualMapInfo,
-          hasGenericDiscrim = !!this.measureDiscrimGem,
-          genericCccDimName = this._genericMeasureCccDimName;
-
-      Object.keys(rolesByCccDimGroup).forEach(function(cccDimGroup) {
-        var isGenericGroup = hasGenericDiscrim && (cccDimGroup === genericCccDimName),
-            ordinal = 0;
-
-        rolesByCccDimGroup[cccDimGroup].forEach(function(roleName) {
-          // Role may be unbound.
-          var ais = def.getOwn(visualMapInfo, roleName);
-          if(ais) ais.forEach(function(ai) {
-            /* jshint laxbreak:true*/
-            ai.cccDimName = isGenericGroup
-              ? cccDimGroup
-              : pvc.buildIndexedId(cccDimGroup, ordinal++);
-          });
-        });
-      });
-    },
-
-    /**
+     * Specifies readers (and measuresIndexes and dataCategoriesCount)
+     * because this is the only way to bind specific columns to arbitrary, specific dimensions.
      * With all the plain table transformations in place,
      * and apart from the measure discriminator,
      * which always takes the first position in CCC's logical row,
-     * the CCC mapping is 1-1.
+     * the CCC readers mapping is 1-1.
      */
-    _configureCccReaders: function() {
-      var readers = this.options.readers,
-          dataView = this._dataView,
-          C = dataView.getNumberOfColumns(),
-          j = -1,
-          hasGenericReader = false,
-          attrName, ai;
+    _transformData: function() {
+      // For DataView source columns
+      var categoriesSourceIndexes = [];
+      var measuresSourceIndexes   = [];
 
-      if(this.measureDiscrimGem)
-        readers.push(this.measureDiscrimGem.cccDimName);
+      // For CCC readers
+      var categoriesDimNames = [];
+      var measuresDimNames   = [];
 
-      while(++j < C) {
-        attrName = dataView.getColumnAttribute(j).name;
-        ai = this._getAttributeInfoByName(attrName);
-        if(ai.isMeasureGeneric) {
-          // All generic measure columns are collapsed into a single measure dimension.
-          if(hasGenericReader) continue;
-          hasGenericReader = true;
-        }
-        readers.push(ai.cccDimName);
+      // If there are generic measures, then the cross-tab format is used.
+      if(this._isGenericMeasureMode) {
+        this.options.crosstabMode  = true;
+        this.options.isMultiValued = false;
+
+        categoriesDimNames.push(this.GENERIC_MEASURE_DISCRIM_DIM_NAME);
+
+        this._mappingAttrInfos.forEach(function(mai) {
+          if(mai.attr) {
+            var sourceIndexes = mai.isMeasureGeneric ? measuresSourceIndexes : categoriesSourceIndexes;
+            sourceIndexes.push(mai.attr.ordinal);
+
+            if(!mai.isMeasureDiscrim && !mai.isMeasureGeneric) {
+              categoriesDimNames.push(mai.cccDimName);
+            }
+          }
+        });
+
+        measuresDimNames.push(this.GENERIC_MEASURE_DIM_NAME);
+      } else {
+        // The use of the relational translator with the following options
+        // is the most reliable way to "control" the translator code and avoid unexpected shuffling of columns
+        this.options.crosstabMode = false;
+        this.options.isMultiValued = true;
+
+        this._mappingAttrInfos.forEach(function(mai) {
+          if(mai.attr) {
+            var sourceIndexes;
+            var dimNames;
+
+            if(mai.attr.type === "number") {
+              sourceIndexes = measuresSourceIndexes;
+              dimNames = measuresDimNames;
+            } else {
+              sourceIndexes = categoriesSourceIndexes;
+              dimNames = categoriesDimNames;
+            }
+
+            sourceIndexes.push(mai.attr.ordinal);
+            dimNames.push(mai.cccDimName);
+          }
+        });
+
+        // The already mapped data view indexes of measures.
+        var i = categoriesSourceIndexes.length;
+        var C = measuresSourceIndexes.length;
+        var afterMappingColumnIndexesMeasures = [];
+        while(C--) afterMappingColumnIndexesMeasures.push(i++);
+
+        this.options.measuresIndexes = afterMappingColumnIndexesMeasures;
+
+        // dataCategoriesCount is sort of irrelevant in this case, but it is set anyway, J.I.C.
+        // It is only used to split discrete columns among series and categories
+        // which, because readers are fully specified, does not affect the mapping.
       }
+
+      this._dataView = new DataView(this._dataView);
+      this._dataView.setSourceColumns(categoriesSourceIndexes.concat(measuresSourceIndexes));
+
+      this.options.dataCategoriesCount = categoriesSourceIndexes.length;
+
+      this.options.readers = categoriesDimNames.concat(measuresDimNames);
     },
 
     _configure: function() {
-      var options = this.options,
-          model   = this.model;
+      var options = this.options;
+      var model   = this.model;
 
       var colorScaleKind = this._getColorScaleKind();
       if(colorScaleKind)
@@ -853,8 +959,8 @@ define([
     },
 
     _configureColor: function(colorScaleKind) {
-      var options = this.options,
-          model = this.model;
+      var options = this.options;
+      var model = this.model;
 
       switch(colorScaleKind) {
         case "discrete":
@@ -879,8 +985,8 @@ define([
     _getDiscreteColorsCore: function() {
       var colorMap = this._getDiscreteColorMap();
       if(colorMap) {
-        var defaultScale = pv.colors(this._getDefaultDiscreteColors()),
-            scaleFactory = this._createDiscreteColorMapScaleFactory(colorMap, defaultScale);
+        var defaultScale = pv.colors(this._getDefaultDiscreteColors());
+        var scaleFactory = this._createDiscreteColorMapScaleFactory(colorMap, defaultScale);
 
         // Make sure the scales returned by scaleFactory
         // "are like" pv.Scale - have all the necessary methods.
@@ -902,34 +1008,34 @@ define([
       //     the color role.
       // 2 - When a measure discrim is used and there is only one measure, the CCC dim name of the discriminator is
       //      not of the "series" group; so in this case, there's no discriminator in the key.
-      var colorGems = this._getDiscreteColorGems(),
-          C = colorGems.length,
-          M = this._genericMeasuresCount,
-          colorMap;
+      var colorMais = this._getDiscreteColorMais();
+      var C = colorMais.length;
+      var M = this._genericMeasuresCount;
+      var colorMap;
 
       // Possible to create colorMap based on memberPalette?
       if(C || M) {
         if(!C || M > 1) {
           // Use measure colors.
-          // More than one measure gem or no color gems.
+          // More than one measure mai or no color mais.
           // var keyIncludesMeasureDiscriminator = M > 1 && C > 0;
-          // When the measure discriminator exists, it is the last gem.
+          // When the measure discriminator exists, it is the last mai.
           colorMap = this._copyColorMap(null, memberPalette["[Measures].[MeasuresLevel]"]);
         } else {
           // If C > 0, Pie chart always ends up here...
           // Use the members' colors of the last color attribute.
-          colorMap = this._copyColorMap(null, memberPalette[colorGems[C - 1].name]);
+          colorMap = this._copyColorMap(null, memberPalette[colorMais[C - 1].attr.name]);
         }
       }
 
       return colorMap;
     },
 
-    _getDiscreteColorGems: function() {
+    _getDiscreteColorMais: function() {
       /* jshint laxbreak:true*/
-      var colorAttrInfos = this._getVisualMapInfo()[this._discreteColorRole];
+      var colorAttrInfos = this._getMappingAttrInfosByRole(this._discreteColorRole);
       return colorAttrInfos
-          ? colorAttrInfos.filter(function(attrInfo) { return !attrInfo.isMeasureDiscrim; })
+          ? colorAttrInfos.filter(function(mappingAttrInfo) { return !mappingAttrInfo.isMeasureDiscrim; })
           : [];
     },
 
@@ -988,8 +1094,8 @@ define([
       return function scaleFactory() {
         return function(compKey) {
           if(compKey) {
-            var keys = compKey.split("~"),
-              key = keys[keys.length - 1];
+            var keys = compKey.split("~");
+            var key = keys[keys.length - 1];
             return colorMap[key] || defaultScale(key);
           }
         };
@@ -1008,8 +1114,8 @@ define([
     // endregion
 
     _configureTrends: function() {
-      var options = this.options,
-          model = this.model;
+      var options = this.options;
+      var model = this.model;
 
       var trendType = (this._supportsTrends ? model.trendType : null) || "none";
       switch(trendType) {
@@ -1061,14 +1167,16 @@ define([
       }
 
       // Attribute/dimension-level format info
-      // var ais = this._getAttributeInfosOfRole(measureRole);
+      // var mais = this._getMappingAttrInfosByRole(measureRole);
       var dims = this.options.dimensions;
 
       // 1. Handle all mapped, non-generic measure attributes
-      def.query(Object.keys(this._gemsMap))
-        .select(function(attrName) { return this._gemsMap[attrName]; }, this)
-        .where(function(ai) { return !!ai.attr && !ai.attr.isDiscrete && !ai.isMeasureGeneric; })
-        .each(setFormatInfo);
+      def.query(Object.keys(this._mappingAttrInfoByName))
+        .select(function(attrName) { return this._mappingAttrInfoByName[attrName]; }, this)
+        .where(function(mai) {
+          return !!mai.attr && !mai.attr.isDiscrete && (!this._isGenericMeasureMode || !mai.isMeasureGeneric);
+        }, this)
+        .each(setCccDimFormatInfo);
 
       // 2. Handle generic measure dimension name, if any.
       //    As there are multiple measure attributes in a single CCC dimension,
@@ -1076,32 +1184,29 @@ define([
       //    only the format of the first of these can be specified.
       //    Also, note, there may be more than one generic measure role,
       //    so only the first attribute of the first bound generic measure role is used...
-      if(this.measureDiscrimGem) {
+      if(this._isGenericMeasureMode) {
         // e.g.
-        // _genericMeasureCccDimName = "value"
         // roles:
         //   "measures":     unbound
         //   "measuresLine": "sales", "quantity"
-        var genericRoleNames = this._getRolesByCccDimGroup()[this._genericMeasureCccDimName],
-            firstAi = def.query(genericRoleNames)
-              .selectMany(this._getAttributeInfosOfRole, this)
-              .first(def.notNully);
-        if(firstAi) setFormatInfo(firstAi);
+        var firstMai = this._selectGenericMeasureMappingAttrInfos().first();
+        if(firstMai) setCccDimFormatInfo(firstMai);
       }
 
       // ---
 
-      function setFormatInfo(ai) {
-        var format = ai.attr.format,
-            mask = format && format.number && format.number.mask;
-        if(mask) def.lazy(dims, ai.cccDimName).format = mask;
+      function setCccDimFormatInfo(mai) {
+        var format = mai.attr.format;
+        var mask = format && format.number && format.number.mask;
+        if(mask) def.lazy(dims, mai.cccDimName).format = mask;
       }
     },
 
     // region LABELS
     _configureLabels: function(options, model) {
-      var valuesAnchor = model.labelsOption,
-          valuesVisible = !!valuesAnchor && valuesAnchor !== "none";
+      var valuesAnchor = model.labelsOption;
+      var valuesVisible = !!valuesAnchor && valuesAnchor !== "none" &&
+            !!def.get(this._validExtensionOptions, "valuesVisible", true);
 
       options.valuesVisible = valuesVisible;
       if(valuesVisible) {
@@ -1117,8 +1222,8 @@ define([
     },
 
     _configureLabelsAnchor: function(options, model) {
-      var valuesAnchor = model.labelsOption,
-          simpleCamelCase = /(^\w+)([A-Z])(\w+)/;
+      var valuesAnchor = model.labelsOption;
+      var simpleCamelCase = /(^\w+)([A-Z])(\w+)/;
 
       var match = simpleCamelCase.exec(valuesAnchor);
       if(match != null) {
@@ -1141,7 +1246,7 @@ define([
       }
 
       // Very small charts can't be dominated by text...
-      //options.axisSizeMax = '30%';
+      // options.axisSizeMax = '30%';
 
       var titleFont = util.defaultFont(options.titleFont, 12);
       if(titleFont && !(/black|(\bbold\b)/i).test(titleFont))
@@ -1163,7 +1268,8 @@ define([
     },
 
     _getTooltipText: function(complex, context) {
-      var tooltipLines = [], msg;
+      var tooltipLines = [];
+      var msg;
 
       this._axesIds.forEach(function(axisId) {
         this.axes[axisId].buildHtmlTooltip(tooltipLines, complex, context);
@@ -1171,15 +1277,15 @@ define([
 
       if(!complex.isVirtual) {
         // TODO: container double click tooltip
-        //msg = this._vizHelper.getDoubleClickTooltip();
+        // msg = this._vizHelper.getDoubleClickTooltip();
         if(msg) tooltipLines.push(msg);
       }
 
       /* Add selection information */
       // Not the data point count, but the selection count (a single column selection may select many data points).
-      //var selectedCount = this._chart && this._chart.data.selectedCount();
-      var selections = this._selections,
-          selectedCount = selections && selections.length;
+      // var selectedCount = this._chart && this._chart.data.selectedCount();
+      var selections = this._selections;
+      var selectedCount = selections && selections.length;
       if(selectedCount) {
         var msgId = selectedCount === 1 ? "tooltip.footer.selectedOne" : "tooltip.footer.selectedMany";
 
@@ -1195,7 +1301,7 @@ define([
     // region LEGEND
     _isLegendVisible: function() {
       var colorRole = this._discreteColorRole;
-      return !!colorRole && this._getRoleDepth(colorRole, /*includeMeasureDiscrim:*/true) > 0;
+      return !!colorRole && this._getRoleDepth(colorRole, /* includeMeasureDiscrim: */true) > 0;
     },
 
     _configureLegend: function() {
@@ -1203,8 +1309,8 @@ define([
 
       options.legendFont = util.defaultFont(options.legendFont, 10);
 
-      var legendPosition = options.legendPosition,
-          isTopOrBottom = legendPosition === "top" || legendPosition === "bottom";
+      var legendPosition = options.legendPosition;
+      var isTopOrBottom = legendPosition === "top" || legendPosition === "bottom";
 
       if(this._hasMultiChartColumns && !isTopOrBottom) {
         options.legendAlignTo = "page-middle";
@@ -1216,7 +1322,7 @@ define([
         // to separate the legend from the content area.
         var legendMargins = options.legendMargins;
         if(legendMargins) {
-          if(typeof(legendMargins) !== "object")
+          if(typeof legendMargins !== "object")
             legendMargins = options.legendMargins = {all: legendMargins};
         } else {
           legendMargins = options.legendMargins = {};
@@ -1342,6 +1448,7 @@ define([
             memo.push(operand);
           }
         }
+
         return memo;
       }.bind(this), []);
 
@@ -1362,17 +1469,17 @@ define([
       var selectionsKept = selections;
 
       // limit selection
-      var filterSelectionMaxCount = Infinity, //deselectCount > 0 always false
-          L = selections.length,
-          deselectCount = L - filterSelectionMaxCount;
+      var filterSelectionMaxCount = Infinity; // deselectCount > 0 always false
+      var L = selections.length;
+      var deselectCount = L - filterSelectionMaxCount;
       if(deselectCount > 0) {
         // Build a list of datums to deselect
         var deselectDatums = [];
         selectionsKept = [];
 
         for(var i = 0; i < L; i++) {
-          var selection = selections[i],
-              keep = true;
+          var selection = selections[i];
+          var keep = true;
           if(deselectCount) {
             if(this._previousSelectionKeys) {
               var key = this._getSelectionKey(selection);
@@ -1403,6 +1510,7 @@ define([
         this._chart.updateSelections();
 
         if(typeof alert !== "undefined") {
+          /* eslint no-alert: 0 */
           alert([
             "infoExceededMaxSelectionItems",
             filterSelectionMaxCount,
@@ -1482,5 +1590,5 @@ define([
       return this.base(name, instSpec, classSpec, keyArgs);
     }
   })
-    .implement(ViewDemo);
+  .implement(ViewDemo);
 });

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
@@ -52,7 +52,7 @@ define([
 
       // Remove restrictions on the properties that span multiple charts.
 
-      var multi = this._getAttributeInfosOfRole(this._multiRole);
+      var multi = this._getMappingAttrInfosByRole(this._multiRole);
       if(!multi) return;
 
       var isNotMultiPropertyFilter = function(oper) {
@@ -77,7 +77,7 @@ define([
     },
 
     _isAttributeInRole: function(attrName, roleName) {
-      var roles = O.getOwn(this._getInverseVisualMap(), attrName);
+      var roles = O.getOwn(this._invVisualMap, attrName);
       return roles != null && roles.indexOf(roleName) >= 0;
     },
 

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/model.properties
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/model.properties
@@ -149,22 +149,24 @@ scatter.label=CCC Scatter Chart
 scatter.description=CCC Scatter Chart
 scatter.props.size.label=Size By
 
+## PointAbstract
+
+pointAbstract.label=CCC Point Abstract Chart
+pointAbstract.description=CCC Point Abstract Chart
+
+pointAbstract.props.columns.label=Series
+pointAbstract.props.multi.label=Multi-Chart
+
 ## Line
 line.label=CCC Line Chart
 line.description=CCC Line Chart
 
-line.props.columns.label=Series
-line.props.multi.label=Multi-Chart
 line.props.lineWidth.label=Line Width
 line.props.shape.label=Bullet Style
 
 ## Stacked Area
 areaStacked.label=CCC Stacked Area Chart
 areaStacked.description=CCC Stacked Area Chart
-
-areaStacked.props.columns.label=Series
-areaStacked.props.multi.label=Multi-Chart
-
 
 # Metadata Mixins
 

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/model.js
@@ -48,7 +48,10 @@ define([
           // region Visual Roles
           {
             name: "rows", //VISUAL_ROLE
-            type: "pentaho/visual/role/ordinal",
+            type: {
+              base:   "pentaho/visual/role/mapping",
+              levels: ["ordinal"]
+            },
             ordinal: 5
           },
           // endregion
@@ -151,7 +154,7 @@ define([
           }
         ]
       }
-      
+
     })
     /* jshint sub:true*/
     .implement({type: bundle.structured["abstract"]});

--- a/package-res/resources/web/pentaho/visual/ccc/areaStacked/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/areaStacked/model.js
@@ -15,63 +15,25 @@
  */
 define([
   "module",
-  "../categoricalContinuousAbstract/model",
-  "pentaho/i18n!../abstract/i18n/model",
-  "../abstract/types/labelsOption",
-  "../abstract/mixins/settingsMultiChartType",
-  "../abstract/mixins/interpolationType"
-], function(module, categoricalContinuousAbstractModelFactory, bundle, labelsOptionFactory,
-    settingsMultiChartType, interpolationType) {
+  "../pointAbstract/model",
+  "pentaho/i18n!../abstract/i18n/model"
+], function(module, pointAbstractFactory, bundle) {
 
   "use strict";
 
   return function(context) {
 
-    var CategoricalContinuousAbstract = context.get(categoricalContinuousAbstractModelFactory);
+    var PointAbstract = context.get(pointAbstractFactory);
 
-    return CategoricalContinuousAbstract.extend({
-        type: {
-          sourceId: module.id,
-          id: module.id.replace(/.\w+$/, ""),
-          v2Id: "ccc_area",
-          category: "areachart",
-
-          defaultView: "./View",
-
-          props: [
-            {
-              name: "columns", //VISUAL_ROLE
-              type: "pentaho/visual/role/ordinal",
-              ordinal: 6
-            },
-            {
-              name: "measures", //VISUAL_ROLE
-              type: {
-                props: {attributes: {isRequired: true}}
-              },
-              ordinal: 7
-            },
-            {
-              name: "multi", //VISUAL_ROLE
-              type: "pentaho/visual/role/ordinal",
-              ordinal: 10
-            },
-            {
-              name: "labelsOption",
-              type: {
-                base: labelsOptionFactory,
-                domain: ["none", "center", "left", "right", "top", "bottom"]
-              },
-              isRequired: true,
-              value: "none"
-            }
-          ]
-        }
-      })
-      .implement({type: settingsMultiChartType})
-      .implement({type: bundle.structured["settingsMultiChart"]})
-      .implement({type: interpolationType})
-      .implement({type: bundle.structured["interpolation"]})
-      .implement({type: bundle.structured["areaStacked"]});
+    return PointAbstract.extend({
+      type: {
+        sourceId: module.id,
+        id: module.id.replace(/.\w+$/, ""),
+        v2Id: "ccc_area",
+        category: "areachart",
+        defaultView: "./View"
+      }
+    })
+    .implement({type: bundle.structured.areaStacked});
   };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 define([
+  "cdf/lib/CCC/def",
   "../categoricalContinuousAbstract/View"
-], function(AbstractCategoricalContinuousChart) {
+], function(def, AbstractCategoricalContinuousChart) {
 
   "use strict";
 
@@ -28,7 +29,7 @@ define([
 
       var options = this.options;
       if(options.orientation !== "vertical")
-        options.visualRoles.category = {isReversed: true};
+        def.lazy(options.visualRoles, "category").isReversed = true;
     },
 
     _configureLabelsAnchor: function(options, visualSpec) {

--- a/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
@@ -23,7 +23,7 @@ define([
 
   return AbstractBarChart.extend({
 
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "columns": "series",
       "rows": "category",
       "multi": "multiChart",
@@ -55,15 +55,14 @@ define([
       // 0 -> bars
       // 1 -> lines
 
-      var calculation,
-          measureDiscrimCccDimName = this.measureDiscrimGem && this.measureDiscrimGem.cccDimName;
-
-      if(measureDiscrimCccDimName) {
+      var calculation;
+      if(this._isGenericMeasureMode) {
         /* jshint laxbreak:true*/
-        var barAttrInfos = this._getAttributeInfosOfRole("measures"),
-            barAttrInfosByName = barAttrInfos
-                ? def.query(barAttrInfos).uniqueIndex(function(ai) { return ai.name; })
+        var barAttrInfos = this._getMappingAttrInfosByRole("measures");
+        var barAttrInfosByName = barAttrInfos
+                ? def.query(barAttrInfos).uniqueIndex(function(mai) { return mai.name; })
                 : {};
+        var measureDiscrimCccDimName = this.GENERIC_MEASURE_DISCRIM_DIM_NAME;
 
         calculation = function(datum, atoms) {
           var meaAttrName = datum.atoms[measureDiscrimCccDimName].value;
@@ -72,7 +71,7 @@ define([
       } else if(this._genericMeasuresCount > 0) {
         // One measure of one of the roles exists.
         // And so, either it is always bar or always line...
-        var constDataPart = this._getAttributeInfosOfRole("measures") ? "0" : "1";
+        var constDataPart = this._getMappingAttrInfosByRole("measures") ? "0" : "1";
         calculation = function(datum, atoms) { atoms.dataPart = constDataPart; };
       } else {
         throw def.error("At least one of the measure roles must be specified");
@@ -83,6 +82,7 @@ define([
     },
 
     _readUserOptions: function(options) {
+
       this.base.apply(this, arguments);
 
       var shape = this.model.shape;
@@ -97,7 +97,7 @@ define([
     _configure: function() {
       this.base();
 
-      this._configureAxisRange(/*isPrimary*/false, "ortho2");
+      this._configureAxisRange(/* isPrimary: */false, "ortho2");
 
       this._configureAxisTitle("ortho2", "");
 
@@ -124,7 +124,7 @@ define([
     _configureDisplayUnits: function() {
       this.base();
 
-      this._configureAxisDisplayUnits(/*isPrimary*/false, "ortho2");
+      this._configureAxisDisplayUnits(/* isPrimary: */false, "ortho2");
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
@@ -60,7 +60,7 @@ define([
         /* jshint laxbreak:true*/
         var barAttrInfos = this._getMappingAttrInfosByRole("measures");
         var barAttrInfosByName = barAttrInfos
-                ? def.query(barAttrInfos).uniqueIndex(function(mai) { return mai.name; })
+                ? def.query(barAttrInfos).uniqueIndex(function(maInfo) { return maInfo.name; })
                 : {};
         var measureDiscrimCccDimName = this.GENERIC_MEASURE_DISCRIM_DIM_NAME;
 

--- a/package-res/resources/web/pentaho/visual/ccc/bubble/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/bubble/View.js
@@ -28,7 +28,7 @@ define([
     },
 
     /* Override Default map */
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "multi": "multiChart",
       "rows": "category",
       "x": "x",

--- a/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
@@ -57,8 +57,8 @@ define([
      * of the role, or empty, if the role has more than one attribute.
      */
     _getMeasureRoleTitle: function(measureRole) {
-      var ais = this._getAttributeInfosOfRole(measureRole);
-      return (ais && ais.length === 1) ? ais[0].label : "";
+      var mais = this._getMappingAttrInfosByRole(measureRole);
+      return (mais && mais.length === 1) ? mais[0].label : "";
     },
 
     _getDiscreteRolesTitle: function(roleNames) {
@@ -66,9 +66,9 @@ define([
 
       if(this._multiRole) q = q.where(function(rn) { return rn !== this._multiRole; }, this);
 
-      var labels = q.selectMany(function(rn) { return this._getAttributeInfosOfRole(rn); }, this)
-          .distinct(function(ai) { return ai.name; })
-          .select(function(ai) { return ai.label; })
+      var labels = q.selectMany(function(rn) { return this._getMappingAttrInfosByRole(rn); }, this)
+          .distinct(function(mai) { return mai.name; })
+          .select(function(mai) { return mai.label; })
           .where(def.truthy)
           .array();
 

--- a/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
@@ -57,8 +57,8 @@ define([
      * of the role, or empty, if the role has more than one attribute.
      */
     _getMeasureRoleTitle: function(measureRole) {
-      var mais = this._getMappingAttrInfosByRole(measureRole);
-      return (mais && mais.length === 1) ? mais[0].label : "";
+      var maInfos = this._getMappingAttrInfosByRole(measureRole);
+      return (maInfos && maInfos.length === 1) ? maInfos[0].label : "";
     },
 
     _getDiscreteRolesTitle: function(roleNames) {
@@ -67,8 +67,8 @@ define([
       if(this._multiRole) q = q.where(function(rn) { return rn !== this._multiRole; }, this);
 
       var labels = q.selectMany(function(rn) { return this._getMappingAttrInfosByRole(rn); }, this)
-          .distinct(function(mai) { return mai.name; })
-          .select(function(mai) { return mai.label; })
+          .distinct(function(maInfo) { return maInfo.name; })
+          .select(function(maInfo) { return maInfo.label; })
           .where(def.truthy)
           .array();
 

--- a/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return AbstractCartesianChart.extend({
-    _genericMeasureCccDimName: "value",
+    _genericMeasureCccVisualRole: "value",
 
     _options: {
       panelSizeRatio: 0.8
@@ -32,25 +32,32 @@ define([
     },
 
     _getOrthoAxisTitle: function() {
-      var roleNames = def.getOwn(this._getRolesByCccDimGroup(), this._genericMeasureCccDimName);
+      var roleNames = def.getOwn(this._rolesByCccVisualRole, this._genericMeasureCccVisualRole);
       return roleNames ? this._getMeasureRoleTitle(roleNames[0]) : "";
     },
 
     _getBaseAxisTitle: function() {
-      var roleNames = this._getRolesByCccDimGroup()["category"];
+      var roleNames = def.getOwn(this._rolesByCccVisualRole, "category");
       return roleNames ? this._getDiscreteRolesTitle(roleNames) : "";
+    },
+
+    _isBaseAxisQualitative: function() {
+      var roleNames = def.getOwn(this._rolesByCccVisualRole, "category");
+      return !!roleNames && this._isRoleQualitative(roleNames[0]);
     },
 
     _configure: function() {
       this.base();
 
-      this._configureAxisRange(/*isPrimary*/true, "ortho");
+      this._configureAxisRange(/* isPrimary: */true, "ortho");
 
       var options = this.options;
       if(options.orientation === "vertical") {
-        options.xAxisLabel_textAngle    = -Math.PI/4;
-        options.xAxisLabel_textAlign    = "right";
-        options.xAxisLabel_textBaseline = "top";
+        if(this._isBaseAxisQualitative()) {
+          options.xAxisLabel_textAngle = -Math.PI / 4;
+          options.xAxisLabel_textAlign = "right";
+          options.xAxisLabel_textBaseline = "top";
+        }
       } else {
         options.xAxisPosition = "top";
       }
@@ -59,7 +66,7 @@ define([
     _configureDisplayUnits: function() {
       this.base();
 
-      this._configureAxisDisplayUnits(/*isPrimary*/true, "ortho");
+      this._configureAxisDisplayUnits(/* isPrimary: */true, "ortho");
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
@@ -24,7 +24,7 @@ define([
   return AbstractCartesianChart.extend({
     _cccClass: "HeatGridChart",
 
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "columns": "series",
       "rows": "category",
       "color": "value",

--- a/package-res/resources/web/pentaho/visual/ccc/line/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/line/View.js
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 define([
-  "../categoricalContinuousAbstract/View",
+  "../pointAbstract/View",
   "../trends"
-], function(AbstractCategoricalContinuousChart) {
+], function(PointAbstractChart) {
 
   "use strict";
 
-  return AbstractCategoricalContinuousChart.extend({
+  return PointAbstractChart.extend({
     _cccClass: "LineChart",
 
     _supportsTrends: true,
-
-    _options: {
-      axisOffset: 0,
-      tooltipOffset: 15
-    },
 
     _readUserOptions: function(options) {
       this.base.apply(this, arguments);
@@ -40,10 +35,6 @@ define([
         options.dotsVisible = true;
         options.dot_shape = shape;
       }
-    },
-
-    _setNullInterpolationMode: function(options, value) {
-      options.nullInterpolationMode = value;
     },
 
     _configureLegend: function() {

--- a/package-res/resources/web/pentaho/visual/ccc/line/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/line/model.js
@@ -15,83 +15,46 @@
  */
 define([
   "module",
-  "../categoricalContinuousAbstract/model",
+  "../pointAbstract/model",
   "pentaho/i18n!../abstract/i18n/model",
-  "../abstract/types/labelsOption",
   "../abstract/types/shape",
   "../abstract/types/lineWidth",
-  "../abstract/mixins/trendType",
-  "../abstract/mixins/settingsMultiChartType",
-  "../abstract/mixins/interpolationType"
-], function(module, categoricalContinuousAbstractFactory, bundle, labelsOptionFactory, shapeFactory, lineWidthFactory,
-    trendType, settingsMultiChartType, interpolationType) {
+  "../abstract/mixins/trendType"
+], function(module, pointAbstractFactory, bundle, shapeFactory, lineWidthFactory, trendType) {
 
   "use strict";
 
   return function(context) {
 
-    var CategoricalContinuousAbstract = context.get(categoricalContinuousAbstractFactory);
+    var PointAbstract = context.get(pointAbstractFactory);
 
-    return CategoricalContinuousAbstract.extend({
+    return PointAbstract.extend({
+      type: {
+        sourceId: module.id,
+        id: module.id.replace(/.\w+$/, ""),
+        v2Id: "ccc_line",
+        category: "linechart",
+        defaultView: "./View",
+        props: [
+          {
+            name: "lineWidth",
+            type: lineWidthFactory,
+            isApplicable: function() { return this.count("measures") > 0; },
+            isRequired: true,
+            value: 1
+          },
+          {
+            name: "shape",
+            type: shapeFactory,
+            isRequired: true,
+            value: "circle"
+          }
+        ]
+      }
 
-        type: {
-          sourceId: module.id,
-          id: module.id.replace(/.\w+$/, ""),
-          v2Id: "ccc_line",
-          category: "linechart",
-          defaultView: "./View",
-
-          props: [
-            {
-              name: "columns", //VISUAL_ROLE
-              type: "pentaho/visual/role/ordinal",
-              ordinal: 6
-            },
-            {
-              name: "measures", //VISUAL_ROLE
-              type: {
-                props: {attributes: {isRequired: true}}
-              },
-              ordinal: 7
-            },
-            {
-              name: "multi", //VISUAL_ROLE
-              type: "pentaho/visual/role/ordinal",
-              ordinal: 10
-            },
-
-            {
-              name: "lineWidth",
-              type: lineWidthFactory,
-              isApplicable: function() { return this.count("measures") > 0; },
-              isRequired: true,
-              value: 1
-            },
-            {
-              name: "shape",
-              type: shapeFactory,
-              isRequired: true,
-              value: "circle"
-            },
-            {
-              name: "labelsOption",
-              type: {
-                base: labelsOptionFactory,
-                domain: ["none", "center", "left", "right", "top", "bottom"]
-              },
-              isRequired: true,
-              value: "none"
-            }
-          ]
-        }
-
-      })
-      .implement({type: trendType})
-      .implement({type: bundle.structured["trendType"]})
-      .implement({type: settingsMultiChartType})
-      .implement({type: bundle.structured["settingsMultiChart"]})
-      .implement({type: interpolationType})
-      .implement({type: bundle.structured["interpolation"]})
-      .implement({type: bundle.structured["line"]});
+    })
+    .implement({type: trendType})
+    .implement({type: bundle.structured.trendType})
+    .implement({type: bundle.structured.line});
   };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/View.js
@@ -32,7 +32,7 @@ define([
     },
 
     /* Override Default map */
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "multi": "multiChart",
       "rows": "category",
       "x": "x",
@@ -50,11 +50,7 @@ define([
     },
 
     _isColorDiscrete: function() {
-      var levelEffective = this.model.color.levelEffective;
-      if(levelEffective) {
-        var MeasurementLevel = this.model.type.context.get(levelFactory);
-        return MeasurementLevel.type.isQualitative(levelEffective);
-      }
+      if(this.model.color.isMapped) return this._isRoleQualitative("color");
     },
 
     _getColorScaleKind: function() {
@@ -67,17 +63,8 @@ define([
 
       this.base();
 
-      this._configureAxisRange(/*isPrimary*/true,  "base" );
-      this._configureAxisRange(/*isPrimary*/false, "ortho");
-    },
-
-    _configureColor: function(colorScaleKind) {
-      this.base(colorScaleKind);
-
-      if(colorScaleKind === "discrete") {
-        // Must force the discrete type
-        this.options.dimensionGroups.color = {valueType: String};
-      }
+      this._configureAxisRange(/* isPrimary: */true, "base");
+      this._configureAxisRange(/* isPrimary: */false, "ortho");
     },
 
     _isLegendVisible: function() {
@@ -101,8 +88,8 @@ define([
 
       this.base();
 
-      this._configureAxisDisplayUnits(/*isPrimary*/true,  "base",  /*allowFractional*/true);
-      this._configureAxisDisplayUnits(/*isPrimary*/false, "ortho", /*allowFractional*/true);
+      this._configureAxisDisplayUnits(/* isPrimary: */true,  "base",  /* allowFractional: */true);
+      this._configureAxisDisplayUnits(/* isPrimary: */false, "ortho", /* allowFractional: */true);
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/model.js
@@ -49,7 +49,6 @@ define([
               name: "x", //VISUAL_ROLE
               type: {
                 base: "pentaho/visual/role/quantitative",
-                dataType: "number",
                 props: {attributes: {countMin: 1, countMax: 1}}
               },
               ordinal: 1
@@ -58,7 +57,6 @@ define([
               name: "y", //VISUAL_ROLE
               type: {
                 base: "pentaho/visual/role/quantitative",
-                dataType: "number",
                 props: {attributes: {countMin: 1, countMax: 1}}
               },
               ordinal: 2

--- a/package-res/resources/web/pentaho/visual/ccc/pie/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pie/View.js
@@ -35,7 +35,7 @@ define([
 
     _discreteColorRole: "rows",
 
-    _tooltipHidePercentageForPercentMais: true,
+    _tooltipHidePercentageOnPercentAttributes: true,
 
     _options: {
       legendShape: "circle",
@@ -85,10 +85,10 @@ define([
             category: {
               sliceLabelMask: function() {
                 var meaAtom = this.atoms[genericMeasureDiscrimName];
-                var meaMaiId;
-                var meaMai;
-                if(meaAtom && (meaMaiId = meaAtom.value) &&
-                   (meaMai = mappingAttrInfoByName[meaMaiId]) && meaMai.isPercent) {
+                var meaMAInfoId;
+                var meaMAInfo;
+                if(meaAtom && (meaMAInfoId = meaAtom.value) &&
+                   (meaMAInfo = mappingAttrInfoByName[meaMAInfoId]) && meaMAInfo.isPercent) {
                   return "{value}"; // the value is the percentage itself;
                 }
 
@@ -103,14 +103,14 @@ define([
     _getDiscreteColorMap: function() {
       var memberPalette = this._getMemberPalette();
       if(memberPalette) {
-        var colorMais = this._getDiscreteColorMais();
-        var C = colorMais.length;
+        var colorMAInfos = this._getDiscreteColorMappingAttrInfos();
+        var C = colorMAInfos.length;
         // C >= 0 (color -> "rows" -> is optional)
         // When multiple measures exist, the pie chart shows them as multiple charts
         // and if these would affect color, each small chart would have a single color.
         // => consider M = 0;
         // If C, use the members' colors of the last color attribute.
-        if(C) return this._copyColorMap(null, memberPalette[colorMais[C - 1].name]);
+        if(C) return this._copyColorMap(null, memberPalette[colorMAInfos[C - 1].name]);
       }
     }
   });

--- a/package-res/resources/web/pentaho/visual/ccc/pie/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pie/View.js
@@ -23,25 +23,26 @@ define([
   return AbstractChart.extend({
     _cccClass: "PieChart",
 
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "columns": "multiChart",
       "rows": "category",
       "measures": "value"
     },
 
-    _genericMeasureCccDimName: "value",
+    _genericMeasureCccVisualRole: "value",
 
     _multiRole: "columns",
 
     _discreteColorRole: "rows",
 
-    _tooltipHidePercentageForPercentGems: true,
+    _tooltipHidePercentageForPercentMais: true,
 
     _options: {
       legendShape: "circle",
       titlePosition: "bottom",
       slice_strokeStyle: "white",
-      slice_lineWidth: 0.8
+      slice_lineWidth: 0.8,
+      valuesAnchor: "outer"
     },
 
     _configure: function() {
@@ -58,8 +59,12 @@ define([
       this.base.apply(this, arguments);
 
       if(options.valuesVisible) {
-        options.valuesLabelStyle = model.labelsOption;
+        options.valuesLabelStyle = model.labelsOption === "outside" ? "linked" : model.labelsOption;
       }
+    },
+
+    _configureLabelsAnchor: function(options, model) {
+      // NOOP
     },
 
     _configureMultiChart: function() {
@@ -71,15 +76,19 @@ define([
     _configureValuesMask: function() {
       // Change values mask according to each category's
       // discriminated measure being isPercent or not
-      if(this.measureDiscrimGem) {
-        var gemsMap = this._gemsMap, meaDiscrimName = this.measureDiscrimGem.cccDimName;
+      if(this._isGenericMeasureMode) {
+        var mappingAttrInfoByName = this._mappingAttrInfoByName;
+        var genericMeasureDiscrimName = this.GENERIC_MEASURE_DISCRIM_DIM_NAME;
 
         this.options.pie = {
           scenes: {
             category: {
               sliceLabelMask: function() {
-                var meaAtom = this.atoms[meaDiscrimName], meaGemId, meaGem;
-                if(meaAtom && (meaGemId = meaAtom.value) && (meaGem = gemsMap[meaGemId]) && meaGem.isPercent) {
+                var meaAtom = this.atoms[genericMeasureDiscrimName];
+                var meaMaiId;
+                var meaMai;
+                if(meaAtom && (meaMaiId = meaAtom.value) &&
+                   (meaMai = mappingAttrInfoByName[meaMaiId]) && meaMai.isPercent) {
                   return "{value}"; // the value is the percentage itself;
                 }
 
@@ -94,13 +103,14 @@ define([
     _getDiscreteColorMap: function() {
       var memberPalette = this._getMemberPalette();
       if(memberPalette) {
-        var colorGems = this._getDiscreteColorGems(), C = colorGems.length;
+        var colorMais = this._getDiscreteColorMais();
+        var C = colorMais.length;
         // C >= 0 (color -> "rows" -> is optional)
         // When multiple measures exist, the pie chart shows them as multiple charts
         // and if these would affect color, each small chart would have a single color.
         // => consider M = 0;
         // If C, use the members' colors of the last color attribute.
-        if(C) return this._copyColorMap(null, memberPalette[colorGems[C - 1].name]);
+        if(C) return this._copyColorMap(null, memberPalette[colorMais[C - 1].name]);
       }
     }
   });

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/View.js
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 define([
-  "../pointAbstract/View"
-], function(PointAbstractChart) {
+  "../categoricalContinuousAbstract/View"
+], function(AbstractCategoricalContinuousChart) {
 
   "use strict";
 
-  return PointAbstractChart.extend({
-    _cccClass: "StackedAreaChart"
+  return AbstractCategoricalContinuousChart.extend({
+    _options: {
+      axisOffset: 0,
+      tooltipOffset: 15
+    },
+
+    _setNullInterpolationMode: function(options, value) {
+      options.nullInterpolationMode = value;
+    }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
@@ -1,0 +1,101 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "module",
+  "../categoricalContinuousAbstract/model",
+  "pentaho/i18n!../abstract/i18n/model",
+  "../abstract/types/labelsOption",
+  "../abstract/types/shape",
+  "../abstract/mixins/settingsMultiChartType",
+  "../abstract/mixins/interpolationType"
+], function(module, categoricalContinuousAbstractFactory, bundle, labelsOptionFactory, shapeFactory,
+    settingsMultiChartType, interpolationType) {
+
+  "use strict";
+
+  return function(context) {
+
+    var CategoricalContinuousAbstract = context.get(categoricalContinuousAbstractFactory);
+
+    return CategoricalContinuousAbstract.extend({
+
+      type: {
+        sourceId: module.id,
+        id: module.id.replace(/.\w+$/, ""),
+        defaultView: "./View",
+        props: [
+          {
+            name: "rows", // VISUAL_ROLE
+            type: {
+              // Make it modal, by extending it with quantitative ability
+              levels: ["ordinal", "quantitative"],
+              instance: {
+                _getAttributesMaxLevel: function() {
+                  // If the mapping contains a single `number` attribute,
+                  // consider it ordinal, and not quantitative as the base code does.
+                  if(this.attributes.count === 1) {
+                    var model = this.model;
+                    var data;
+                    if(model && (data = model.data)) {
+                      var attrName = this.attributes.at(0).name;
+                      var attr = data.model.attributes.get(attrName);
+                      if(attr && attr.type === "number")
+                        return "ordinal";
+                    }
+                  }
+
+                  return this.base();
+                }
+              }
+            }
+          },
+          {
+            name: "columns", // VISUAL_ROLE
+            type: "pentaho/visual/role/ordinal",
+            ordinal: 6
+          },
+          {
+            name: "measures", // VISUAL_ROLE
+            type: {
+              props: {attributes: {isRequired: true}}
+            },
+            ordinal: 7
+          },
+          {
+            name: "multi", // VISUAL_ROLE
+            type: "pentaho/visual/role/ordinal",
+            ordinal: 10
+          },
+          {
+            name: "labelsOption",
+            type: {
+              base: labelsOptionFactory,
+              domain: ["none", "center", "left", "right", "top", "bottom"]
+            },
+            isRequired: true,
+            value: "none"
+          }
+        ]
+      }
+
+    })
+    .implement({type: settingsMultiChartType})
+    .implement({type: bundle.structured.settingsMultiChart})
+    .implement({type: interpolationType})
+    .implement({type: bundle.structured.interpolation})
+    .implement({type: bundle.structured.pointAbstract});
+  };
+});

--- a/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
@@ -186,11 +186,11 @@ define([
         // The color role, "rows" is required, so necessarily C > 0.
         // Also, there can be at most one measure gem, "size", so M <= 1.
         // Use member colors of all of the color attributes.
-        this._getDiscreteColorMais().forEach(function(colorMai) {
+        this._getDiscreteColorMappingAttrInfos().forEach(function(colorMAInfo) {
           // Copy map values to colorMap.
           // All color maps are joined together and there will be no
           // value collisions because the key is prefixed with the category.
-          var map = memberPalette[colorMai.name];
+          var map = memberPalette[colorMAInfo.name];
           if(map) this._copyColorMap(colorMap, map);
         }, this);
       }

--- a/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
@@ -26,7 +26,7 @@ define([
   return AbstractChart.extend({
     _cccClass: "SunburstChart",
 
-    _roleToCccDimGroup: {
+    _roleToCccRole: {
       "multi": "multiChart",
       "rows": "category",
       "size": "size"
@@ -72,22 +72,23 @@ define([
 
         options.label_visible = function(scene) {
           // Only show the size label if the size-value label also fits
-          var pvLabel = this.pvMark,
-              ir = scene.innerRadius,
-              irmin = ir,
-              or = scene.outerRadius,
-              tm = pvLabel.textMargin(),
-              a = scene.angle, // angle span
-              m = pv.Text.measure(scene.vars.size.label, pvLabel.font()),
-              twMax;
+          var pvLabel = this.pvMark;
+          var ir = scene.innerRadius;
+          var irmin = ir;
+          var or = scene.outerRadius;
+          var tm = pvLabel.textMargin();
+          var a = scene.angle; // angle span
+          var m = pv.Text.measure(scene.vars.size.label, pvLabel.font());
+          var twMax;
 
           if(a < Math.PI) {
-            var th = m.height * 0.85, // tight text bounding box
-                // The effective height of text that must be covered.
-                // one text margin, for the anchor,
-                // half text margin for the anchor's opposite side.
-                // All on only one of the sides of the wedge.
-                thEf = 2 * (th + 3 * tm / 2);
+            var th = m.height * 0.85; // tight text bounding box
+
+            // The effective height of text that must be covered.
+            // one text margin, for the anchor,
+            // half text margin for the anchor's opposite side.
+            // All on only one of the sides of the wedge.
+            var thEf = 2 * (th + 3 * tm / 2);
 
             // Minimum inner radius whose straight-arc has a length `thEf`
             irmin = Math.max(irmin, thEf / (2 * Math.tan(a / 2)));
@@ -146,8 +147,8 @@ define([
       var displayUnits = this.model.displayUnits;
       var scaleFactor = displayUnitsType.scaleFactorOf(displayUnits);
       if(scaleFactor > 1) {
-        var dims = this.options.dimensions,
-            dimSize = dims.size || (dims.size = {});
+        var dims = this.options.dimensions;
+        var dimSize = dims.size || (dims.size = {});
 
         // Values returned by the server are already divided by scaleFactor.
         // The formatting, however is that of the original value.
@@ -179,16 +180,17 @@ define([
     _getDiscreteColorMap: function() {
       // Always return a color map, even if no fixed member colors exist.
       // This leads into creating the general #_createDiscreteColorMapScaleFactory color scale.
-      var colorMap = {}, memberPalette = this._getMemberPalette();
+      var colorMap = {};
+      var memberPalette = this._getMemberPalette();
       if(memberPalette) {
         // The color role, "rows" is required, so necessarily C > 0.
         // Also, there can be at most one measure gem, "size", so M <= 1.
         // Use member colors of all of the color attributes.
-        this._getDiscreteColorGems().forEach(function(colorGem) {
+        this._getDiscreteColorMais().forEach(function(colorMai) {
           // Copy map values to colorMap.
           // All color maps are joined together and there will be no
           // value collisions because the key is prefixed with the category.
-          var map = memberPalette[colorGem.name];
+          var map = memberPalette[colorMai.name];
           if(map) this._copyColorMap(colorMap, map);
         }, this);
       }
@@ -206,7 +208,9 @@ define([
       return function scaleFactory() {
         return function(compKey) {
           if(compKey) {
-            var keys = compKey.split("~"), level = keys.length - 1, keyLevel = keys[level];
+            var keys = compKey.split("~");
+            var level = keys.length - 1;
+            var keyLevel = keys[level];
 
             // Obtain color for most specific key from color map.
             // If color map has no color and it is the 1st level,

--- a/package-res/resources/web/pentaho/visual/role/mapping.js
+++ b/package-res/resources/web/pentaho/visual/role/mapping.js
@@ -181,7 +181,7 @@ define([
          * Downgrade from quantitative to any qualitative is possible.
          * Auto Level:    quantitative->ordinal
          */
-        var levelLowest = this._getLowestLevelInAttrs();
+        var levelLowest = this._getAttributesMaxLevel();
         if(levelLowest) return this._getRoleLevelCompatibleWith(levelLowest);
       },
 
@@ -235,18 +235,21 @@ define([
       },
 
       /**
-       * Determines the lowest level of measurement of all the data properties
+       * Determines the highest level of measurement supported by all of the data properties
        * in mapping attributes.
        *
-       * When no attributes or any attribute is invalid, `undefined` is returned.
-       * The level of measurement compatibility is not considered for validity at this point.
+       * Only attributes that satisfy the visual role's supported data types should be considered.
+       *
+       * When there are no attributes or when all attributes are invalid, `undefined` is returned.
+       * The level of measurement compatibility should not be considered by this method.
        *
        * @return {string|undefined} The lowest level of measurement.
-       * @private
+       * @protected
        */
-      _getLowestLevelInAttrs: function() {
+      _getAttributesMaxLevel: function() {
         var mappingAttrs = this.attributes;
-        var data, visualModel;
+        var data;
+        var visualModel;
         var L;
         if(!(L = mappingAttrs.count) || !(visualModel = this.model) || !(data = visualModel.data))
           return;
@@ -348,12 +351,12 @@ define([
           // Must be one of the role's levels.
           if(!allRoleLevels.has(level.key)) {
             addErrors(new Error(bundle.format(
-                bundle.structured.errors.mapping.levelIsNotOneOfRoleLevels,
-                {
-                  role: this.modelProperty,
-                  level: level,
-                  roleLevels: ("'" + allRoleLevels.toArray().join("', '") + "'")
-                })));
+              bundle.structured.errors.mapping.levelIsNotOneOfRoleLevels,
+              {
+                role: this.modelProperty,
+                level: level,
+                roleLevels: ("'" + allRoleLevels.toArray().join("', '") + "'")
+              })));
             return;
           }
 
@@ -365,19 +368,19 @@ define([
         }
 
         // Data Attributes, if any, must be compatible with level.
-        var dataAttrLevel = this._getLowestLevelInAttrs();
+        var dataAttrLevel = this._getAttributesMaxLevel();
         if(dataAttrLevel) {
           var roleLevel = this._getRoleLevelCompatibleWith(dataAttrLevel, roleLevels);
           if(!roleLevel) {
             addErrors(new Error(
-                bundle.format(
-                    bundle.structured.errors.mapping.attributesLevelNotCompatibleWithRoleLevels,
-                    {
-                      role: this.modelProperty,
-                      // Try to provide a label for dataAttrLevel.
-                      dataLevel: MeasurementLevel.type.domain.get(dataAttrLevel),
-                      roleLevels: ("'" + allRoleLevels.toArray().join("', '") + "'")
-                    })));
+              bundle.format(
+                bundle.structured.errors.mapping.attributesLevelNotCompatibleWithRoleLevels,
+                {
+                  role: this.modelProperty,
+                  // Try to provide a label for dataAttrLevel.
+                  dataLevel: MeasurementLevel.type.domain.get(dataAttrLevel),
+                  roleLevels: ("'" + allRoleLevels.toArray().join("', '") + "'")
+                })));
           }
         }
       },


### PR DESCRIPTION
…ehaving unpredictably depending on column data type.

Updated CCC wrapper Line and StackedArea to support modal ordinal/quantitative X-axis visual roles
Updated Scatter and Bubble to not limiting the quantitative X and Y visual roles to the number data type, thus additionally supporting the date datatype.

Should be merged together with https://github.com/pentaho/pentaho-det/pull/305.

@pentaho/millenniumfalcon please review.