### PR TITLE
[BACKLOG-10265] Promoting `dynamicAttributes` to public and moving it…

### DIFF
--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -256,6 +256,8 @@ define([
      *     * [pentaho/type/list]{@link pentaho.type.List}
      *     * [pentaho/type/element]{@link pentaho.type.Element}
      *       * [pentaho/type/complex]{@link pentaho.type.Complex}
+     *         * [pentaho/type/application]{@link pentaho.type.Application}
+     *         * [pentaho/type/model]{@link pentaho.type.Model}
      *       * [pentaho/type/simple]{@link pentaho.type.Simple}
      *         * [pentaho/type/string]{@link pentaho.type.String}
      *         * [pentaho/type/number]{@link pentaho.type.Number}
@@ -351,7 +353,7 @@ define([
      * the instance constructors corresponding to
      * given type references.
      *
-     * The specified type references are each resolved synchonously,
+     * The specified type references are each resolved synchronously,
      * using [get]{@link pentaho.type.Context#get},
      * when the bound function is first called.
      * Thus, any resolve errors are only thrown then.

--- a/package-res/resources/web/pentaho/type/_doc/spec/IApplication.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IApplication.jsdoc
@@ -1,0 +1,26 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.IApplication` interface describes an application instance in object form.
+ *
+ * @name pentaho.type.spec.IApplication
+ *
+ * @interface
+ * @extends pentaho.type.spec.IComplex
+ *
+ * @see pentaho.type.spec.UComplex
+ */

--- a/package-res/resources/web/pentaho/type/_doc/spec/IModel.jsdoc
+++ b/package-res/resources/web/pentaho/type/_doc/spec/IModel.jsdoc
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.IModel` interface describes a model instance in object form.
+ *
+ * @name pentaho.type.spec.IModel
+ *
+ * @interface
+ * @extends pentaho.type.spec.IComplex
+ *
+ * @see pentaho.type.spec.UComplex
+ */
+
+/**
+ * Represents the relevant state and interface of the application in which a model is being used.
+ *
+ * @name application
+ * @memberOf pentaho.type.spec.IModel#
+ * @type {pentaho.type.spec.IApplication|pentaho.type.Application}
+ */

--- a/package-res/resources/web/pentaho/type/application.js
+++ b/package-res/resources/web/pentaho/type/application.js
@@ -1,0 +1,63 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "module",
+  "./complex",
+  "../i18n!types"
+], function(module, complexFactory, bundle) {
+
+  "use strict";
+
+  return function(context) {
+
+    var Complex = context.get(complexFactory);
+
+    /**
+     * @name pentaho.type.Application.Type
+     * @class
+     * @extends pentaho.type.Complex.Type
+     *
+     * @classDesc The base type class of application types.
+     *
+     * For more information see {@link pentaho.type.Application}.
+     */
+
+    /**
+     * @name pentaho.type.Application
+     * @class
+     * @extends pentaho.type.Complex
+     *
+     * @amd {pentaho.type.Factory<pentaho.type.Application>} pentaho/type/application
+     *
+     * @classDesc The base class of application types.
+     *
+     * @description Creates an application instance.
+     *
+     * @constructor
+     * @param {pentaho.type.spec.IApplication} [spec] An application specification.
+     */
+    var Application = Complex.extend(/** @lends pentaho.type.Application# */{
+      type: /** @lends pentaho.type.Application.Type# */{
+        id: module.id
+      }
+    })
+    .implement({
+      type: bundle.structured.application
+    });
+
+    return Application;
+  };
+});

--- a/package-res/resources/web/pentaho/type/complex.js
+++ b/package-res/resources/web/pentaho/type/complex.js
@@ -725,7 +725,7 @@ define([
 
           var name = propType.name;
 
-          if(omitProps && O.getOwn(omitProps, name)) return;
+          if(omitProps && omitProps[name] === true) return;
 
           var value = this._getByType(propType);
 

--- a/package-res/resources/web/pentaho/type/i18n/types.properties
+++ b/package-res/resources/web/pentaho/type/i18n/types.properties
@@ -1,4 +1,5 @@
 # TYPES properties
+
 ## INSTANCE
 instance.label=Instance
 instance.description=The most abstract thing.
@@ -35,6 +36,14 @@ object.description=An object value.
 ## FUNCTION
 function.label=Function
 function.description=A JS function value.
+
+## MODEL
+model.label=Model
+model.description=A model of an application.
+## APPLICATION
+application.label=Application
+application.description=An application.
+
 # ERROR MESSAGES
 ## REFINEMENT TYPES
 errors.refinement.domain.notSubsetOfBase=Must be a subset of the base domain.

--- a/package-res/resources/web/pentaho/type/model.js
+++ b/package-res/resources/web/pentaho/type/model.js
@@ -1,0 +1,98 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "module",
+  "./complex",
+  "../i18n!types"
+], function(module, complexFactory, bundle) {
+
+  "use strict";
+
+  return function(context) {
+
+    var Complex = context.get(complexFactory);
+
+    /**
+     * @name pentaho.type.Model.Type
+     * @class
+     * @extends pentaho.type.Complex.Type
+     *
+     * @classDesc The base type class of model types.
+     *
+     * For more information see {@link pentaho.type.Model}.
+     */
+
+    /**
+     * @name pentaho.type.Model
+     * @class
+     * @extends pentaho.type.Complex
+     *
+     * @amd {pentaho.type.Factory<pentaho.type.Model>} pentaho/type/model
+     *
+     * @classDesc The base class of model types.
+     *
+     * @description Creates a model instance.
+     *
+     * @constructor
+     * @param {pentaho.type.spec.IModel} [spec] A model specification.
+     */
+    var Model = Complex.extend(/** @lends pentaho.type.Model# */{
+
+      // region serialization
+      toSpecInContext: function(keyArgs) {
+        if(keyArgs && keyArgs.isJson) {
+          keyArgs = keyArgs ? Object.create(keyArgs) : {};
+
+          var omitProps = keyArgs.omitProps;
+          keyArgs.omitProps = omitProps = omitProps ? Object.create(omitProps) : {};
+
+          if(omitProps.application == null) omitProps.application = true;
+        }
+
+        return this.base(keyArgs);
+      },
+      // endregion
+
+      type: /** @lends pentaho.type.Model.Type# */{
+        id: module.id,
+
+        props: [
+          /**
+           * Gets or sets the application object.
+           *
+           * The application object represents the relevant state and
+           * interface of the application in which a model is being used.
+           *
+           * This property does not serialize to JSON by default.
+           *
+           * @name application
+           * @memberOf pentaho.type.Model#
+           * @type {pentaho.type.Application}
+           */
+          {
+            name: "application",
+            type: "pentaho/type/application"
+          }
+        ]
+      }
+    })
+    .implement({
+      type: bundle.structured.model
+    });
+
+    return Model;
+  };
+});

--- a/package-res/resources/web/pentaho/type/standard.js
+++ b/package-res/resources/web/pentaho/type/standard.js
@@ -28,11 +28,14 @@ define([
   "./object",
   "./function",
   "./property",
+  "./model",
+  "./application",
   "./facets/standard",
   "./filter/standard"
 ], function(instanceFactory, valueFactory, elementFactory, listFactory, refinementFactory,
     simpleFactory, complexFactory, stringFactory, numberFactory, booleanFactory,
     dateFactory, objectFactory, functionFactory, propertyFactory,
+    modelFactory, applicationFactory,
     standardFacets, standardFilters) {
 
   "use strict";
@@ -53,6 +56,8 @@ define([
     "object":   objectFactory,
     "function": functionFactory,
     "property": propertyFactory,
+    "model":    modelFactory,
+    "application": applicationFactory,
     "facets":   standardFacets,
     "filter":   standardFilters
   };

--- a/package-res/resources/web/pentaho/type/value.js
+++ b/package-res/resources/web/pentaho/type/value.js
@@ -147,7 +147,7 @@ define([
        * You can use the error utilities in {@link pentaho.type.Util} to
        * help in the implementation.
        *
-       * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
+       * @return {Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
        *
        * @see pentaho.type.Value#isValid
        */

--- a/package-res/resources/web/pentaho/visual/base/_doc/spec/IApplication.jsdoc
+++ b/package-res/resources/web/pentaho/visual/base/_doc/spec/IApplication.jsdoc
@@ -1,0 +1,26 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `spec.IApplication` interface describes a visual application instance in object form.
+ *
+ * @name pentaho.visual.base.spec.IApplication
+ *
+ * @interface
+ * @extends pentaho.type.spec.IComplex
+ *
+ * @see pentaho.type.spec.UComplex
+ */

--- a/package-res/resources/web/pentaho/visual/base/_doc/spec/IModel.jsdoc
+++ b/package-res/resources/web/pentaho/visual/base/_doc/spec/IModel.jsdoc
@@ -19,8 +19,18 @@
  *
  * @name pentaho.visual.base.spec.IModel
  * @interface
+ * @extends pentaho.type.spec.IModel
  *
  * @see pentaho.visual.base.Model
+ */
+
+/**
+ * Represents the relevant state and interface of the visual application in which a
+ * visual model is being used.
+ *
+ * @name application
+ * @memberOf pentaho.visual.base.spec.IModel#
+ * @type {pentaho.visual.base.spec.IApplication}
  */
 
 /**

--- a/package-res/resources/web/pentaho/visual/base/application.js
+++ b/package-res/resources/web/pentaho/visual/base/application.js
@@ -1,0 +1,63 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "module",
+  "pentaho/type/application",
+  "pentaho/i18n!type"
+], function(module, applicationFactory, bundle) {
+
+  "use strict";
+
+  return function(context) {
+
+    var Application = context.get(applicationFactory);
+
+    /**
+     * @name pentaho.visual.base.Application.Type
+     * @class
+     * @extends pentaho.type.Application.Type
+     *
+     * @classDesc The base type class of visual application types.
+     *
+     * For more information see {@link pentaho.visual.base.Application}.
+     */
+
+    /**
+     * @name pentaho.visual.base.Application
+     * @class
+     * @extends pentaho.type.Application
+     *
+     * @amd {pentaho.type.Factory<pentaho.visual.Application>} pentaho/visual/base/application
+     *
+     * @classDesc The base class of visual applications.
+     *
+     * @description Creates a visual application instance.
+     *
+     * @constructor
+     * @param {pentaho.visual.base.spec.IApplication} [spec] A visual application specification.
+     */
+    var VisualApplication = Application.extend(/** @lends pentaho.visual.base.Application# */{
+      type: /** @lends pentaho.visual.base.Application.Type# */{
+        id: module.id
+      }
+    })
+    .implement({
+      type: bundle.structured.application
+    });
+
+    return VisualApplication;
+  };
+});

--- a/package-res/resources/web/pentaho/visual/base/i18n/type.properties
+++ b/package-res/resources/web/pentaho/visual/base/i18n/type.properties
@@ -3,3 +3,6 @@ props.height.label=Height
 
 error.selection.invalid=Invalid selection
 error.action.notDefined=Action is not defined
+
+application.label=Visual Application
+application.description=A visual application.

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
@@ -41,6 +41,8 @@ define([
           {
             name: "rows", // VISUAL_ROLE
             type: {
+              // Always a visual key, whatever the effective measurement level.
+              isVisualKey: true,
               // Make it modal, by extending it with quantitative ability
               levels: ["ordinal", "quantitative"],
               instance: {

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
@@ -41,7 +41,7 @@ define([
           {
             name: "rows", // VISUAL_ROLE
             type: {
-              // Always a visual key, whatever the effective measurement level.
+              // Always a visual key, whatever the effective measurement level or data type.
               isVisualKey: true,
               // Make it modal, by extending it with quantitative ability
               levels: ["ordinal", "quantitative"],

--- a/package-res/resources/web/pentaho/visual/role/mapping.js
+++ b/package-res/resources/web/pentaho/visual/role/mapping.js
@@ -141,6 +141,23 @@ define([
       },
 
       /**
+       * Gets whether the visual role is considered a visual key according to the mapping's current state.
+       *
+       * @type {boolean}
+       * @readOnly
+       */
+      get isVisualKey() {
+        var value = this.type.isVisualKeyEval(this);
+        if(value == null) {
+          // By default, when there mapping is not [mapped]{@link pentaho.visual.role.Mapping#isMapped},
+          // `false` is returned.
+          var level = this.levelEffective;
+          value = !!level && !MeasurementLevel.type.isQuantitative(level);
+        }
+        return value;
+      },
+
+      /**
        * Gets the automatic measurement level.
        *
        * The automatic measurement level is determined based on the visual role's
@@ -181,8 +198,8 @@ define([
          * Downgrade from quantitative to any qualitative is possible.
          * Auto Level:    quantitative->ordinal
          */
-        var levelLowest = this._getAttributesMaxLevel();
-        if(levelLowest) return this._getRoleLevelCompatibleWith(levelLowest);
+        var attrsMaxLevel = this._getAttributesMaxLevel();
+        if(attrsMaxLevel) return this._getRoleLevelCompatibleWith(attrsMaxLevel);
       },
 
       /**
@@ -218,13 +235,13 @@ define([
        * @private
        */
       _getRoleLevelsCompatibleWith: function(attributeLevel, allRoleLevels) {
-        var isLowestQuant = MeasurementLevel.type.isQuantitative(attributeLevel);
+        var isMaxQuant = MeasurementLevel.type.isQuantitative(attributeLevel);
 
         // if attributeLevel is Quantitative, any role levels are compatible.
         // if attributeLevel is Qualitative,  **only qualitative** role levels are compatible.
 
         var roleLevels = allRoleLevels || this.type.levels.toArray();
-        if(!isLowestQuant) {
+        if(!isMaxQuant) {
           roleLevels = roleLevels.filter(function(level) {
             return !MeasurementLevel.type.isQuantitative(level);
           });
@@ -238,12 +255,16 @@ define([
        * Determines the highest level of measurement supported by all of the data properties
        * in mapping attributes.
        *
-       * Only attributes that satisfy the visual role's supported data types should be considered.
+       * Any attributes that aren't defined in the visual model's current data should be ignored.
+       * Defined attributes should be considered even if their data type is not compatible with the visual role's
+       * supported data types.
        *
        * When there are no attributes or when all attributes are invalid, `undefined` is returned.
-       * The level of measurement compatibility should not be considered by this method.
        *
-       * @return {string|undefined} The lowest level of measurement.
+       * This method should not care about whether the returned level of measurement
+       * is one of the supported visual role's measurement levels.
+       *
+       * @return {string|undefined} The highest level of measurement.
        * @protected
        */
       _getAttributesMaxLevel: function() {
@@ -258,20 +279,17 @@ define([
         // The lowest of the levels in attributes that are also supported by the visual role.
         var levelLowest;
 
-        var roleDataType = this.type.dataType;
         var dataAttrs = data.model.attributes;
         var i = -1;
-        var name, dataAttr;
+        var name;
+        var dataAttr;
         var dataAttrLevel;
-        var dataAttrType;
         while(++i < L) {
           var mappingAttr = mappingAttrs.at(i);
           if(!(name = mappingAttr.name) ||
-              !(dataAttr = dataAttrs.get(name)) ||
-              !(dataAttrLevel = dataAttr.level) ||
-              !MeasurementLevel.type.domain.get(dataAttrLevel) ||
-              !(dataAttrType = context.get(dataAttr.type).type) ||
-              !dataAttrType.isSubtypeOf(roleDataType))
+             !(dataAttr = dataAttrs.get(name)) ||
+             !(dataAttrLevel = dataAttr.level) ||
+             !MeasurementLevel.type.domain.get(dataAttrLevel))
             return; // invalid
 
           if(!levelLowest || MeasurementLevel.type.compare(dataAttrLevel, levelLowest) < 0)
@@ -336,7 +354,7 @@ define([
       },
 
       /**
-       * Validates the level attribute and that the levels of attributes are compatible with
+       * Validates the level property and that the levels of attributes are compatible with
        * the visual role's levels.
        *
        * @param {function} addErrors - Called to add errors.
@@ -387,7 +405,7 @@ define([
 
       /**
        * Validates that every mapped attribute references a defined data property in the
-       * data of the visual model and that its type is compatible with the visual role's dataType.
+       * data of the visual model and that its type is compatible with the visual role's `dataType`.
        *
        * Assumes the mapping is valid according to the base complex validation.
        *
@@ -412,26 +430,27 @@ define([
           var dataAttr = dataAttrs && dataAttrs.get(name);
           if(!dataAttr) {
             addErrors(new Error(
-                bundle.format(
-                    bundle.structured.errors.mapping.attributeIsNotDefinedInVisualModelData,
-                    {
-                      name: name,
-                      role: rolePropType
-                    })));
+              bundle.format(
+                bundle.structured.errors.mapping.attributeIsNotDefinedInVisualModelData,
+                {
+                  name: name,
+                  role: rolePropType
+                })));
             continue;
           }
 
+          // Attribute of an incompatible data type.
           var dataAttrType = context.get(dataAttr.type).type;
           if(!dataAttrType.isSubtypeOf(roleDataType)) {
             addErrors(new Error(
-                bundle.format(
-                    bundle.structured.errors.mapping.attributeDataTypeNotSubtypeOfRoleType,
-                    {
-                      name: name,
-                      dataType: dataAttrType,
-                      role: rolePropType,
-                      roleDataType: roleDataType
-                    })));
+              bundle.format(
+                bundle.structured.errors.mapping.attributeDataTypeNotSubtypeOfRoleType,
+                {
+                  name: name,
+                  dataType: dataAttrType,
+                  role: rolePropType,
+                  roleDataType: roleDataType
+                })));
           }
         }
       },
@@ -466,20 +485,20 @@ define([
             var message;
             if(isQuant) {
               message = bundle.format(
-                  bundle.structured.errors.mapping.attributeAndAggregationDuplicate,
-                  {
-                    name: dataAttr,
-                    aggregation: roleAttr.get("aggregation"),
-                    role: rolePropType
-                  });
+                bundle.structured.errors.mapping.attributeAndAggregationDuplicate,
+                {
+                  name: dataAttr,
+                  aggregation: roleAttr.get("aggregation"),
+                  role: rolePropType
+                });
 
             } else {
               message = bundle.format(
-                  bundle.structured.errors.mapping.attributeDuplicate,
-                  {
-                    name: dataAttr,
-                    role: rolePropType
-                  });
+                bundle.structured.errors.mapping.attributeDuplicate,
+                {
+                  name: dataAttr,
+                  role: rolePropType
+                });
             }
 
             addErrors(new Error(message));
@@ -740,8 +759,95 @@ define([
 
             this._dataType = newType;
           }
-        }
+        },
         // endregion
+
+        dynamicAttributes: {
+          /**
+           * Evaluates the value of the `isVisualKey` attribute on a given mapping instance of this type.
+           *
+           * This method is used by the instance-level
+           * [isVisualKey]{@link pentaho.visual.role.Mapping#isVisualKey} property and
+           * is not intended to be used directly.
+           *
+           * @name isVisualKeyEval
+           * @memberOf pentaho.visual.role.Mapping.Type#
+           * @param {pentaho.visual.role.Mapping} mapping - The mapping instance.
+           * @return {boolean} The evaluated value of the `isRequired` attribute.
+           *
+           * @ignore
+           */
+
+          /**
+           * Gets or sets a value that indicates if visual roles of this type are visual keys.
+           *
+           * ### This attribute is *Dynamic*
+           *
+           * When a _dynamic_ attribute is set to a function,
+           * it can evaluate to a different value for each mapping instance.
+           *
+           * When a _dynamic_ attribute is set to a value other than a function or a {@link Nully} value,
+           * its value is the same for every mapping instance.
+           *
+           * ### This attribute is *Monotonic*
+           *
+           * The value of a _monotonic_ attribute can change, but only in some, predetermined _monotonic_ direction.
+           *
+           * In this case, while a _visual role_'s `isVisualKey` attribute is `null`,
+           * it can later be marked as being either `true` or `false`.
+           * However, after a _visual role_'s `isVisualKey` is set or evaluates to either `true` or `false`,
+           * its value can no longer change.
+           *
+           * Because this attribute is also _dynamic_,
+           * the actual `isVisualKey` values are only known
+           * when evaluated for specific mapping instances.
+           * This behavior ensures that monotonic changes are deferred until evaluation.
+           * No errors are thrown; non-monotonic changes simply don't take effect.
+           *
+           * ### This attribute is *Inherited*
+           *
+           * When there is no _local value_, the _effective value_ of the attribute is the _inherited effective value_.
+           *
+           * The first set local value must respect the _monotonicity_ property with the inherited value.
+           *
+           * ### Other characteristics
+           *
+           * The value got by the attribute is the **last set local, value**, if any -
+           * a function, a constant value or `undefined`, when unset.
+           *
+           * When set to a {@link Nully} value, the set operation is ignored.
+           *
+           * When set and the property already has [descendant]{@link pentaho.type.Type#hasDescendants} properties,
+           * an error is thrown.
+           *
+           * The default (root) `isVisualKey` attribute value is `null`.
+           *
+           * When the result of evaluation is `null`,
+           * the ultimate `isVisualKey` value is determined
+           * by considering that [mapped]{@link pentaho.visual.role.Mapping#isMapped}
+           * mappings with a _qualitative_ effective measurement level are the visual keys.
+           *
+           * @name isVisualKey
+           * @memberOf pentaho.visual.role.Mapping.Type#
+           * @type undefined | boolean | pentaho.type.DynamicAttribute.<pentaho.visual.role.Mapping, boolean>
+           *
+           * @throws {pentaho.lang.OperationInvalidError} When setting and the type already has
+           * [descendant]{@link pentaho.type.Type#hasDescendants} types.
+           *
+           * @see pentaho.visual.role.Mapping#isVisualKey
+           */
+          isVisualKey: {
+            value: null,
+            cast:  Boolean,
+            combine: function(baseEval, localEval) {
+              return function() {
+                // localEval is skipped if base is true or false (not nully).
+                var value = baseEval.call(this);
+                return value != null ? value : localEval.call(this);
+              };
+            }
+          }
+        }
       }
     })
     .implement({type: bundle.structured.mapping});

--- a/test-js/unit/pentaho/type/application.Spec.js
+++ b/test-js/unit/pentaho/type/application.Spec.js
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/type/application",
+  "pentaho/type/Context"
+], function(applicationFactory, Context) {
+
+  "use strict";
+
+  /* global describe:true, it:true, expect:true, beforeEach:true*/
+
+  describe("pentaho.type.Application -", function() {
+
+    it("is a function", function() {
+      expect(typeof applicationFactory).toBe("function");
+    });
+
+    describe("new Application()", function() {
+      var Application;
+
+      beforeEach(function() {
+        Application = applicationFactory(new Context());
+      });
+
+      it("should be a function", function() {
+        expect(typeof Application).toBe("function");
+      });
+
+      it("should return an instance of Application", function() {
+        expect((new Application()) instanceof Application).toBe(true);
+      });
+    });
+  }); // pentaho.type.Application
+});

--- a/test-js/unit/pentaho/type/complex.serialization.Spec.js
+++ b/test-js/unit/pentaho/type/complex.serialization.Spec.js
@@ -263,7 +263,7 @@ define([
         });
 
         it("should omit a property if its name is in keyArgs.omitProps with a true value", function() {
-          var spec = value.toSpecInContext({omitProps: {type: 1}});
+          var spec = value.toSpecInContext({omitProps: {type: true}});
 
           scope.dispose();
 

--- a/test-js/unit/pentaho/type/date.Spec.js
+++ b/test-js/unit/pentaho/type/date.Spec.js
@@ -17,57 +17,57 @@ define([
   "pentaho/type/date",
   "pentaho/type/Context",
   "tests/pentaho/util/errorMatch"
-], function (dateFactory, Context, errorMatch) {
+], function(dateFactory, Context, errorMatch) {
 
   "use strict";
 
   /* global describe:true, it:true, expect:true, beforeEach:true*/
 
-  describe("pentaho.type.Date -", function () {
+  describe("pentaho.type.Date -", function() {
 
-    it("is a function", function () {
+    it("is a function", function() {
       expect(typeof dateFactory).toBe("function");
     });
 
-    describe("new Date()", function () {
+    describe("new Date()", function() {
       var PentahoDate;
 
-      beforeEach(function () {
+      beforeEach(function() {
         PentahoDate = dateFactory(new Context());
       });
 
-      it("should be a function", function () {
+      it("should be a function", function() {
         expect(typeof PentahoDate).toBe("function");
       });
 
-      it("should return an object", function () {
+      it("should return an object", function() {
         expect(typeof new PentahoDate(new Date())).toBe("object");
       });
 
-      it("should accept a javascript Date()", function () {
+      it("should accept a javascript Date()", function() {
         var today =  new Date();
         expect(new PentahoDate(today).value).toBe(today);
       });
 
-      it("should accept an ISO string", function () {
+      it("should accept an ISO string", function() {
         var testDate = new Date("1960-01-25");
         expect(new PentahoDate(testDate.toISOString()).value.toString()).toBe(testDate.toString());
       });
 
-      it("should not accept nothing", function () {
-        expect(function () {
+      it("should not accept nothing", function() {
+        expect(function() {
           var foo = new PentahoDate();
         }).toThrow(errorMatch.argRequired("value"));
       });
 
-      it("should not accept null", function () {
-        expect(function () {
+      it("should not accept null", function() {
+        expect(function() {
           var foo = new PentahoDate(null);
         }).toThrow(errorMatch.argRequired("value"));
       });
 
-      it("should not accept undefined", function () {
-        expect(function () {
+      it("should not accept undefined", function() {
+        expect(function() {
           var foo = new PentahoDate(undefined);
         }).toThrow(errorMatch.argRequired("value"));
       });
@@ -76,7 +76,7 @@ define([
     describe("#toJSON()", function() {
       var PentahoDate;
 
-      beforeEach(function () {
+      beforeEach(function() {
         PentahoDate = dateFactory(new Context());
       });
 

--- a/test-js/unit/pentaho/type/model.Spec.js
+++ b/test-js/unit/pentaho/type/model.Spec.js
@@ -1,0 +1,106 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/type/model",
+  "pentaho/type/Context"
+], function(modelFactory, Context) {
+
+  "use strict";
+
+  /* global describe:true, it:true, expect:true, beforeEach:true*/
+
+  describe("pentaho.type.Model -", function() {
+
+    it("is a function", function() {
+      expect(typeof modelFactory).toBe("function");
+    });
+
+    describe("new Model()", function() {
+      var Model;
+
+      beforeEach(function() {
+        Model = modelFactory(new Context());
+      });
+
+      it("should be a function", function() {
+        expect(typeof Model).toBe("function");
+      });
+
+      it("should return an instance of Model", function() {
+        expect((new Model()) instanceof Model).toBe(true);
+      });
+
+      it("should define a property named application of type application", function() {
+        var p = Model.type.get("application");
+        expect(p != null).toBe(true);
+        expect(p.type.id).toBe("pentaho/type/application");
+      });
+
+      it("should have a default application of null", function() {
+        var m = new Model();
+        expect(m.application).toBe(null);
+      });
+
+      it("should be valid without an application defined", function() {
+        var m = new Model();
+        expect(m.isValid).toBe(true);
+      });
+    });
+
+    describe("#toSpecInContext(keyArgs)", function() {
+
+      var Model;
+
+      beforeEach(function() {
+        Model = modelFactory(new Context());
+      });
+
+      it("should return an object", function() {
+        var model = new Model();
+        var result = model.toSpec();
+        expect(result != null).toBe(true);
+        expect(typeof result).toBe("object");
+      });
+
+      it("should contain the application serialization, by default", function() {
+        var model = new Model({application: {}});
+        expect(model.application != null).toBe(true);
+
+        var result = model.toSpec();
+        expect(result.application != null).toBe(true);
+        expect(typeof result.application).toBe("object");
+      });
+
+      it("should not contain the application serialization, when isJson is true", function() {
+        var model = new Model({application: {}});
+        expect(model.application != null).toBe(true);
+
+        var result = model.toSpec({isJson: true});
+        expect("application" in result).toBe(false);
+      });
+
+      it("should contain the application serialization, when isJson is true and omitProps specifies application with " +
+         "a value of false", function() {
+        var model = new Model({application: {}});
+        expect(model.application != null).toBe(true);
+
+        var result = model.toSpec({isJson: true, omitProps: {application: false}});
+        expect(result.application != null).toBe(true);
+        expect(typeof result.application).toBe("object");
+      });
+    });
+  }); // pentaho.type.Model
+});

--- a/test-js/unit/pentaho/type/property.Type.Spec.js
+++ b/test-js/unit/pentaho/type/property.Type.Spec.js
@@ -55,7 +55,7 @@ define([
         var typeSpec = {
           name: "a", label: "foo"
         };
-        
+
         var pType = propertyTypeUtil.createRoot(Complex.type, typeSpec);
 
         var baseType = pType.type;
@@ -566,6 +566,9 @@ define([
           }).toThrow(errorMatch.operInvalid());
         });
 
+        /* Not possible to do anymore since now, the default pre-loaded context
+           has derived complex classes with properties, and has thus already derived the
+           Property class...
         it("should not delete when set to undefined at Property.type", function() {
           // Must obtain a fresh Property such that hasDescendants is false.
           var context2 = new Context();
@@ -575,7 +578,8 @@ define([
 
           expect(Property2.type.hasOwnProperty("_value")).toBe(true);
         });
-      }); //end #value
+        */
+      }); // end #value
       // endregion
 
       // region Dynamic & Monotonic Attributes
@@ -1261,7 +1265,7 @@ define([
           var Property2 = context2.get("property")
                 .implement({
                   type: {
-                    _attrs: {
+                    dynamicAttributes: {
                       isFoo: {
                         value: false,
                         // cast: null. // <<---- no cast function

--- a/test-js/unit/pentaho/visual/role/mapping.Spec.js
+++ b/test-js/unit/pentaho/visual/role/mapping.Spec.js
@@ -540,6 +540,82 @@ define([
       });
     });
 
+    describe("#isVisualKey", function() {
+
+      function testItLocal(valueSpec, valueExpected) {
+        var ValidMapping = Mapping.extend({type: {levels: ["nominal"], isVisualKey: valueSpec}});
+
+        var model = createVisualModelWithMapping(ValidMapping);
+
+        model.data = new Table(getDataSpec1());
+
+        var mapping = model.visualRole;
+        mapping.attributes.add(["country"]);
+
+        expect(mapping.isVisualKey).toBe(valueExpected);
+      }
+
+      function testItInherited(value1Spec, value2Spec, valueExpected) {
+        var DerivedMapping1 = Mapping.extend({type: {levels: ["nominal"], isVisualKey: value1Spec}});
+        var DerivedMapping2 = DerivedMapping1.extend({type: {isVisualKey: value2Spec}});
+
+        var model = createVisualModelWithMapping(DerivedMapping2);
+
+        model.data = new Table(getDataSpec1());
+
+        var mapping = model.visualRole;
+        mapping.attributes.add(["country"]);
+
+        expect(mapping.isVisualKey).toBe(valueExpected);
+      }
+
+      it("should be false for an unmapped quantitative visual role", function() {
+        var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"]}});
+        var mapping = new DerivedMapping();
+        expect(mapping.isVisualKey).toBe(false);
+      });
+
+      it("should be false for an unmapped qualitative visual role", function() {
+        var DerivedMapping = Mapping.extend({type: {levels: ["nominal"]}});
+        var mapping = new DerivedMapping();
+        expect(mapping.isVisualKey).toBe(false);
+      });
+
+      it("should be true for a mapped qualitative visual role, when not specified in the type", function() {
+        var mapping = createFullValidQualitativeMapping();
+        expect(mapping.isVisualKey).toBe(true);
+      });
+
+      it("should be false for a mapped quantitative visual role, when not specified in the type", function() {
+        var mapping = createFullValidQuantitativeMapping();
+        expect(mapping.isVisualKey).toBe(false);
+      });
+
+      it("should evaluate to the specified, local, constant type#isVisualKey value", function() {
+        testItLocal(true, true);
+        testItLocal(false, false);
+      });
+
+      it("should evaluate to the specified, local, function type#isVisualKey value", function() {
+        testItLocal(function() { return true;  }, true);
+        testItLocal(function() { return false; }, false);
+      });
+
+      it("should inherit the type#isVisualKey value", function() {
+        testItInherited(true, null, true);
+        testItInherited(false, null, false);
+        testItInherited(function() { return true;  }, null, true);
+        testItInherited(function() { return false; }, null, false);
+      });
+
+      it("should not allow overriding a defined, inherited type#isVisualKey value", function() {
+        testItInherited(true, false, true);
+        testItInherited(false, true, false);
+        testItInherited(function() { return true;  }, false, true);
+        testItInherited(function() { return false; }, function() { return true;  }, false);
+      });
+    });
+
     describe(".Type", function() {
 
       describe("#levels", function() {
@@ -855,6 +931,98 @@ define([
           }
 
           expect(extendMapping).toThrow(errorMatch.argInvalid("dataType"));
+        });
+      });
+
+      describe("#isVisualKey", function() {
+
+        it("should have a root value of null", function() {
+          expect(Mapping.type.isVisualKey).toBe(null);
+        });
+
+        it("should be undefined by default", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"]}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(undefined);
+        });
+
+        it("should respect a specified boolean false value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: false}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(false);
+        });
+
+        it("should respect a specified boolean true value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: true}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+        });
+
+        it("should consider as true a specified truthy value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: 1}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+        });
+
+        it("should consider as false a specified falsey, non-nully value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: 0}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(false);
+        });
+
+        it("should ignore a specified null value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: null}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(undefined);
+        });
+
+        it("should ignore a specified undefined value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: undefined}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(undefined);
+        });
+
+        it("should ignore setting to an undefined value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: true}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+
+          DerivedMapping.type.isVisualKey = undefined;
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+        });
+
+        it("should ignore setting to a null value", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: true}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+
+          DerivedMapping.type.isVisualKey = null;
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+        });
+
+        it("should respect setting to the value true", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"]}});
+
+          DerivedMapping.type.isVisualKey = true;
+
+          expect(DerivedMapping.type.isVisualKey).toBe(true);
+        });
+
+        it("should respect setting to the value false", function() {
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"]}});
+
+          DerivedMapping.type.isVisualKey = false;
+
+          expect(DerivedMapping.type.isVisualKey).toBe(false);
+        });
+
+        it("should allow specifying a function", function() {
+          var fIsKey = function() { return true; };
+          var DerivedMapping = Mapping.extend({type: {levels: ["quantitative"], isVisualKey: fIsKey}});
+
+          expect(DerivedMapping.type.isVisualKey).toBe(fIsKey);
         });
       });
     });

--- a/test-js/unit/pentaho/visual/role/mapping.Spec.js
+++ b/test-js/unit/pentaho/visual/role/mapping.Spec.js
@@ -53,13 +53,14 @@ define([
     function getDataSpec1() {
       return {
         model: [
-          {name: "country", type: "string", label: "Country"},
-          {name: "product", type: "string", label: "Product"},
-          {name: "sales",   type: "number", label: "Sales"  }
+          {name: "country",   type: "string", label: "Country"},
+          {name: "product",   type: "string", label: "Product"},
+          {name: "sales",     type: "number", label: "Sales"  },
+          {name: "date",      type: "date",   label: "Date"}
         ],
         rows: [
-          {c: ["Portugal", "fish", 100]},
-          {c: ["Ireland",  "beer", 200]}
+          {c: ["Portugal", "fish", 100, "2016-01-01"]},
+          {c: ["Ireland",  "beer", 200, "2016-01-02"]}
         ]
       };
     }
@@ -586,7 +587,13 @@ define([
         expect(mapping.isVisualKey).toBe(true);
       });
 
-      it("should be false for a mapped quantitative visual role, when not specified in the type", function() {
+      it("should be true for a mapped qualitative visual role with dates, when not specified in the type", function() {
+        var mapping = createFullValidQuantitativeMapping();
+        mapping.attributes.add(["date"]);
+        expect(mapping.isVisualKey).toBe(true);
+      });
+
+      it("should be false for a number-mapped visual role, when not specified in the type", function() {
         var mapping = createFullValidQuantitativeMapping();
         expect(mapping.isVisualKey).toBe(false);
       });


### PR DESCRIPTION
… to `pentaho.type.Type`.

* Adding `isVisualKey` attribute to visual roles.
* Fix definition of PointAbstract "rows" visual role as always an `isVisualKey`.
* Added new types `pentaho.type.Application` and `pentaho.type.Model`. The `pentaho.visual.base.Model` now extends from the latter.

Merge together with https://github.com/pentaho/pentaho-det/pull/328 and https://github.com/pentaho/pentaho-det-ee/pull/191.

@pentaho/millenniumfalcon please review.