### PR TITLE
[BACKLOG-11154] Specifying the new CCC compatibility flag `discreteTi…

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
@@ -43,6 +43,7 @@ define([
   var lineStrokeStyle = "#D1D3D4";  // "#D1D3D4"; //"#A0A0A0"; // #D8D8D8",// #f0f0f0
   var extensionBlacklist = {
     "compatVersion": 1,
+    "compatFlags": 1,
     "interactive": 1,
     "isMultiValued": 1,
     "measuresIndexes": 1,
@@ -72,6 +73,9 @@ define([
   var baseOptions = {
     // Chart
     compatVersion: 2, // use CCC version 2
+    compatFlags: {
+      discreteTimeSeriesTickFormat: false
+    },
 
     margins: 0,
     paddings: 10,


### PR DESCRIPTION
…meSeriesTickFormat` to disable the discrete cartesian axis "smart" timeSeries format...

Also, blacklisted the new CCC option `compatFlags`.

@pentaho/millenniumfalcon please review.

To merge together with https://github.com/webdetails/ccc/pull/256.