### PR TITLE
[BACKLOG-10709] Moved "columns"/"Breakdown By" and "multi" visual rol…

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/barAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barAbstract/model.js
@@ -30,22 +30,9 @@ define([
       type: {
         sourceId: module.id,
         id: module.id.replace(/.\w+$/, ""),
-        isAbstract: true,
-
-        props: [
-          {
-            name: "columns", //VISUAL_ROLE
-            type: "pentaho/visual/role/ordinal",
-            ordinal: 6
-          },
-          {
-            name: "multi", //VISUAL_ROLE
-            type: "pentaho/visual/role/ordinal",
-            ordinal: 10
-          }
-        ]
+        isAbstract: true
       }
-      
+
     })
     .implement({type: settingsMultiChartType})
     .implement({type: bundle.structured["settingsMultiChart"]})

--- a/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/model.js
@@ -33,6 +33,16 @@ define([
 
         props: [
           {
+            name: "columns", //VISUAL_ROLE
+            type: "pentaho/visual/role/ordinal",
+            ordinal: 6
+          },
+          {
+            name: "multi", // VISUAL_ROLE
+            type: "pentaho/visual/role/ordinal",
+            ordinal: 10
+          },
+          {
             name: "measures", //VISUAL_ROLE
             ordinal: 7,
             type: {

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/model.js
@@ -61,21 +61,11 @@ define([
             }
           },
           {
-            name: "columns", // VISUAL_ROLE
-            type: "pentaho/visual/role/ordinal",
-            ordinal: 6
-          },
-          {
             name: "measures", // VISUAL_ROLE
             type: {
               props: {attributes: {isRequired: true}}
             },
             ordinal: 7
-          },
-          {
-            name: "multi", // VISUAL_ROLE
-            type: "pentaho/visual/role/ordinal",
-            ordinal: 10
           },
           {
             name: "labelsOption",


### PR DESCRIPTION
…es, from the "barAbstract" and "pointAbstract", to the base class "categoricalContinuousAbstract"

@pentaho/millenniumfalcon please review.