### PR TITLE
[CLEANUP] Debuggability of Client Metadata Model and VizAPI objects

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -64,7 +64,10 @@
   if(minSuffix) {
     requirePaths["common-ui/util/require-css/css"] = basePath + "/util/require-css/css" + minSuffix;
   }
-  requireMap["*"]["css" ] = "common-ui/util/require-css/css";
+  requireMap["*"]["css"] = "common-ui/util/require-css/css";
+
+  // Use the debugInfoByUrl implementation.
+  requireMap["*"]["pentaho/util/debugInfo"] = "pentaho/util/debugInfoByUrl";
 
   // DOJO
   requirePaths["dojo" ] = basePath + "/dojo/dojo";

--- a/package-res/resources/web/pentaho/GlobalContextVars.js
+++ b/package-res/resources/web/pentaho/GlobalContextVars.js
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 define([
+  "module",
   "./lang/Base",
   "./util/object",
   "./util/arg"
-], function(Base, O, arg) {
+], function(module, Base, O, arg) {
 
   "use strict";
 
   /* global SESSION_NAME:false, SESSION_LOCALE:false, active_theme:false */
 
-  return Base.extend("pentaho.GlobalContextVars", {
+  return Base.extend(module.id, {
 
     /**
      * @alias GlobalContextVars

--- a/package-res/resources/web/pentaho/lang/EventSource.js
+++ b/package-res/resources/web/pentaho/lang/EventSource.js
@@ -29,11 +29,11 @@ define([
    * @implements pentaho.lang.IEventRegistrationHandle
    * @private
    */
-  function EventRegistrationHandle(dispose) {
+  function pentaho_lang_IEventRegistrationHandle(dispose) {
     this.dispose = dispose;
   }
 
-  EventRegistrationHandle.prototype.remove = function() {
+  pentaho_lang_IEventRegistrationHandle.prototype.remove = function() {
     return this.dispose();
   };
 
@@ -119,7 +119,7 @@ define([
 
               queue[i + 1] = listenerInfo;
 
-              handles.push(new EventRegistrationHandle(removeSingleHandle.bind(this, eventType, listenerInfo)));
+              handles.push(new pentaho_lang_IEventRegistrationHandle(removeSingleHandle.bind(this, eventType, listenerInfo)));
 
               break;
             }
@@ -132,7 +132,7 @@ define([
       }
 
       if(handles.length > 1) {
-        return new EventRegistrationHandle(removeMultipleHandles.bind(this, handles));
+        return new pentaho_lang_IEventRegistrationHandle(removeMultipleHandles.bind(this, handles));
       }
 
       return null;
@@ -219,7 +219,7 @@ define([
     off: function(typeOrHandle, listener) {
       if(!typeOrHandle) throw error.argRequired("typeOrHandle");
 
-      if(typeOrHandle instanceof EventRegistrationHandle) {
+      if(typeOrHandle instanceof pentaho_lang_IEventRegistrationHandle) {
         // This is just syntax sugar, so let dispose from any source.
         typeOrHandle.dispose();
         return;

--- a/package-res/resources/web/pentaho/type/Context.js
+++ b/package-res/resources/web/pentaho/type/Context.js
@@ -59,7 +59,7 @@ define([
     _standardTypeMids[_baseFacetsMid + name] = 1;
   });
 
-  var Context = Base.extend(/** @lends pentaho.type.Context# */{
+  var Context = Base.extend(module.id, /** @lends pentaho.type.Context# */{
 
     /**
      * @alias Context

--- a/package-res/resources/web/pentaho/type/PropertyTypeCollection.js
+++ b/package-res/resources/web/pentaho/type/PropertyTypeCollection.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "./property",
   "../lang/Collection",
   "../util/arg",
   "../util/error",
   "../util/object"
-], function(propertyFactory, Collection, arg, error, O) {
+], function(module, propertyFactory, Collection, arg, error, O) {
 
   "use strict";
 
@@ -38,9 +39,7 @@ define([
    * @see pentaho.type.Property
    * @ignore
    */
-  return Collection.extend("pentaho.type.PropertyTypeCollection",
-      /** @lends pentaho.type.PropertyTypeCollection# */{
-
+  return Collection.extend(module.id, /** @lends pentaho.type.PropertyTypeCollection# */{
     /**
      * Initializes a property collection.
      *

--- a/package-res/resources/web/pentaho/type/ReferenceList.js
+++ b/package-res/resources/web/pentaho/type/ReferenceList.js
@@ -15,12 +15,13 @@
  */
 
 define([
+  "module",
   "../lang/Base"
-], function(Base) {
+], function(module, Base) {
 
   "use strict";
 
-  return Base.Array.extend("pentaho.type.ReferenceList", /** @lends pentaho.type.ReferenceList# */{
+  return Base.Array.extend(module.id, /** @lends pentaho.type.ReferenceList# */{
 
     /**
      * @alias ReferenceList

--- a/package-res/resources/web/pentaho/type/SpecificationContext.js
+++ b/package-res/resources/web/pentaho/type/SpecificationContext.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../lang/Base",
   "../util/object",
   "../util/error"
-], function(Base, O, error) {
+], function(module, Base, O, error) {
 
   "use strict";
 
@@ -55,7 +56,7 @@ define([
    * @constructor
    * @description Creates a `SpecificationContext`.
    */
-  var SpecificationContext = Base.extend(/** @lends pentaho.type.SpecificationContext# */{
+  var SpecificationContext = Base.extend(module.id, /** @lends pentaho.type.SpecificationContext# */{
 
     constructor: function() {
       /**

--- a/package-res/resources/web/pentaho/type/SpecificationScope.js
+++ b/package-res/resources/web/pentaho/type/SpecificationScope.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "./SpecificationContext",
   "../lang/Base"
-], function(SpecificationContext, Base) {
+], function(module, SpecificationContext, Base) {
 
   "use strict";
 
-  return Base.extend(/** @lends pentaho.type.SpecificationScope# */{
+  return Base.extend(module.id, /** @lends pentaho.type.SpecificationScope# */{
 
     /**
      * @alias SpecificationScope

--- a/package-res/resources/web/pentaho/type/ValidationError.js
+++ b/package-res/resources/web/pentaho/type/ValidationError.js
@@ -15,8 +15,9 @@
  */
 
 define([
+  "module",
   "../lang/UserError"
-], function(UserError) {
+], function(module, UserError) {
 
   "use strict";
 
@@ -35,7 +36,7 @@ define([
    * @param {string} message - The error message.
    */
 
-  return UserError.extend("pentaho.type.ValidationError", /** @lends pentaho.type.ValidationError# */{
+  return UserError.extend(module.id, /** @lends pentaho.type.ValidationError# */{
     /**
      * The name of the type of error.
      *

--- a/package-res/resources/web/pentaho/util/BitSet.js
+++ b/package-res/resources/web/pentaho/util/BitSet.js
@@ -1,13 +1,14 @@
 define([
+  "module",
   "pentaho/lang/Base"
-], function(Base) {
+], function(module, Base) {
 
   "use strict";
 
   // Allow ~0
   // jshint -W016
 
-  return Base.extend(/** @lends pentaho.util.BitSet# */{
+  return Base.extend(module.id, /** @lends pentaho.util.BitSet# */{
 
     /**
      * The `BitSet` class represents a set data structure that is

--- a/package-res/resources/web/pentaho/util/debug/DebugInfo.js
+++ b/package-res/resources/web/pentaho/util/debug/DebugInfo.js
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "./InformationLevels"
+], function(InformationLevels) {
+
+  "use strict";
+
+  /**
+   * The `DebugInfo` class provides access to the current debugging level for a given code context.
+   *
+   * @memberOf pentaho.util.debug
+   * @amd pentaho/util/debug/DebugInfo
+   * @class
+   * @private
+   */
+  function DebugInfo() {
+  }
+
+  DebugInfo.prototype = /** @lends pentaho.util.debug.DebugInfo# */{
+    /**
+     * The standard information levels.
+     *
+     * @type {!Class.<pentaho.util.debug.InformationLevels>}
+     * @readOnly
+     */
+    Levels: InformationLevels,
+
+    /**
+     * Gets the maximum active information level for a given AMD module.
+     *
+     * @param {!Object} module - The AMD module object, as returned by requesting the `"module"` dependency.
+     * @return {pentaho.util.debug.InformationLevels} The information level.
+     */
+    getMaxLevel: function(module) {
+      return 0; // InformationLevels.none;
+    }
+  };
+
+  return DebugInfo;
+});

--- a/package-res/resources/web/pentaho/util/debug/DebugInfoByUrl.js
+++ b/package-res/resources/web/pentaho/util/debug/DebugInfoByUrl.js
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "./DebugInfo"
+], function(DebugInfo) {
+
+  "use strict";
+
+  /**
+   * The `DebugInfoByUrl` class provides access to the current debugging level for a given code context,
+   * and reads the debugging level from the document's url.
+   *
+   * @memberOf pentaho.util.debug
+   * @amd pentaho/util/debug/DebugInfoByUrl
+   * @class
+   * @extends pentaho.util.debug.DebugInfo
+   * @private
+   */
+  function DebugInfoByUrl() {
+
+    var maxLevel = 0;
+
+    // Check URL for "debug" and "debugLevel"
+    // Because these class will probably be used as a singleton,
+    // no "caching" of urlIfHasDebug or of the used RegExps is performed.
+
+    /* global window:true */
+    if((typeof window !== "undefined") && window.location) {
+      var urlIfHasDebug = function(url) {
+        return url && (/\bdebug=true\b/).test(url) ? url : null;
+      };
+
+      var url = urlIfHasDebug(window.location.href);
+      if(!url) {
+        try {
+          url = urlIfHasDebug(window.top.location.href);
+        } catch(e) {
+          /* XSS */
+        }
+      }
+
+      if(url) {
+        var m = /\bdebugLevel=(\d+)/.exec(url);
+        maxLevel = m ? (+m[1]) : 3;
+      }
+    }
+
+    this.__maxLevel = maxLevel;
+  }
+
+  DebugInfoByUrl.prototype = Object.create(DebugInfo.prototype);
+  DebugInfoByUrl.prototype.constructor = DebugInfoByUrl;
+
+  DebugInfoByUrl.prototype.getMaxLevel = function() {
+    return this.__maxLevel;
+  };
+
+  return DebugInfoByUrl;
+});

--- a/package-res/resources/web/pentaho/util/debug/InformationLevels.js
+++ b/package-res/resources/web/pentaho/util/debug/InformationLevels.js
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(function() {
+
+  "use strict";
+
+  /**
+   * The `InformationLevels` enum is the class of names of well known _information levels_.
+   *
+   * @memberOf pentaho.util.debug
+   * @enum {number}
+   * @readonly
+   * @private
+   */
+  var InformationLevels = {
+    /**
+     * The `none` information level represents the absence of information or not wanting to receive any.
+     * @default
+     */
+    none: 0,
+
+    /**
+     * The `error` information level represents error events.
+     * @default
+     */
+    error: 1,
+
+    /**
+     * The `exception` is an alias for the [error]{@link pentaho.util.debug.InformationLevels#error} level.
+     * @default
+     */
+    exception: 1,
+
+    /**
+     * The `warn` information level represents events situations that might be a problem or not.
+     * @default
+     */
+    warn: 2,
+
+    /**
+     * The `info` information level represents general information.
+     * @default
+     */
+    info: 3,
+
+    /**
+     * The `debug` information level represents information that is relevant to **debug** an application.
+     * @default
+     */
+    debug: 4,
+
+    /**
+     * The `log` is an alias for the [debug]{@link pentaho.util.debug.InformationLevels#debug} level.
+     * @default
+     */
+    log: 4,
+
+    /**
+     * The `trace` information level represents information with the same character as
+     * the [debug]{@link pentaho.util.debug.InformationLevels#debug} level, but more detailed.
+     *
+     * @default
+     */
+    trace: 5,
+
+    /**
+     * The `all` information level represents _all_ information.
+     * @default
+     */
+    all: Infinity
+  };
+
+  return Object.freeze(InformationLevels);
+});

--- a/package-res/resources/web/pentaho/util/debug/_doc/_namespace.jsdoc
+++ b/package-res/resources/web/pentaho/util/debug/_doc/_namespace.jsdoc
@@ -15,10 +15,9 @@
  */
 
 /**
- * The `util` namespace contains a minimal set of supporting modules
- * used by other Pentaho Client Metadata Model classes.
+ * The `debug` namespace contains types for helping programs deal with
+ * various debugging information such as debugging level.
  *
- * @name pentaho.util
+ * @name pentaho.util.debug
  * @namespace
- * @private
  */

--- a/package-res/resources/web/pentaho/util/debugInfo.js
+++ b/package-res/resources/web/pentaho/util/debugInfo.js
@@ -13,12 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+define([
+  "./debug/DebugInfo"
+], function(DebugInfo) {
 
-/**
- * The `util` namespace contains a minimal set of supporting modules
- * used by other Pentaho Client Metadata Model classes.
- *
- * @name pentaho.util
- * @namespace
- * @private
- */
+  "use strict";
+
+  /**
+   * The `debugInfo` singleton provides access to the current maximum information level
+   * and other debugging information.
+   *
+   * @name debugInfo
+   * @namespace
+   * @memberOf pentaho.util
+   * @amd {pentaho.util.debug.DebugInfo} pentaho/util/debugInfo
+   * @private
+   */
+  return new DebugInfo();
+});

--- a/package-res/resources/web/pentaho/util/debugInfoByUrl.js
+++ b/package-res/resources/web/pentaho/util/debugInfoByUrl.js
@@ -13,12 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+define([
+  "./debug/DebugInfoByUrl"
+], function(DebugInfoByUrl) {
 
-/**
- * The `util` namespace contains a minimal set of supporting modules
- * used by other Pentaho Client Metadata Model classes.
- *
- * @name pentaho.util
- * @namespace
- * @private
- */
+  "use strict";
+
+  /**
+   * The `debugInfoByUrl` singleton provides access to the current maximum information level
+   * and other debugging information. The information level is initialized using url parameters.
+   *
+   * @name debugInfoByUrl
+   * @namespace
+   * @memberOf pentaho.util
+   * @amd {pentaho.util.debug.DebugInfoByUrl} pentaho/util/debugInfoByUrl
+   * @private
+   */
+  return new DebugInfoByUrl();
+});

--- a/package-res/resources/web/pentaho/visual/base/View.js
+++ b/package-res/resources/web/pentaho/visual/base/View.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Base",
   "pentaho/lang/EventSource",
   "./events/WillUpdate",
@@ -27,7 +28,7 @@ define([
   "pentaho/util/error",
   "pentaho/util/logger",
   "pentaho/util/promise"
-], function(Base, EventSource, WillUpdate, DidUpdate, RejectedUpdate, UserError,
+], function(module, Base, EventSource, WillUpdate, DidUpdate, RejectedUpdate, UserError,
             O, arg, F, BitSet, error, logger, promise) {
 
   "use strict";
@@ -39,7 +40,7 @@ define([
 
   var _reUpdateMethodName = /^_update(.+)$/;
 
-  var View = Base.extend("pentaho.visual.base.View", /** @lends pentaho.visual.base.View# */{
+  var View = Base.extend(module.id, /** @lends pentaho.visual.base.View# */{
 
     /**
      * @alias View

--- a/package-res/resources/web/pentaho/visual/base/events/DidExecute.js
+++ b/package-res/resources/web/pentaho/visual/base/events/DidExecute.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/util/error"
-], function(Event, mixinDataFilter, error) {
+], function(module, Event, mixinDataFilter, error) {
+
   "use strict";
 
   /**
@@ -37,8 +39,7 @@ define([
    * @param {?Object} value - The value of a fulfilled {@link pentaho.lang.ActionResult|ActionResult}.
    * @param {pentaho.visual.base.events.WillSelect} will - The "will:execute" event object.
    */
-  return Event.extend("pentaho.visual.base.events.DidExecute",
-    /** @lends pentaho.visual.base.events.DidExecute# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.DidExecute# */{
 
       constructor: function(source, value, will) {
         if(!will) throw error.argRequired("will");

--- a/package-res/resources/web/pentaho/visual/base/events/DidSelect.js
+++ b/package-res/resources/web/pentaho/visual/base/events/DidSelect.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/util/error"
-], function(Event, mixinDataFilter, error) {
+], function(module, Event, mixinDataFilter, error) {
+
   "use strict";
 
   /**
@@ -37,8 +39,7 @@ define([
    * @param {?Object} value - The value of a fulfilled {@link pentaho.lang.ActionResult|ActionResult}.
    * @param {pentaho.visual.base.events.WillSelect} will - The "will:select" event object.
    */
-  return Event.extend("pentaho.visual.base.events.DidSelect",
-    /** @lends pentaho.visual.base.events.DidSelect# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.DidSelect# */{
 
       constructor: function(source, value, will) {
         if(!will) throw error.argRequired("will");

--- a/package-res/resources/web/pentaho/visual/base/events/DidUpdate.js
+++ b/package-res/resources/web/pentaho/visual/base/events/DidUpdate.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event"
-], function(Event) {
+], function(module, Event) {
+
   "use strict";
 
   /**
@@ -32,8 +34,7 @@ define([
    *
    * @param {!pentaho.visual.base.View} source - The view object that is emitting the event.
    */
-  return Event.extend("pentaho.visual.base.events.DidUpdate",
-    /** @lends pentaho.visual.base.events.DidUpdate# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.DidUpdate# */{
 
       constructor: function(source) {
         this.base("did:update", source, false);

--- a/package-res/resources/web/pentaho/visual/base/events/RejectedExecute.js
+++ b/package-res/resources/web/pentaho/visual/base/events/RejectedExecute.js
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/type/mixins/mixinError",
   "pentaho/util/error"
-], function(Event, mixinDataFilter, mixinError, utilError) {
+], function(module, Event, mixinDataFilter, mixinError, utilError) {
+
   "use strict";
 
-  return Event.extend("pentaho.visual.base.events.RejectedExecute",
-    /** @lends pentaho.visual.base.events.RejectedExecute# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.RejectedExecute# */{
 
       /**
        * @alias RejectedExecute

--- a/package-res/resources/web/pentaho/visual/base/events/RejectedSelect.js
+++ b/package-res/resources/web/pentaho/visual/base/events/RejectedSelect.js
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/type/mixins/mixinError",
   "pentaho/util/error"
-], function(Event, mixinDataFilter, mixinError, utilError) {
+], function(module, Event, mixinDataFilter, mixinError, utilError) {
+
   "use strict";
 
-  return Event.extend("pentaho.visual.base.events.RejectedSelect",
-    /** @lends pentaho.visual.base.events.RejectedSelect# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.RejectedSelect# */{
 
       /**
        * @alias RejectedSelect

--- a/package-res/resources/web/pentaho/visual/base/events/RejectedUpdate.js
+++ b/package-res/resources/web/pentaho/visual/base/events/RejectedUpdate.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "pentaho/type/mixins/mixinError"
-], function(Event, mixinError) {
+], function(module, Event, mixinError) {
+
   "use strict";
 
   /**
@@ -41,8 +43,7 @@ define([
    * @param {!Error|pentaho.lang.UserError} error - The error of a rejected
    * {@link pentaho.lang.ActionResult|ActionResult}.
    */
-  return Event.extend("pentaho.visual.base.events.RejectedUpdate",
-    /** @lends pentaho.visual.base.events.RejectedUpdate# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.RejectedUpdate# */{
 
       constructor: function(source, error) {
         this.base("rejected:update", source, false);

--- a/package-res/resources/web/pentaho/visual/base/events/WillExecute.js
+++ b/package-res/resources/web/pentaho/visual/base/events/WillExecute.js
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/util/error",
   "pentaho/util/fun"
-], function(Event, mixinDataFilter, error, F) {
+], function(module, Event, mixinDataFilter, error, F) {
+
   "use strict";
 
-  return Event.extend("pentaho.visual.base.events.WillExecute",
-    /** @lends pentaho.visual.base.events.WillExecute# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.WillExecute# */{
 
       /**
        * @alias WillExecute

--- a/package-res/resources/web/pentaho/visual/base/events/WillSelect.js
+++ b/package-res/resources/web/pentaho/visual/base/events/WillSelect.js
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event",
   "../mixins/mixinDataFilter",
   "pentaho/util/error",
   "pentaho/util/fun"
-], function(Event, mixinDataFilter, error, F) {
+], function(module, Event, mixinDataFilter, error, F) {
+
   "use strict";
 
-  return Event.extend("pentaho.visual.base.events.WillSelect",
-    /** @lends pentaho.visual.base.events.WillSelect# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.WillSelect# */{
 
       /**
        * @alias WillSelect

--- a/package-res/resources/web/pentaho/visual/base/events/WillUpdate.js
+++ b/package-res/resources/web/pentaho/visual/base/events/WillUpdate.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/lang/Event"
-], function(Event) {
+], function(module, Event) {
+
   "use strict";
 
-  return Event.extend("pentaho.visual.base.events.WillUpdate", /** @lends pentaho.visual.base.events.WillUpdate# */{
+  return Event.extend(module.id, /** @lends pentaho.visual.base.events.WillUpdate# */{
     /**
      * @alias WillUpdate
      * @memberOf pentaho.visual.base.events

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 define([
+  "module",
   "pentaho/visual/base/View",
   "pentaho/visual/base/types/selectionModes",
   "cdf/lib/CCC/def",
@@ -30,7 +31,7 @@ define([
   "pentaho/data/TableView",
   "./ViewDemo",
   "pentaho/i18n!view"
-], function(View, selectionModes,
+], function(module, View, selectionModes,
             def, pvc, cdo, pv, Axis,
             util, O, logger, visualColorUtils, visualPaletteRegistry,
             measurementLevelFactory, DataView, ViewDemo, bundle) {
@@ -154,7 +155,7 @@ define([
     legend2Dot_strokeStyle: legendShapeColorProp
   };
 
-  return View.extend(/** @lends pentaho.visual.ccc.base.View# */{
+  return View.extend(module.id, /** @lends pentaho.visual.ccc.base.View# */{
 
     // region PROPERTIES
     _options: baseOptions,

--- a/package-res/resources/web/pentaho/visual/ccc/areaStacked/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/areaStacked/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../pointAbstract/View"
-], function(PointAbstractChart) {
+], function(module, PointAbstractChart) {
 
   "use strict";
 
-  return PointAbstractChart.extend({
+  return PointAbstractChart.extend(module.id, {
     _cccClass: "StackedAreaChart"
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/bar/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/bar/View.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barAbstract/View",
   "../trends"
-], function(AbstractBarChart) {
+], function(module, AbstractBarChart) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
     _supportsTrends: true
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "../categoricalContinuousAbstract/View"
-], function(def, AbstractCategoricalContinuousChart) {
+], function(module, def, AbstractCategoricalContinuousChart) {
 
   "use strict";
 
-  return AbstractCategoricalContinuousChart.extend({
+  return AbstractCategoricalContinuousChart.extend(module.id, {
 
     _cccClass: "BarChart",
 

--- a/package-res/resources/web/pentaho/visual/ccc/barHorizontal/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barHorizontal/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barAbstract/View"
-], function(AbstractBarChart) {
+], function(module, AbstractBarChart) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
     _options: {
       orientation: "horizontal"
     }

--- a/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barLine/View.js
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "../barAbstract/View",
   "../util"
-], function(def, AbstractBarChart, util) {
+], function(module, def, AbstractBarChart, util) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
 
     _roleToCccRole: {
       "columns": "series",

--- a/package-res/resources/web/pentaho/visual/ccc/barNormalized/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barNormalized/View.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barNormalizedAbstract/View"
-], function(AbstractNormalizedBarChart) {
+], function(module, AbstractNormalizedBarChart) {
 
   "use strict";
 
-  return AbstractNormalizedBarChart.extend();
+  return AbstractNormalizedBarChart.extend(module.id);
 });

--- a/package-res/resources/web/pentaho/visual/ccc/barNormalizedAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barNormalizedAbstract/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barAbstract/View"
-], function(AbstractBarChart) {
+], function(module, AbstractBarChart) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
     _options: {
       valuesNormalized: true,
       stacked: true

--- a/package-res/resources/web/pentaho/visual/ccc/barNormalizedHorizontal/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barNormalizedHorizontal/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barNormalizedAbstract/View"
-], function(AbstractNormalizedBarChart) {
+], function(module, AbstractNormalizedBarChart) {
 
   "use strict";
 
-  return AbstractNormalizedBarChart.extend({
+  return AbstractNormalizedBarChart.extend(module.id, {
     _options: {
       orientation: "horizontal"
     }

--- a/package-res/resources/web/pentaho/visual/ccc/barStacked/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barStacked/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barAbstract/View"
-], function(AbstractBarChart) {
+], function(module, AbstractBarChart) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
     _options: {
       stacked: true
     }

--- a/package-res/resources/web/pentaho/visual/ccc/barStackedHorizontal/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barStackedHorizontal/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../barAbstract/View"
-], function(AbstractBarChart) {
+], function(module, AbstractBarChart) {
 
   "use strict";
 
-  return AbstractBarChart.extend({
+  return AbstractBarChart.extend(module.id, {
     _options: {
       orientation: "horizontal",
       stacked: true

--- a/package-res/resources/web/pentaho/visual/ccc/bubble/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/bubble/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../metricDotAbstract/View"
-], function(MetricDotAbstractView) {
+], function(module, MetricDotAbstractView) {
 
   "use strict";
 
-  return MetricDotAbstractView.extend({
+  return MetricDotAbstractView.extend(module.id, {
     _options: {
       sizeAxisUseAbs:  false,
       sizeAxisRatio:   1 / 5,

--- a/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/cartesianAbstract/View.js
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "../abstract/View",
   "pentaho/i18n!../abstract/i18n/view"
-], function(def, AbstractChart, bundle) {
+], function(module, def, AbstractChart, bundle) {
 
   "use strict";
 
-  return AbstractChart.extend({
+  return AbstractChart.extend(module.id, {
     _options: {
       orientation: "vertical"
     },

--- a/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "../cartesianAbstract/View"
-], function(def, AbstractCartesianChart) {
+], function(module, def, AbstractCartesianChart) {
 
   "use strict";
 
-  return AbstractCartesianChart.extend({
+  return AbstractCartesianChart.extend(module.id, {
     _genericMeasureCccVisualRole: "value",
 
     _options: {

--- a/package-res/resources/web/pentaho/visual/ccc/donut/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/donut/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../pie/View"
-], function(PieView) {
+], function(module, PieView) {
 
   "use strict";
 
-  return PieView.extend({
+  return PieView.extend(module.id, {
     _options: {
       slice_innerRadiusEx: "60%"
     }

--- a/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "cdf/lib/CCC/cdo",
   "../cartesianAbstract/View"
-], function(def, cdo, AbstractCartesianChart) {
+], function(module, def, cdo, AbstractCartesianChart) {
 
   "use strict";
 
-  return AbstractCartesianChart.extend({
+  return AbstractCartesianChart.extend(module.id, {
     _cccClass: "HeatGridChart",
 
     _roleToCccRole: {

--- a/package-res/resources/web/pentaho/visual/ccc/line/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/line/View.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../pointAbstract/View",
   "../trends"
-], function(PointAbstractChart) {
+], function(module, PointAbstractChart) {
 
   "use strict";
 
-  return PointAbstractChart.extend({
+  return PointAbstractChart.extend(module.id, {
     _cccClass: "LineChart",
 
     _supportsTrends: true,

--- a/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/View.js
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../cartesianAbstract/View",
   "pentaho/visual/role/level",
   "../trends"
-], function(AbstractCartesianChart, levelFactory) {
+], function(module, AbstractCartesianChart, levelFactory) {
 
   "use strict";
 
-  return AbstractCartesianChart.extend({
+  return AbstractCartesianChart.extend(module.id, {
     _cccClass: "MetricDotChart",
 
     _supportsTrends: true,

--- a/package-res/resources/web/pentaho/visual/ccc/pie/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pie/View.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/def",
   "../abstract/View"
-], function(def, AbstractChart) {
+], function(module, def, AbstractChart) {
 
   "use strict";
 
-  return AbstractChart.extend({
+  return AbstractChart.extend(module.id, {
     _cccClass: "PieChart",
 
     _roleToCccRole: {

--- a/package-res/resources/web/pentaho/visual/ccc/pointAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/pointAbstract/View.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../categoricalContinuousAbstract/View"
-], function(AbstractCategoricalContinuousChart) {
+], function(module, AbstractCategoricalContinuousChart) {
 
   "use strict";
 
-  return AbstractCategoricalContinuousChart.extend({
+  return AbstractCategoricalContinuousChart.extend(module.id, {
     _options: {
       axisOffset: 0,
       tooltipOffset: 15

--- a/package-res/resources/web/pentaho/visual/ccc/scatter/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/scatter/View.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 define([
+  "module",
   "../metricDotAbstract/View"
-], function(MetricDotAbstractView) {
+], function(module, MetricDotAbstractView) {
 
   "use strict";
 
-  return MetricDotAbstractView.extend({});
+  return MetricDotAbstractView.extend(module.id);
 });

--- a/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 define([
+  "module",
   "cdf/lib/CCC/protovis",
   "cdf/lib/CCC/def",
   "../abstract/View",
   "../util",
   "pentaho/i18n!../abstract/i18n/view"
-], function(pv, def, AbstractChart, util, bundle) {
+], function(module, pv, def, AbstractChart, util, bundle) {
 
   "use strict";
 
-  return AbstractChart.extend({
+  return AbstractChart.extend(module.id, {
     _cccClass: "SunburstChart",
 
     _roleToCccRole: {


### PR DESCRIPTION
When the url contains "&debug=true&debugLevel=5" (or a higher debug level), a special **debug mode** is activated in the `pentaho/lang/Base.js` library.

This mode fills-in class names in constructors and method names in methods. Because of this,
instead of "[Object]" or "(anonymous function)" in a debugger watch window, something like "[pentaho_visual_barChart_model]" would show.

The debugging mode causes code to run slower.
When debugLevel is < 5, the code behaves exactly the same as it does today.

@pamval, @pentaho/millenniumfalcon please review.

ATTENTION: Only merge from Monday, 10/Oct/2016 onward.