### PR TITLE
[BACKLOG-11206] - Report Viewer: 'Request failed' message when inputt…

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/nls/messages.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages.properties
@@ -54,3 +54,6 @@ RowLimitSchedule=Schedule
 RowLimitExceededDialogTitle=Maximum Row Limit Exceeded
 SystemRowLimitExceededDialogMessage=The row limit you have entered is too high, and will be set to the maximum ({0}) defined by your administrator.
 RowLimitExceededDialogOKButtonLabel=OK
+
+# ParameterValidationErrorMessages
+DefaultReportParameterValidator.ParameterIsInvalidValue=This prompt value is of an invalid value

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages_de.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages_de.properties
@@ -40,3 +40,6 @@ PageControlPreviousPage_title=Vorherige Seite
 #ExpressionTree - labels for filter's operators
 AND=UND
 OR=ODER
+
+# ParameterValidationErrorMessages
+DefaultReportParameterValidator.ParameterIsInvalidValue=Dieser Eingabeaufforderungswert hat einen ung\u00fcltigen Wert

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages_fr.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages_fr.properties
@@ -40,3 +40,6 @@ PageControlPreviousPage_title=Page pr\u00e9c\u00e9dente
 #ExpressionTree - labels for filter's operators
 AND=ET
 OR=OU
+
+# ParameterValidationErrorMessages
+DefaultReportParameterValidator.ParameterIsInvalidValue=Valeur d'invite non valide.

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages_ja.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages_ja.properties
@@ -40,3 +40,6 @@ PageControlPreviousPage_title=\u524d\u30da\u30fc\u30b8
 #ExpressionTree - labels for filter's operators
 AND=AND
 OR=OR
+
+# ParameterValidationErrorMessages
+DefaultReportParameterValidator.ParameterIsInvalidValue=\u3053\u306e\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u5024\u306f\u4e0d\u6b63\u306a\u5024\u3067\u3059\u3002

--- a/package-res/resources/web/prompting/builders/TextAreaBuilder.js
+++ b/package-res/resources/web/prompting/builders/TextAreaBuilder.js
@@ -97,7 +97,7 @@ define(['./FormattedParameterWidgetBuilderBase', 'cdf/components/TextareaInputCo
           comp.getValue = function(){
             var val = $('#' + this.name).val();
             if (this.formatter) {
-              return this.transportFormatter.format(this.formatter.parse(val));
+              return this.transportFormatter.format(this.formatter.parse(val)) !== null ? this.transportFormatter.format(this.formatter.parse(val)) : val;
             } else {
               return val;
             }

--- a/package-res/resources/web/prompting/builders/TextInputBuilder.js
+++ b/package-res/resources/web/prompting/builders/TextInputBuilder.js
@@ -93,7 +93,10 @@ define(["common-ui/util/util", 'dojo/number', 'cdf/components/TextInputComponent
             var initialValue;
             $.each(this.param.values, function(i, v) {
               if (v.selected) {
-                initialValue = this.formatter ? this.formatter.format(this.transportFormatter.parse(v.value)) : v.value;
+               	initialValue = v.value;
+              	if (this.formatter) {
+              		initialValue = this.formatter.format(this.transportFormatter.parse(v.value)) !== null ? this.formatter.format(this.transportFormatter.parse(v.value)) : v.value;
+              	}
 
                 try {
                   if (isNaN(v.value) || Math.abs(v.value) == Infinity) {


### PR DESCRIPTION
[BACKLOG-11206] - Report Viewer: 'Request failed' message when inputting letters in parameter with numeric value type.

Related pull: https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/454

@tmorgner please review.
