### PR TITLE
[BACKLOG-11724] CCC wrapper - Moved CCC chart instance creation to a …

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/ViewDemo.js
@@ -126,8 +126,9 @@ define([
 
     // Temporary. Used for demo of BACKLOG-6739
     _renderCore: function() {
-      this.base();
+      var result = this.base();
       this._renderCounter++;
+      return result;
     },
 
     // Temporary. Used for demo of ...

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/view.properties
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/view.properties
@@ -6,3 +6,4 @@ tooltip.dim.interpolation.zero=(empty treated as zero)
 axis.title.multipleDimText={0}, {1}
 treemap.rootCategoryLabel=Root
 sunburst.rootCategoryLabel=Root
+error.visualElemsCountMax=This visualization cannot render more than {countMax} visual elements.

--- a/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/categoricalContinuousAbstract/View.js
@@ -67,6 +67,24 @@ define([
       this.base();
 
       this._configureAxisDisplayUnits(/* isPrimary: */true, "ortho");
+    },
+
+    _createChart: function(ChartClass, options) {
+
+      var chart = this.base(ChartClass, options);
+
+      var visualElemsCountMax = this._getVisualElementsCountMax();
+      if(visualElemsCountMax > 0) {
+        var me = this;
+        chart.override("_onWillCreatePlotPanelScene", function(plotPanel, data, axisSeriesDatas, axisCategDatas) {
+          var S = axisSeriesDatas.length;
+          var C = axisCategDatas.length;
+          var visualElemsCount = S * C;
+          me._validateVisualElementsCount(visualElemsCount, visualElemsCountMax);
+        });
+      }
+
+      return chart;
     }
   });
 });

--- a/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/heatGrid/View.js
@@ -107,6 +107,24 @@ define([
 
       options.xAxisSize = xAxisSize;
       options.yAxisSize = yAxisSize;
+    },
+
+    _createChart: function(ChartClass, options) {
+
+      var chart = this.base(ChartClass, options);
+
+      var visualElemsCountMax = this._getVisualElementsCountMax();
+      if(visualElemsCountMax > 0) {
+        var me = this;
+        chart.override("_onWillCreatePlotPanelScene", function(plotPanel, data, axisSeriesDatas, axisCategDatas) {
+          var S = axisSeriesDatas.length;
+          var C = axisCategDatas.length;
+          var visualElemsCount = S * C;
+          me._validateVisualElementsCount(visualElemsCount, visualElemsCountMax);
+        });
+      }
+
+      return chart;
     }
 
     // TODO: not true anymore...
@@ -116,6 +134,5 @@ define([
 
     // _getBaseAxisTitle: function(){
     // },
-
   });
 });


### PR DESCRIPTION
…separate method to allow per-instance override of the new `pvc.CategoricalChartAbstract#_onWillCreatePlotPanelScene`.

* Added validation of maximum number of plots' visual scenes.
* Removed ViewDemo.
* Forwarding any Chart#getLastRenderError() as `View#update` rejections.
* Removed clearing of the domContainer in ccc/abstract/View

Depends on https://github.com/webdetails/ccc/pull/262.

@pamval @pentaho/millenniumfalcon please review.