### PR TITLE
Backport of [BACKLOG-11740] - [Safari] Query limit value is not visible in the Ro…

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/RowLimitControl.css
+++ b/package-res/resources/web/dojo/pentaho/common/RowLimitControl.css
@@ -63,3 +63,7 @@
   width: 500px;
   height: 30px;
 }
+
+.dj_safari .rl_rowsNumberInput .dijitTextBoxDisabled input {
+  color: #333; /* BACKLOG-11740 */
+}


### PR DESCRIPTION
Backport of [BACKLOG-11740] - [Safari] Query limit value is not visible in the Row Limit text box.

@tmorgner please review.