### PR TITLE
[CLEANUP][FIX] Debuggability of Client Metadata Model and VizAPI object

### DIFF
--- a/package-res/resources/web/common-ui-require-js-cfg.js
+++ b/package-res/resources/web/common-ui-require-js-cfg.js
@@ -67,7 +67,7 @@
   requireMap["*"]["css"] = "common-ui/util/require-css/css";
 
   // Use the debugInfoByUrl implementation.
-  requireMap["*"]["pentaho/util/debugInfo"] = "pentaho/util/debugInfoByUrl";
+  requirePaths["pentaho/util/debugInfo"] = basePath + "/pentaho/util/debugInfoByUrl";
 
   // DOJO
   requirePaths["dojo" ] = basePath + "/dojo/dojo";


### PR DESCRIPTION
* The way the AMD re-mapping of the debugInfo module was causing problems in r.js, in Analyzer,
  even though, apparently, there’s nothing wrong with using “map” in this situation.

@pentaho/millenniumfalcon please review.