### PR TITLE
[BACKLOG-8522] Sync Analyzer layout panel with VizAPI 3.0 model

### DIFF
--- a/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/View.js
@@ -872,7 +872,7 @@ define([
         this._mappingAttrInfos.forEach(function(maInfo) {
           if(maInfo.attr) {
             var sourceIndexes = maInfo.isMeasureGeneric ? measuresSourceIndexes : categoriesSourceIndexes;
-            sourceIndexes.push(maInfo.attr.attrColIndex);
+            sourceIndexes.push(maInfo.attrColIndex);
 
             if(!maInfo.isMeasureDiscrim && !maInfo.isMeasureGeneric) {
               categoriesDimNames.push(maInfo.cccDimName);


### PR DESCRIPTION
* [FIX] Column/Bar/Line/Area/Pie/Donut charts only accept one measure field. This also happens in DET.

@pentaho/millenniumfalcon please review.