### PR TITLE
[BACKLOG-11608] Firefox: Bottom edge of Row Limit drop-down is cut in…

### DIFF
--- a/package-res/resources/web/dojo/pentaho/common/RowLimitControl.css
+++ b/package-res/resources/web/dojo/pentaho/common/RowLimitControl.css
@@ -15,7 +15,6 @@
   float: left;
   margin: 3px 5px;
   width: 9.5em;
-  height: 23px;
 }
 
 .rl_rowLimitRestrictionsSelect .dijitSelect {


### PR DESCRIPTION
… Sapphire theme

Verified this is okay for Sapphire, Onyx, and Crystal themes on windows 7 for Chrome, IE, and FireFox.

@bmorrise @wseyler 