### PR TITLE
[BACKLOG-8759] Fixed differences in property captions between v2 and …

### DIFF
--- a/package-res/resources/themes/native/globalNative.css
+++ b/package-res/resources/themes/native/globalNative.css
@@ -1182,107 +1182,19 @@ has no buttons add an addition class to your element, pentaho-dialog-buttonless,
     background: -ms-linear-gradient(top, #e0e0e0 0%, #e6e5e5 51%, #d4d4d4 100%); /* IE10+ */
     background: linear-gradient(top, #e0e0e0 0%, #e6e5e551%, #d4d4d4 100%); /* W3C */
     zoom: 1;
-
-*
-
-/
-
-border:
-
-1
-px solid
-
-rgba
-(
-255
-,
-255
-,
-255
-,
-0.59375
-)
-;
-/* */
--moz-border-radius:
-
-7
-px
-
-;
--webkit-border-radius:
-
-7
-px
-
-;
-border-radius:
-
-7
-px
-
-;
--moz-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
--webkit-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
-padding:
-
-4
-px
-
-4
-px
-
-4
-px
-
-4
-px
-
-;
-    }
+    
+    border: 1px solid rgba (255, 255, 255, 0.59375); /* */
+    
+    -moz-border-radius: 7px;
+    -webkit-border-radius: 7px;
+    border-radius: 7px;
+    
+    -moz-box-shadow: 2px 2px 6px 1px #747474;
+    -webkit-box-shadow: 2px 2px 6px 1px #747474;
+    box-shadow: 2px 2px 6px 1px #747474;
+    
+    padding: 4px 4px 4px 4px;
+}
 
 .pentaho-disclosure-panel-closed {
     width: 100%;
@@ -1304,107 +1216,19 @@ px
     background: -ms-linear-gradient(top, #e0e0e0 0%, #e6e5e5 51%, #d4d4d4 100%); /* IE10+ */
     background: linear-gradient(top, #e0e0e0 0%, #e6e5e551%, #d4d4d4 100%); /* W3C */
     zoom: 1;
-
-*
-
-/
-
-border:
-
-1
-px solid
-
-rgba
-(
-255
-,
-255
-,
-255
-,
-0.59375
-)
-;
-/* */
--moz-border-radius:
-
-7
-px
-
-;
--webkit-border-radius:
-
-7
-px
-
-;
-border-radius:
-
-7
-px
-
-;
--moz-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
--webkit-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
-box-shadow:
-
-2
-px
-
-2
-px
-
-6
-px
-
-1
-px #747474
-
-;
-padding:
-
-4
-px
-
-4
-px
-
-4
-px
-
-4
-px
-
-;
-    }
+    
+    border: 1px solid rgba(255, 255, 255, 0.59375);
+    /* */
+    -moz-border-radius: 7px;
+    -webkit-border-radius: 7px;
+    border-radius: 7px;
+    
+    -moz-box-shadow: 2px 2px 6px 1px #747474;
+    -webkit-box-shadow: 2px 2px 6px 1px #747474;
+    box-shadow: 2px 2px 6px 1px #747474;
+    
+    padding: 4px 4px 4px 4px;
+}
 
 .contrast-color {
     color: #000;

--- a/package-res/resources/web/dojo/dijit/themes/pentaho/layout/LayoutPanel.css
+++ b/package-res/resources/web/dojo/dijit/themes/pentaho/layout/LayoutPanel.css
@@ -18,6 +18,13 @@
   padding: 5px 0px 0px 2px;
 }
 
+/* begin BACKLOG-8759 ensure some blank space between the label and the icon */
+.pentahoPropertiesPanel .captionIcon {
+  margin-left: 5px;
+}
+/* end BACKLOG-8759 ensure some blank space between the label and the icon */
+
+
 .propPanel-seperator{
   border-top: 1px solid #777;
   margin: 10px 10px 4px;

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages.properties
@@ -14,9 +14,9 @@ Yes_txt=Yes
 No_txt=No
 
 FilterTextValueFromPrompt=value of Prompt {0}
-Pattern=Pattern:
-Color=Color:
-Shape=Shape:
+Pattern=Pattern
+Color=Color
+Shape=Shape
 color_by=Color By
 size_by=Size By
 x_axis=X Axis

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages_de.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages_de.properties
@@ -14,8 +14,8 @@ Yes_txt=Ja
 No_txt=Nein
 
 FilterTextValueFromPrompt=Wert der Eingabeaufforderung {0}
-Pattern=Muster:
-Color=Farbe:
+Pattern=Muster
+Color=Farbe
 Shape=Form
 color_by=Farbe nach
 size_by=Gr\u00f6\u00dfe nach

--- a/package-res/resources/web/dojo/pentaho/common/nls/messages_fr.properties
+++ b/package-res/resources/web/dojo/pentaho/common/nls/messages_fr.properties
@@ -14,9 +14,9 @@ Yes_txt=Oui
 No_txt=Non
 
 FilterTextValueFromPrompt=valeur de l'invite {0}
-Pattern=Motif\u0020:
-Color=Couleur\u0020:
-Shape=Forme\u0020:
+Pattern=Motif\u0020
+Color=Couleur\u0020
+Shape=Forme\u0020
 color_by=Couleur par
 size_by=Taille par
 x_axis=Axe X

--- a/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
+++ b/package-res/resources/web/dojo/pentaho/common/propertiesPanel/Panel.js
@@ -62,7 +62,7 @@ define([
 
   var Panel = declare("pentaho.common.propertiesPanel.Panel", [ContentPane, Evented], {
 
-    captionTemplate: "<div class='caption'><span class='caption-text'>${ui.caption:i18n}&nbsp;&nbsp;</span><i class='captionIcon'></i></div>",
+    captionTemplate: "<div class='caption'><span class='caption-text'>${ui.caption:i18n}</span><i class='captionIcon'></i></div>",
     seperatorTemplate: "<div class='propPanel-seperator'></div>",
     propUIs: null,
     groups:  null,
@@ -126,7 +126,19 @@ define([
         var cap = construct.toDom(string.substitute(this.captionTemplate, item, null,
             {
               i18n: function(value, key) {
-                return Messages.getString(value, value);
+                var s = Messages.getString(value, value);
+
+                // Since BACKLOG-8367 (Pentaho 7.1), the usage of colons has been moved to
+                // stylesheets and are thus theme-dependent.
+                // The following block ensures the captions do not contain a terminal colon :,
+                // as there could have been custom visualizations defining custom properties with
+                // captions containing a terminal colon, which could lead to the weird-looking stituation
+                // that a caption terminates with consecutive two colons.
+                if(s.length && s[s.length - 1] === ":"){
+                  return s.slice(0, -1);
+                }
+
+                return s;
               }
             }));
 

--- a/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/model.properties
+++ b/package-res/resources/web/pentaho/visual/ccc/abstract/i18n/model.properties
@@ -68,6 +68,7 @@ barLine.props.measuresLine.label=Measures - Line
 barLine.props.lineWidth.label=Line Width
 barLine.props.labelsOption.label=Column Data Labels
 barLine.props.lineLabelsOption.label=Line Data Labels
+barLine.props.shape.label=Bullet Style
 
 ## Stacked Bar Chart (Vertical)
 barStacked.label=CCC Vertical Stacked Bar Chart
@@ -256,8 +257,8 @@ labelsOption.domain.none.f=None
 labelsOption.domain.center.f=Center
 labelsOption.domain.left.f=Left
 labelsOption.domain.right.f=Right
-labelsOption.domain.top.f=Top
-labelsOption.domain.bottom.f=Bottom
+labelsOption.domain.top.f=Above
+labelsOption.domain.bottom.f=Below
 labelsOption.domain.insideEnd.f=Inside End
 labelsOption.domain.insideBase.f=Inside Base
 labelsOption.domain.outsideEnd.f=Outside End

--- a/package-res/resources/web/pentaho/visual/ccc/bar/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/bar/model.js
@@ -57,7 +57,7 @@ define([
       }
     })
     .implement({type: trendType})
-    .implement({type: bundle.structured["trendType"]})
+    .implement({type: bundle.structured["trend"]})
     .implement({type: bundle.structured["bar"]});
   };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barAbstract/View.js
@@ -43,15 +43,15 @@ define([
           options.valuesAnchor = "center";
           break;
 
-        case "inside_end":
+        case "insideEnd":
           options.valuesAnchor = options.orientation === "horizontal" ? "right" : "top";
           break;
 
-        case "inside_base":
+        case "insideBase":
           options.valuesAnchor = options.orientation === "horizontal" ? "left" : "bottom";
           break;
 
-        case "outside_end":
+        case "outsideEnd":
           if(options.orientation === "horizontal") {
             options.valuesAnchor = "right";
             options.label_textAlign = "left";

--- a/package-res/resources/web/pentaho/visual/ccc/barLine/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/barLine/model.js
@@ -42,7 +42,7 @@ define([
 
     function hasAttributesMeasures() {
       /* jshint validthis:true*/
-      return this.measuresLine.attributes.count > 0;
+      return this.measures.attributes.count > 0;
     }
 
     return BarAbstract.extend({

--- a/package-res/resources/web/pentaho/visual/ccc/line/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/line/model.js
@@ -54,7 +54,7 @@ define([
 
     })
     .implement({type: trendType})
-    .implement({type: bundle.structured.trendType})
-    .implement({type: bundle.structured.line});
+    .implement({type: bundle.structured["trend"]})
+    .implement({type: bundle.structured["line"]});
   };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/model.js
+++ b/package-res/resources/web/pentaho/visual/ccc/metricDotAbstract/model.js
@@ -116,7 +116,7 @@ define([
       .implement({type: settingsMultiChartType})
       .implement({type: bundle.structured["settingsMultiChart"]})
       .implement({type: trendType})
-      .implement({type: bundle.structured["trendType"]})
+      .implement({type: bundle.structured["trend"]})
       .implement({type: bundle.structured["metricDot"]});
   };
 });

--- a/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
+++ b/package-res/resources/web/pentaho/visual/ccc/sunburst/View.js
@@ -120,9 +120,9 @@ define([
               .text(function(scene) {
                 /* jshint laxbreak:true*/
                 var pvMainLabel = this.proto;
-                return !pvMainLabel.text()
-                    ? ""
-                    : me._formatSize(scene.vars.size, scene.firstAtoms.size.dimension);
+                if (!pvMainLabel.text()) return "";
+                var sizeCccDimName = me._getMappingAttrInfosByRole("size")[0].cccDimName;
+                return me._formatSize(scene.vars.size, scene.firstAtoms[sizeCccDimName].dimension);
               })
               .textBaseline("top");
         };


### PR DESCRIPTION
…v3 visualizations. Removed colons from the names of properties.

@pentaho/millenniumfalcon  Please review
@DFieldFL please take a look.

Please see also the companion pull requests on:
- analyzer: https://github.com/pentaho/pentaho-analyzer/pull/1304
- commons-gwt-modules: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/496

Note that `pentaho/common/propertiesPanel/Panel.js` now removes trailing colons from property captions, so that the themes' stylesheets can control the separator to be added (or not).