### PR TITLE
[SP-3167][PIR-1296]-Interactive Report Filter never loads when the search characters are Chinese or Japanese.

### DIFF
--- a/package-res/resources/web/dataapi/models-mql.js
+++ b/package-res/resources/web/dataapi/models-mql.js
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -329,7 +329,7 @@ pentaho.pda.model.mql.prototype.submit = function( jsonString, rowLimit, callbac
   try {
     // get the info about the models from the server
     var url = this.handler.METADATA_SERVICE_URL+'/doJsonQueryToCdaJson';
-    var query = 'json='+escape(jsonString)+'&rowLimit='+rowLimit;
+    var query = 'json='+encodeURIComponent(jsonString)+'&rowLimit='+rowLimit;
 
     var resultXml = pentahoGet( url, query, callback ? handleResultCallback : undefined);
     if (!callback) {


### PR DESCRIPTION
 - replace escape() to encodeURIComponent for encoding request parameters