### PR TITLE
[BACKLOG-13170]-Pass widget id to parameterChanged callback in order …

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -821,15 +821,16 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          * @param {Parameter} param
          * @param {String} name
          * @param {Object} value
+         * @param {String} widgetId - dijit widget id
          */
-        parameterChanged: function (param, name, value) {
+        parameterChanged: function (param, name, value, widgetId) {
           if (this.onParameterChanged) {
             var paramCallback = this.onParameterChanged[name] ?
                   this.onParameterChanged[name] :
                   this.onParameterChanged[''];
             if (paramCallback) {
               if (typeof paramCallback === 'function') {
-                paramCallback(name, value);
+                paramCallback(name, value, widgetId);
               } else {
                 Logger.warn("The parameterChanged callback for '" + name + "' is not a function");
               }

--- a/package-res/resources/web/prompting/WidgetBuilder.js
+++ b/package-res/resources/web/prompting/WidgetBuilder.js
@@ -120,7 +120,7 @@ define(['./builders/PromptPanelBuilder', './builders/ParameterGroupPanelBuilder'
           var widget = this._findBuilderFor(args, type).build(args);
           if (widget.parameter && widget.param) {
             widget.postChange = function () {
-              args.promptPanel.parameterChanged(this.param, this.parameter, this.getValue());
+              args.promptPanel.parameterChanged(this.param, this.parameter, this.getValue(), this.dijitId);
             }.bind(widget);
           }
           return widget;

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -339,7 +339,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         panel.parameterChanged(param, name, value);
         expect(panel.parametersChanged).toBeTruthy();
         expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
-        expect(parameterChangedSpy).toHaveBeenCalledWith(name, value);
+        expect(parameterChangedSpy).toHaveBeenCalledWith(name, value, undefined);
       });
 
       it("parameterChanged only specific callback should be called", function() {
@@ -357,7 +357,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         panel.parameterChanged(param, name, value);
         expect(panel.parametersChanged).toBeTruthy();
         expect(panel._setTimeoutRefreshPrompt).toHaveBeenCalled();
-        expect(parameterChangedSpySpecific).toHaveBeenCalledWith(name, value);
+        expect(parameterChangedSpySpecific).toHaveBeenCalledWith(name, value, undefined);
         expect(parameterChangedSpyGeneric).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
…to have access to the widget

Currently we can't access a parameter widget in a parameterChanged callback.
Need it for https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/512

