### PR TITLE
[BISERVER-13280]-Support blur and click at the same time

### DIFF
--- a/package-res/resources/web/prompting/components/SubmitPromptComponent.js
+++ b/package-res/resources/web/prompting/components/SubmitPromptComponent.js
@@ -91,6 +91,25 @@ define(['./ScopedPentahoButtonComponent', 'common-ui/jquery-clean'], function(Sc
       if (promptPanel.getAutoSubmitSetting()) {
         this.expression(/*isInit*/true);
       }
+
+
+      //BISERVER-13280
+      //A blur event on text input prevents execution of the click event if a blur and a click is a single action on UI.
+      //It can be fixed with a timeout, but we also must prevent a double exucution by clearing a timeout if the click event still occured.
+      var button = $('#' + this.htmlObject + ' button');
+      button.mousedown(function(){
+        this.submitTimeout = setTimeout( function(){
+          this.expression(true);
+          delete this.submitTimeout;
+        }.bind(this), 500);
+      }.bind(this));
+
+      button.click(function(){
+        if(this.submitTimeout){
+          clearTimeout(this.submitTimeout);
+          delete this.submitTimeout;
+        }
+      }.bind(this));
     },
 
     /**


### PR DESCRIPTION
When a user types a value into a mandatory textfield and clicks the 'View report' button, 
the blur event prevents the click event on the button from being fired, so the user is forced to click it again.
A mousedown event is not prevented though, so we can set a timeout for the click logic execution.
If no click event happens the timeout will fire a submit, if it still happens ( for examle the user just clicked the button and no mandatory prompts were involved ) then the timeout is cleared and we are safe from multiple executions.