### PR TITLE
[BACKLOG-13170]-Sync parameter definition with latest user selection

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -809,6 +809,68 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
         },
 
         /**
+         * Called to sync the parameter definition with the latest user input
+         * @param {Parameter} param
+         * @param value
+         * @private
+         */
+        _applyUserInput: function (param, value) {
+          if (!param.values || param.values.length < 1) {
+            return;
+          }
+          //Working with a list
+          if (param.values.length > 1) {
+            //Unify multivalue and singlevalue logic
+            if (!$.isArray(value)) {
+              value = [value];
+            }
+            var counter = 0;
+            for (var i in param.values) {
+              var paramVal = param.values[i];
+              if (value.indexOf(paramVal.value) > -1) {
+                if (!paramVal.selected) {
+                  paramVal.selected = true;
+                  counter++;
+                }
+              } else {
+                if (paramVal.selected) {
+                  paramVal.selected = false;
+                  counter++;
+                }
+              }
+              //Ok, we changed something, let's ask for a parameter component refresh
+              if (counter > 0) {
+                param.forceUpdate = true;
+              }
+            }
+          } else {
+            //Working with a plain parameter
+            //Already has a valid value
+            if (param.values[0].value === value) {
+              return;
+            } else {
+              //Datepickers require some extra care
+              if (param.attributes['parameter-render-type'] === 'datepicker') {
+
+                if (param.timezoneHint) {
+                  value = value + param.timezoneHint.slice(1);
+                }
+
+                //We are comparing only the date, not the time
+                if ((new Date(value).setHours(0, 0, 0, 0)) === (new Date(param.values[0].value).setHours(0, 0, 0, 0))) {
+                  //Already has a valid value
+                  return;
+                }
+
+              }
+              //Need to update the value and request a parameter component refresh
+              param.values[0].value = value;
+              param.forceUpdate = true;
+            }
+          }
+        },
+
+        /**
          * Called when a parameter value changes.
          *
          * The current implementation of  WidgetBuilder#build hooks
@@ -823,6 +885,9 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
          * @param {Object} value
          */
         parameterChanged: function (param, name, value) {
+
+          this._applyUserInput(param, value);
+
           if (this.onParameterChanged) {
             var paramCallback = this.onParameterChanged[name] ?
                   this.onParameterChanged[name] :


### PR DESCRIPTION
Hey @tmorgner 
Your idea with a transient parameter didn't worked well, datepickers chnges caused an infinite loop, lists were not updated unless we requested it by a special flag, also we needed to hide the transient value...
Nevertheless the place for the fix was defined correctly.
What we are doing here - detect if the dashboard and parameter definition are not in sync, update the latest, request a parameter component update, thats it.
Checked for various controls and datatypes, see the params.prpt in the Jira ticket.