### PR TITLE
[SP-3297][BISERVER-13522] Migrated or Imported Interactive reports do…

### DIFF
--- a/package-res/resources/web/dataapi/controller.js
+++ b/package-res/resources/web/dataapi/controller.js
@@ -70,7 +70,38 @@ pentaho.pda.app.prototype.discoverSources = function(callback, options) {
 	return sources;
 }
 
+/**
+ * This function is calling a datasource search once again,
+ * falling back to a new ID (including ".xmi" extension).
+ * 
+ * First search can return empty array, even when required datasource is here.
+ * This can happen when datasource and report created in older version of BA server
+ * are uploaded - datasource is imported using "new" rules, adding ".xmi" extension to domain ID,
+ * but report is simply uploaded to the repository and is still referencing to an old domain ID.
+ */
 pentaho.pda.app.prototype.getSources = function(callback, options) {
+    var that = this;
+    var sources = that.doGetSources(callback, options);
+
+    if (options.filter) {
+        if (!sources || (sources instanceof Array && sources.length === 0)) {
+            var filterValue = options.filter.value;
+            var filterValueSplit = filterValue.split(':');
+            if (filterValueSplit.length === 2) {
+                var domainId = filterValueSplit[0];
+                var modelId = filterValueSplit[1];
+                var filterValueNew = domainId + '.xmi:' + modelId;
+                options.filter.value = filterValueNew;
+
+                sources = that.doGetSources(callback, options);
+            }
+        }
+    }
+
+    return sources;
+}
+
+pentaho.pda.app.prototype.doGetSources = function(callback, options) {
 
 	var i,j,_sources = [], each;
   options = options || {};


### PR DESCRIPTION
… not run due to missing XMI extension

- added fallback function to cover the case when report is referencing "old" datasource"s domain ID