### PR TITLE
[BACKLOG-14317] Missing space in Heat Grid label

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/ccc/abstract/i18n/model.properties
+++ b/impl/client/src/main/javascript/web/pentaho/visual/ccc/abstract/i18n/model.properties
@@ -120,8 +120,8 @@ pie.props.measures.label=Measures
 donut.label=Donut
 donut.description=
 
-## HeatGrid
-heatGrid.label=HeatGrid
+## Heat Grid
+heatGrid.label=Heat Grid
 heatGrid.description=
 
 heatGrid.props.rows.label=X-Axis


### PR DESCRIPTION
@pentaho/millenniumfalcon please review