### PR TITLE
[BACKLOG-14836] Added support for type alias and property alias.

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/type/spec/IPropertyTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IPropertyTypeProto.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,26 @@
  * @type {!nonEmptyString | any}
  *
  * @see pentaho.type.Property.Type#name
+ */
+
+/**
+ * The alias for the name of the _property type_.
+ *
+ * The alias of a _property type_ is an alternative name for serialization purposes.
+ *
+ * ### Set
+ *
+ * This attribute can only be set when defining a new _property type_,
+ * and cannot be changed afterwards.
+ *
+ * When set to a non-{@link Nully} and non-{@link String} value,
+ * the value is first replaced by the result of calling its `toString` method.
+ *
+ * @name nameAlias
+ * @memberOf pentaho.type.spec.IPropertyTypeProto#
+ * @type {!nonEmptyString | any}
+ *
+ * @see pentaho.type.Property.Type#nameAlias
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/ITypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/ITypeProto.jsdoc
@@ -24,11 +24,30 @@
 /**
  * A reference to the type's base type, if any.
  *
+ * When the specification is used in the context of property, it defaults to `"property"`.
+ * Otherwise, when absent or `undefined`, it defaults to `"complex"`.
+ *
  * See a subtype's documentation for more information on default values.
  *
  * @name base
  * @memberOf pentaho.type.spec.ITypeProto#
  * @type {?pentaho.type.spec.UTypeReference}
+ */
+
+/**
+ * Indicates if the type is abstract.
+ *
+ * An abstract type cannot be used directly to create an instance
+ * and, as such, it is not usually exposed to users in a user interface.
+ *
+ * When not a boolean,
+ * it is taken instead to be the result of passing it to the `Boolean` function.
+ *
+ * @name isAbstract
+ * @memberOf pentaho.type.spec.ITypeProto#
+ * @type {?boolean | any}
+ * @default false
+ * @see pentaho.type.spec.ITypeProto#isBrowsable
  */
 
 /**
@@ -39,6 +58,58 @@
  * @type {pentaho.type.spec.ITypeProto}
  *
  * @see pentaho.type.spec.IInstanceProto#type
+ */
+
+/**
+ * The identifier of the type's AMD module, a _temporary identifier_, or `null`.
+ *
+ * An empty string or `undefined` value is interpreted as `null`.
+ *
+ * For serialization purposes,
+ * a **temporary identifier** can be assigned to an anonymous type.
+ * An identifier is _temporary_ if it starts with
+ * [idTemporaryPrefix]{@link pentaho.type.SpecificationContext.idTemporaryPrefix}.
+ *
+ * Temporary identifiers are ignored upon type construction.
+ *
+ * When unspecified or `null`, it defaults to [sourceId]{@link pentaho.type.spec.ITypeProto#sourceId}.
+ *
+ * @name id
+ * @memberOf pentaho.type.spec.ITypeProto#
+ * @type {?string}
+ *
+ * @see pentaho.type.SpecificationContext.isIdTemporary
+ */
+
+/**
+ * The alias for the identifier of this type.
+ *
+ * The alias of a type can only be specified when extending the ancestor type.
+ *
+ * This attribute is not inherited.
+ *
+ * When unspecified, defaults to `null`.
+ *
+ * @name alias
+ * @memberOf pentaho.type.spec.ITypeProto#
+ * @type {?nonEmptyString}
+ * @readonly
+ *
+ * @see pentaho.type.spec.ITypeProto#id
+ */
+
+/**
+ * The identifier of the value type's _source_ AMD module, or `null`.
+ *
+ * An empty string or `undefined` value is interpreted as `null`.
+ *
+ * When unspecified or `null`, it defaults to [id]{@link pentaho.type.spec.ITypeProto#id}.
+ *
+ * @name sourceId
+ * @memberOf pentaho.type.spec.ITypeProto#
+ * @type {?string}
+ *
+ * @see pentaho.type.SpecificationContext.isIdTemporary
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
@@ -33,67 +33,6 @@
  */
 
 /**
- * The identifier of the value type's AMD module, a _temporary identifier_, or `null`.
- *
- * An empty string or `undefined` value is interpreted as `null`.
- *
- * For serialization purposes,
- * a **temporary identifier** can be assigned to an anonymous type.
- * An identifier is _temporary_ if it starts with
- * [idTemporaryPrefix]{@link pentaho.type.SpecificationContext.idTemporaryPrefix}.
- *
- * Temporary identifiers are ignored upon type construction.
- *
- * When unspecified or `null`, it defaults to [sourceId]{@link pentaho.type.spec.IValueTypeProto#sourceId}.
- *
- * @name id
- * @memberOf pentaho.type.spec.IValueTypeProto#
- * @type {?string}
- *
- * @see pentaho.type.SpecificationContext.isIdTemporary
- */
-
-/**
- * The identifier of the value type's _source_ AMD module, or `null`.
- *
- * An empty string or `undefined` value is interpreted as `null`.
- *
- * When unspecified or `null`, it defaults to [id]{@link pentaho.type.spec.IValueTypeProto#id}.
- *
- * @name sourceId
- * @memberOf pentaho.type.spec.IValueTypeProto#
- * @type {?string}
- *
- * @see pentaho.type.SpecificationContext.isIdTemporary
- */
-
-/**
- * A reference to the value type's base type, if any.
- *
- * When absent or `undefined`, it defaults to `"complex"`.
- *
- * @name base
- * @memberOf pentaho.type.spec.IValueTypeProto#
- * @type {?pentaho.type.spec.UTypeReference}
- */
-
-/**
- * Indicates if the type is abstract.
- *
- * An abstract type cannot be used directly to create a value instance
- * and, as such, it is not usually exposed to users in a user interface.
- *
- * When not a boolean,
- * it is taken instead to be the result of passing it to the `Boolean` function.
- *
- * @name isAbstract
- * @memberOf pentaho.type.spec.IValueTypeProto#
- * @type {?boolean | any}
- * @default false
- * @see pentaho.type.spec.ITypeProto#isBrowsable
- */
-
-/**
  * Determines if a value of the type is **valid**.
  *
  * Although not limited to,

--- a/impl/client/src/main/javascript/web/pentaho/type/application.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/application.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ define([
      */
     var Application = Complex.extend(/** @lends pentaho.type.Application# */{
       type: /** @lends pentaho.type.Application.Type# */{
-        id: module.id
+        id: module.id,
+        alias: "application"
       }
     })
     .implement({

--- a/impl/client/src/main/javascript/web/pentaho/type/boolean.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/boolean.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ define([
 
       type: /** @lends pentaho.type.Boolean.Type# */{
         id: module.id,
+        alias: "boolean",
         cast: Boolean
       }
     }).implement(/** @lends pentaho.type.Boolean# */{

--- a/impl/client/src/main/javascript/web/pentaho/type/date.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/date.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ define([
 
       type: /** @lends pentaho.type.Date.Type# */{
         id: module.id,
+        alias: "date",
 
         cast: function(v) {
           return date.parseDateEcma262v7(v);

--- a/impl/client/src/main/javascript/web/pentaho/type/element.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/element.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ define([
       type: /** @lends pentaho.type.Element.Type# */{
 
         id: module.id,
+        alias: "element",
+        isAbstract: true,
 
         get isElement() { return true; },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/facets/DiscreteDomain.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/facets/DiscreteDomain.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,7 +259,7 @@ define([
       var domain = O.getOwn(this, "_domain");
       if(domain) {
         any = true;
-        keyArgs.includeType = false;
+        keyArgs.declaredType = this.type;
         spec.domain = domain.toSpecInContext(keyArgs);
       }
 

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/and.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/and.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ define([
 
       type: /** @lends pentaho.type.filter.And.Type# */{
         id: "pentaho/type/filter/and",
+        alias: "and",
 
         styleClass: "pentaho-type-filter-and"
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,12 +113,14 @@ define([
 
       type: /** @lends pentaho.type.filter.Not.Type# */{
         id: "pentaho/type/filter/not",
+        alias: "not",
 
         styleClass: "pentaho-type-filter-not",
 
         props: [
           {
             name: "operand",
+            nameAlias: "o",
             type: filter.Abstract,
             isRequired: true
           }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/or.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/or.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,7 @@ define([
 
       type: /** @lends pentaho.type.filter.Or.Type# */{
         id: "pentaho/type/filter/or",
+        alias: "or",
 
         styleClass: "pentaho-type-filter-or"
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,6 +193,7 @@ define([
         props: [
           {
             name: "operands",
+            nameAlias: "o",
             type: [filter.Abstract]
           }
         ]

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ define([
 
       type: /** @lends pentaho.type.filter.IsEqual.Type# */{
         id: module.id,
+        alias: "=",
 
         styleClass: "pentaho-type-filter-isEqual",
 
@@ -84,6 +85,7 @@ define([
           {
             // may be `null`
             name: "value",
+            nameAlias: "v",
             type: "value"
           }
         ]

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ define([
 
       type: /** @lends pentaho.type.filter.IsIn.Type# */{
         id: module.id,
+        alias: "isIn",
 
         styleClass: "pentaho-type-filter-isIn",
 
@@ -91,6 +92,7 @@ define([
           {
             // may be empty
             name: "values",
+            nameAlias: "v",
             type: ["element"]
           }
         ]

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 define([
   "module",
+  "../../util/object",
   "./abstract"
-], function(module, abstractFactory) {
+], function(module, O, abstractFactory) {
 
   "use strict";
 
@@ -104,6 +105,7 @@ define([
         props: [
           {
             name: "property",
+            nameAlias: "p",
             type: "string",
             isRequired: true
           }

--- a/impl/client/src/main/javascript/web/pentaho/type/function.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/function.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,7 @@ define([
 
       type: /** @lends pentaho.type.Function.Type# */{
         id: module.id,
+        alias: "function",
         cast: F.as
       }
     }).implement(/** @lends pentaho.type.Function# */{

--- a/impl/client/src/main/javascript/web/pentaho/type/instance.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/instance.js
@@ -155,7 +155,13 @@ define([
        * @param {?boolean} [keyArgs.isJson=false] Generates a JSON-compatible specification.
        * Attributes that don't have a JSON-compatible specification are omitted.
        *
-       * @param {?boolean} [keyArgs.includeType=false] Includes the inline type property, `_`, in the specification.
+       * @param {?pentaho.type.Type} [keyArgs.declaredType] The base type of this value's storage location.
+       * If the value does not have this exact type, its inline type property must be included
+       * in the specification. Otherwise, it can be omitted.
+       * When unspecified, the inline type property is only included if `forceType` is `true`.
+       *
+       * @param {?boolean} [keyArgs.forceType=false] Forces inclusion of the inline type property, `_`,
+       * in the specification.
        *
        * @return {!any} A specification of this instance.
        */
@@ -283,7 +289,7 @@ define([
       }
     });
 
-    Type._initInstCtor(Instance, {id: module.id});
+    Type._initInstCtor(Instance, {id: module.id, alias: "instance"});
 
     Type.implement(bundle.structured.instance);
 

--- a/impl/client/src/main/javascript/web/pentaho/type/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/model.js
@@ -68,6 +68,7 @@ define([
 
       type: /** @lends pentaho.type.Model.Type# */{
         id: module.id,
+        alias: "model",
 
         props: [
           /**

--- a/impl/client/src/main/javascript/web/pentaho/type/number.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/number.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ define([
 
       type: /** @lends pentaho.type.Number.Type# */{
         id: module.id,
+        alias: "number",
         cast: toNumber
       }
     }).implement(/** @lends pentaho.type.Number# */{

--- a/impl/client/src/main/javascript/web/pentaho/type/object.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/object.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ define([
 
       type: /** @lends pentaho.type.Object.Type# */{
         id:   module.id,
+        alias: "object",
         cast: Object
       }
     }).implement(/** @lends pentaho.type.Object# */{

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -81,6 +81,7 @@ define([
         // and not on Property.Type itself.
 
         id: module.id,
+        alias: "property",
 
         isAbstract: true,
 
@@ -279,6 +280,46 @@ define([
           }
         },
         // endregion
+
+        // region alias attribute
+        _nameAlias: undefined,
+
+        /**
+         * Gets or sets the alias for the name of the _property type_.
+         *
+         * The alias for the name of a _property type_ is an alternative identifier for serialization purposes.
+         *
+         * ### Set
+         *
+         * This attribute can only be set when defining a new _property type_,
+         * and cannot be changed afterwards.
+         *
+         * When set to a non-{@link Nully} and non-{@link String} value,
+         * the value is first replaced by the result of calling its `toString` method.
+         *
+         * @type {!nonEmptyString}
+         *
+         * @throws {TypeError} When attempting to set a value and the property is not a root property.
+         * @throws {pentaho.lang.ArgumentRequiredError} When set to an empty string or a _nully_ value.
+         * @throws {TypeError} When set to a value different from the current one.
+         *
+         * @see pentaho.type.spec.IPropertyTypeProto#nameAlias
+         */
+        get nameAlias() {
+          return this._nameAlias;
+        },
+
+        set nameAlias(value) {
+          if(!this.isRoot)
+            throw new TypeError("The 'nameAlias' attribute can only be assigned to a root property.");
+
+          value = nonEmptyString(value);
+
+          if(!value) throw error.argRequired("nameAlias");
+
+          // Cannot change, or throws.
+          O.setConst(this, "_nameAlias", value);
+        }, // endregion
 
         // region list attribute
         /**
@@ -691,9 +732,7 @@ define([
             if(defaultValue !== undefined) {
               any = true;
               if(defaultValue) {
-                var valueType = this.type;
-                keyArgs.includeType = defaultValue.type !== (valueType.isRefinement ? valueType.of : valueType);
-
+                keyArgs.declaredType = this.type;
                 spec.value = defaultValue.toSpecInContext(keyArgs);
               } else {
                 spec.value = null;

--- a/impl/client/src/main/javascript/web/pentaho/type/refinement.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/refinement.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,6 +289,7 @@ define([
         },
 
         id: module.id,
+        alias: "refinement",
 
         // region facets property
         _facets: [],

--- a/impl/client/src/main/javascript/web/pentaho/type/string.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/string.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ define([
 
       type: {
         id: module.id,
+        alias: "string",
         cast: String
       }
     }).implement({

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,13 @@ define([
        * @param {?boolean} [keyArgs.isJson=false] - Generates a JSON-compatible specification.
        * Attributes which don't have a JSON-compatible specification are omitted.
        *
-       * @param {?boolean} [keyArgs.includeType=false] Includes the inline type property, `_`, in the specification.
+       * @param {?pentaho.type.Type} [keyArgs.declaredType] The base type of this value's storage location.
+       * If the value does not have this exact type, its inline type property must be included
+       * in the specification. Otherwise, it can be omitted.
+       * When unspecified, the inline type property is only included if `forceType` is `true`.
+       *
+       * @param {?boolean} [keyArgs.forceType=false] Forces inclusion of the inline type property, `_`,
+       * in the specification.
        *
        * @param {boolean} [keyArgs.omitFormatted=false] Omits the formatted value
        * on [Simple]{@link pentaho.type.Simple} values' specifications.
@@ -255,6 +261,7 @@ define([
        */
       type: /** @lends pentaho.type.Value.Type# */{
         id: module.id,
+        alias: "value",
         isAbstract: true,
 
         get isValue() { return true; },
@@ -359,7 +366,8 @@ define([
           if(!keyArgs) keyArgs = {};
 
           // The type's id or the temporary id in this scope.
-          var spec = {id: this.shortId || SpecificationContext.current.add(this)};
+          var id = keyArgs && keyArgs.noAlias ? this.id : this.shortId;
+          var spec = {id: id || SpecificationContext.current.add(this)};
 
           // The base type in the **current type hierarchy** (root, ancestor, isRoot).
           var baseType = Object.getPrototypeOf(this);

--- a/impl/client/src/test/javascript/pentaho/type/Context.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/Context.spec.js
@@ -284,15 +284,36 @@ define([
             });
         });
 
-        it("should be able to get a standard type given its relative id", function() {
+        describe("should be able to get a standard type given its alias", function () {
 
-          return testGet(function(sync, Context) {
-            var context = new Context();
-            var promise = callGet(context, sync, "string");
+          var aliasMap = {
+            "=": "pentaho/type/filter/isEqual",
+            "and": "pentaho/type/filter/and",
+            "or": "pentaho/type/filter/or"
+          };
 
-            return promise.then(function(InstCtor) {
-              expect(InstCtor.type.id).toBe("pentaho/type/string");
-            });
+          Object.keys(standard).forEach(function (standardType) {
+            switch (standardType) {
+              case "facets":
+              case "filter":
+                return;
+            }
+            aliasMap[standardType] = "pentaho/type/" + standardType;
+          });
+
+          Object.keys(aliasMap).forEach(function (alias) {
+
+            it("for the alias '" + alias + "'", function () {
+
+              return testGet(function (sync, Context) {
+                var context = new Context();
+                var promise = callGet(context, sync, alias);
+
+                return promise.then(function (InstCtor) {
+                  expect(InstCtor.type.id).toBe(aliasMap[alias]);
+                });
+              });
+            })
           });
         });
 

--- a/impl/client/src/test/javascript/pentaho/type/_type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/_type.serialization.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,20 @@ define([
         expect(keyArgs2.bar).toBe(keyArgs.bar);
       });
 
-      it("should return a specification object having the shortId of the type", function() {
+      it("should return a specification object having the alias of the type", function() {
+        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+
+        var scope = new SpecificationScope();
+
+        var spec = derivedType.toSpecInContext();
+
+        scope.dispose();
+
+        expect(spec instanceof Object).toBe(true);
+        expect(spec.id).toBe(derivedType.alias);
+      });
+
+      it("should return a specification object having the id of the type, if no alias is defined", function() {
         var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
 
         var scope = new SpecificationScope();
@@ -143,7 +156,7 @@ define([
         scope.dispose();
 
         expect(spec instanceof Object).toBe(true);
-        expect(spec.id).toBe("test");
+        expect(spec.id).toBe(derivedType.id);
       });
     });
 
@@ -241,12 +254,20 @@ define([
 
     describe("#toRef(keyArgs)", function() {
 
-      it("should return the #shortId of the type when it has an id", function() {
+      it("should return the #id of the type when it has an id and no alias", function() {
         var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
 
         var typeRef = derivedType.toRef();
 
-        expect(typeRef).toBe("test");
+        expect(typeRef).toBe(derivedType.id);
+      });
+
+      it("should return the #alias of the type when it has an id and an alias", function() {
+        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+
+        var typeRef = derivedType.toRef();
+
+        expect(typeRef).toBe(derivedType.alias);
       });
 
       it("should call #toRefInContext when the type is anonymous", function() {
@@ -332,7 +353,7 @@ define([
 
     describe("#toRefInContext(keyArgs)", function() {
 
-      it("should return the #shortId of the type when it has an id", function() {
+      it("should return the #id of the type when it has an id and no alias", function() {
         var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
 
         var scope = new SpecificationScope();
@@ -341,7 +362,19 @@ define([
 
         scope.dispose();
 
-        expect(typeRef).toBe("test");
+        expect(typeRef).toBe(derivedType.id);
+      });
+
+      it("should return the #alias of the type when it has an id and an alias", function() {
+        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+
+        var scope = new SpecificationScope();
+
+        var typeRef = derivedType.toRefInContext();
+
+        scope.dispose();
+
+        expect(typeRef).toBe(derivedType.alias);
       });
 
       it("should return a spec with an anonymous #id when the type is anonymous; the first occurrence", function() {

--- a/impl/client/src/test/javascript/pentaho/type/_type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/_type.spec.js
@@ -242,6 +242,23 @@ define([
       });
     });
 
+    describe("#alias", function() {
+
+      it("cannot be assigned to an anonymous type", function() {
+        expect(function() {
+          var Derived = Instance.extend({type: {label: "Foo", alias: "bar"}});
+        }).toThrow(errorMatch.argInvalid("alias", "Anonymous types cannot have an alias"));
+      });
+
+      it("is read only", function() {
+        expect(function() {
+          var Derived = Instance.extend({type: {label: "Foo", id: "type/bar", alias: "bar"}});
+          Derived.type.alias = "mux";
+        }).toThrowError(TypeError);
+      });
+
+    }); // #alias
+
     describe("#shortId -", function() {
 
       it("should be `null` when id is `null`", function() {
@@ -249,21 +266,16 @@ define([
         expect(Derived.type.shortId).toBe(null);
       });
 
-      it("should be equal to #id when it is not a standard, single-level id", function() {
+      it("should be equal to #id when no alias is defined", function() {
         var Derived = Instance.extend({type: {id: "my/foo"}});
         expect(Derived.type.shortId).toBe(Derived.type.id);
       });
 
-      it("should be equal to the last sub-module of #id when it is of a standard, single-level id", function() {
-        var Derived = Instance.extend({type: {id: "pentaho/type/foo"}});
-        expect(Derived.type.shortId).toBe("foo");
-        expect(Derived.type.id).not.toBe("foo");
+      it("should be equal to #alias when the alias is defined", function() {
+        var Derived = Instance.extend({type: {id: "my/foo", alias: "foo"}});
+        expect(Derived.type.shortId).toBe(Derived.type.alias);
       });
 
-      it("should be equal to #id when it is of a standard, multiple-level id", function() {
-        var Derived = Instance.extend({type: {id: "pentaho/type/foo/bar"}});
-        expect(Derived.type.shortId).toBe(Derived.type.id);
-      });
     }); // #shortId
 
     describe("#defaultView -", function() {
@@ -1166,49 +1178,49 @@ define([
     }); // #hasDescendants
 
     describe("#isList", function() {
-      it("should have default `isList` equal to `false`", function () {
+      it("should have default `isList` equal to `false`", function() {
         expect(Instance.type.isList).toBe(false);
       });
     });
 
     describe("#isRefinement", function() {
-      it("should have default `isRefinement` equal to `false`", function () {
+      it("should have default `isRefinement` equal to `false`", function() {
         expect(Instance.type.isRefinement).toBe(false);
       });
     });
 
     describe("#isValue", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isValue).toBe(false);
       });
     });
 
     describe("#isProperty", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isProperty).toBe(false);
       });
     });
 
     describe("#isElement", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isElement).toBe(false);
       });
     });
 
     describe("#isComplex", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isComplex).toBe(false);
       });
     });
 
     describe("#isSimple", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isSimple).toBe(false);
       });
     });
 
     describe("#isContainer", function() {
-      it("should have default `false`", function () {
+      it("should have default `false`", function() {
         expect(Instance.type.isContainer).toBe(false);
       });
     });

--- a/impl/client/src/test/javascript/pentaho/type/boolean.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/boolean.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ define([
       });
 
       it("should accept '1' as true", function() {
-        expect(new PentahoBoolean('1').value).toBe(true);
+        expect(new PentahoBoolean("1").value).toBe(true);
       });
 
       it("should accept 0 as false", function() {
@@ -56,7 +56,7 @@ define([
       });
 
       it("should accept '0' as true", function() {
-        expect(new PentahoBoolean('0').value).toBe(true);
+        expect(new PentahoBoolean("0").value).toBe(true);
       });
 
       it("should accept true as true", function() {
@@ -68,7 +68,7 @@ define([
       });
 
       it("should accept 'false' as true", function() {
-        expect(new PentahoBoolean('false').value).toBe(true);
+        expect(new PentahoBoolean("false").value).toBe(true);
       });
 
       it("should accept new Date() as true", function() {
@@ -76,11 +76,11 @@ define([
       });
 
       it("should accept empty string as false", function() {
-        expect(new PentahoBoolean('').value).toBe(false);
+        expect(new PentahoBoolean("").value).toBe(false);
       });
 
       it("should accept some random string as true", function() {
-        expect(new PentahoBoolean('someRandom string').value).toBe(true);
+        expect(new PentahoBoolean("someRandom string").value).toBe(true);
       });
 
       it("should not accept null", function() {

--- a/impl/client/src/test/javascript/pentaho/type/complex.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.serialization.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,71 +109,298 @@ define([
         scope = new SpecificationScope();
       });
 
-      describe("when keyArgs.includeType", function() {
+      describe("when keyArgs.declaredType", function() {
 
         describe("= unspecified", function() {
-          it("should default to false", function() {
-            var spec = value.toSpecInContext();
 
-            scope.dispose();
+          describe("when keyArgs.forceType", function() {
 
-            expect(spec.constructor).toBe(Object);
-            expect("_" in spec).toBe(false);
+            describe("= unspecified", function() {
+
+              it("should not include", function() {
+                var spec = value.toSpecInContext();
+
+                scope.dispose();
+
+                expect(spec.constructor).toBe(Object);
+                expect("_" in spec).toBe(false);
+              });
+            });
+
+            describe("= false", function() {
+
+              it("should not include", function() {
+                var spec = value.toSpecInContext();
+
+                scope.dispose();
+
+                expect(spec.constructor).toBe(Object);
+                expect("_" in spec).toBe(false);
+              });
+            });
+
+            describe("= true", function() {
+
+              it("should include", function() {
+                var spec = value.toSpecInContext({forceType: true});
+
+                scope.dispose();
+
+                expect(spec.constructor).toBe(Object);
+                expect("_" in spec).toBe(true);
+              });
+            });
+
           });
         });
 
-        describe("= false", function() {
+        describe("= value.type", function() {
 
-          describe("when keyArgs.preferPropertyArray: false", function() {
+          describe("when keyArgs.forceType", function() {
 
-            it("should return a plain Object", function() {
-              var spec = value.toSpecInContext({includeType: false, preferPropertyArray: false});
+            describe("= unspecified", function() {
 
-              scope.dispose();
+              describe("when keyArgs.preferPropertyArray: false", function() {
 
-              expect(spec.constructor).toBe(Object);
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should not include the type", function() {
+                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(false);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return an Array", function() {
+                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect(Array.isArray(spec)).toBe(true);
+                });
+              });
             });
 
-          });
+            describe("= false", function() {
 
-          describe("when keyArgs.preferPropertyArray: true", function() {
+              describe("when keyArgs.preferPropertyArray: false", function() {
 
-            it("should return an Array", function() {
-              var spec = value.toSpecInContext({includeType: false, preferPropertyArray: true});
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: false});
 
-              scope.dispose();
+                  scope.dispose();
 
-              expect(Array.isArray(spec)).toBe(true);
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should not include the type", function() {
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(false);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return an Array", function() {
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect(Array.isArray(spec)).toBe(true);
+                });
+              });
             });
 
-          });
+            describe("= true", function() {
 
+              describe("when keyArgs.preferPropertyArray: false", function() {
+
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+            });
+          });
         });
 
-        describe("= true", function() {
+        describe("= ascendant.type", function() {
 
-          describe("when keyArgs.preferPropertyArray: false", function() {
+          describe("when keyArgs.forceType", function() {
 
-            it("should return a plain Object", function() {
-              var spec = value.toSpecInContext({includeType: true, preferPropertyArray: false});
+            describe("= unspecified", function() {
 
-              scope.dispose();
+              describe("when keyArgs.preferPropertyArray: false", function() {
 
-              expect(spec.constructor).toBe(Object);
+                it("should return a plain Object", function() {
+
+                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+
+                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return a plain Object", function() {
+
+                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+
+                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
             });
 
-          });
+            describe("= false", function() {
 
-          describe("when keyArgs.preferPropertyArray: true", function() {
+              describe("when keyArgs.preferPropertyArray: false", function() {
 
-            it("should return a plain Object", function() {
-              var spec = value.toSpecInContext({includeType: true, preferPropertyArray: true});
+                it("should return a plain Object", function() {
 
-              scope.dispose();
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
 
-              expect(spec.constructor).toBe(Object);
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return a plain Object", function() {
+
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should not include the type", function() {
+
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
             });
 
+            describe("= true", function() {
+
+              describe("when keyArgs.preferPropertyArray: false", function() {
+
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: false});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+
+              describe("when keyArgs.preferPropertyArray: true", function() {
+
+                it("should return a plain Object", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect(spec.constructor).toBe(Object);
+                });
+
+                it("should include the type", function() {
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: true});
+
+                  scope.dispose();
+
+                  expect("_" in spec).toBe(true);
+                });
+              });
+            });
           });
         });
       });
@@ -183,7 +410,6 @@ define([
         it("should pass-through all options of `keyArgs`", function() {
           var keyArgs = {
             includeDefaults: true,
-            includeType: false,
             foo:  {},
             bar:  {},
             dudu: {}
@@ -214,52 +440,28 @@ define([
           Derived.type.each(function(pType) { expectProperty(pType.name); });
         });
 
-        it("should pass keyArgs.includeType: true when the value is not of the same type of the property", function() {
-          var includeType;
+        it("should pass keyArgs.declaredType with the propertyType's value type", function() {
+          var declaredType;
 
           function expectProperty(name) {
             var v = value.get(name);
             if(v) {
               expect(v.toSpecInContext.calls.count()).toBe(1);
 
-              expect(includeType).toBe(true);
+              expect(declaredType).toBe(TestLevel1.type);
             }
           }
 
           spyProperty("anything", function(keyArgs) {
-            includeType = keyArgs.includeType;
+            declaredType = keyArgs.declaredType;
             return {};
           });
 
-          value.toSpecInContext({includeType: false});
+          value.toSpecInContext({});
 
           scope.dispose();
 
           expectProperty("anything");
-        });
-
-        it("should pass keyArgs.includeType: false when the value is of the same type of the property", function() {
-          var includeType;
-
-          function expectProperty(name) {
-            var v = value.get(name);
-            if(v) {
-              expect(v.toSpecInContext.calls.count()).toBe(1);
-
-              expect(includeType).toBe(false);
-            }
-          }
-
-          spyProperty("noFormat", function(keyArgs) {
-            includeType = keyArgs.includeType;
-            return {};
-          });
-
-          value.toSpecInContext({includeType: false});
-
-          scope.dispose();
-
-          expectProperty("noFormat");
         });
 
         it("should omit a property if its name is in keyArgs.omitProps with a true value", function() {
@@ -289,7 +491,7 @@ define([
         it("should omit a property if its value's toSpecInContext returns null", function() {
           spyProperty("type", function() { return null; });
 
-          var spec = value.toSpecInContext({includeType: false});
+          var spec = value.toSpecInContext({});
 
           scope.dispose();
 
@@ -299,7 +501,7 @@ define([
         it("should include a property as null if its value's toSpecInContext returns null and array form is used", function() {
           spyProperty("type", function() { return null; });
 
-          var spec = value.toSpecInContext({includeType: false, preferPropertyArray: true});
+          var spec = value.toSpecInContext({preferPropertyArray: true});
 
           scope.dispose();
 
@@ -309,7 +511,7 @@ define([
         it("should include a property as null if its value's toSpecInContext returns null and defaults are included", function() {
           spyProperty("type", function() { return null; });
 
-          var spec = value.toSpecInContext({includeType: false, includeDefaults: true});
+          var spec = value.toSpecInContext({includeDefaults: true});
 
           scope.dispose();
 
@@ -321,7 +523,7 @@ define([
         var spec;
 
         beforeEach(function() {
-          spec = value.toSpecInContext({includeType: false, preferPropertyArray: true});
+          spec = value.toSpecInContext({preferPropertyArray: true});
         });
 
         it("should have one entry for each of the complex type's properties", function() {
@@ -345,7 +547,7 @@ define([
             describe("non-list properties", function() {
               it("should return an array with nulls where the value is equal to the default value", function() {
 
-                var spec = value.toSpecInContext({includeType: false, includeDefaults: false, preferPropertyArray: true});
+                var spec = value.toSpecInContext({includeDefaults: false, preferPropertyArray: true});
 
                 scope.dispose();
 
@@ -364,9 +566,13 @@ define([
             });
 
             describe("list properties", function() {
+
               it("should not return an empty array for an empty list that has an empty default value", function() {
+
                 var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: false});
+                  preferPropertyArray: true,
+                  includeDefaults: false
+                });
 
                 scope.dispose();
 
@@ -374,8 +580,11 @@ define([
               });
 
               it("should return an empty array for an empty list that has non-empty default value", function() {
+
                 var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: false});
+                  preferPropertyArray: true,
+                  includeDefaults: false
+                });
 
                 scope.dispose();
 
@@ -383,8 +592,11 @@ define([
               });
 
               it("should serialize a non-empty list", function() {
+
                 var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: false});
+                  preferPropertyArray: true,
+                  includeDefaults: false
+                });
 
                 scope.dispose();
 
@@ -398,7 +610,7 @@ define([
             it("should return an array with entries for all complex type's properties, " +
                "some with the default values", function() {
 
-              var spec = value.toSpecInContext({includeType: false, includeDefaults: true, preferPropertyArray: true});
+              var spec = value.toSpecInContext({includeDefaults: true, preferPropertyArray: true});
 
               scope.dispose();
 
@@ -407,8 +619,7 @@ define([
 
             describe("list properties", function() {
               it("should return an empty array for an empty list that has an empty default value", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: true, includeDefaults: true});
 
                 scope.dispose();
 
@@ -416,8 +627,7 @@ define([
               });
 
               it("should return an empty array for an empty list that has non-empty default value", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: true, includeDefaults: true});
 
                 scope.dispose();
 
@@ -425,8 +635,7 @@ define([
               });
 
               it("should serialize a non-empty list", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: true, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: true, includeDefaults: true});
 
                 scope.dispose();
 
@@ -440,7 +649,7 @@ define([
       describe("when returning a complex in object form", function() {
 
         it("should return nested complexes in object form as well", function() {
-          var spec = value.toSpecInContext({includeType: false, preferPropertyArray: false});
+          var spec = value.toSpecInContext({preferPropertyArray: false});
 
           scope.dispose();
 
@@ -455,8 +664,7 @@ define([
               it("should return a plain object with properties only for each of " +
                  "the non-default-valued complex type's properties", function() {
 
-                var spec = value.toSpecInContext(
-                    {includeType: false, includeDefaults: false, preferPropertyArray: false});
+                var spec = value.toSpecInContext({includeDefaults: false, preferPropertyArray: false});
 
                 scope.dispose();
 
@@ -474,7 +682,7 @@ define([
 
             describe("list properties", function() {
               it("should not return an empty array for an empty list that has an empty default value", function() {
-                var spec = value.toSpecInContext({includeType: false, preferPropertyArray: false, includeDefaults: false});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: false});
 
                 scope.dispose();
 
@@ -482,7 +690,7 @@ define([
               });
 
               it("should return an empty array for an empty list that has non-empty default value", function() {
-                var spec = value.toSpecInContext({includeType: false, preferPropertyArray: false, includeDefaults: false});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: false});
 
                 scope.dispose();
 
@@ -491,7 +699,7 @@ define([
               });
 
               it("should serialize a non-empty list", function() {
-                var spec = value.toSpecInContext({includeType: false, preferPropertyArray: false, includeDefaults: false});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: false});
 
                 scope.dispose();
 
@@ -506,8 +714,7 @@ define([
             it("should return a plain object with properties for all complex type's properties, " +
                "even those with default values", function() {
 
-              var spec = value.toSpecInContext(
-                  {includeType: false, includeDefaults: true, preferPropertyArray: false});
+              var spec = value.toSpecInContext({includeDefaults: true, preferPropertyArray: false});
 
               scope.dispose();
 
@@ -518,8 +725,7 @@ define([
 
             describe("list properties", function() {
               it("should not return an empty array for an empty list that has an empty default value", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: false, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: true});
 
                 scope.dispose();
 
@@ -528,8 +734,7 @@ define([
               });
 
               it("should return an empty array for an empty list that has non-empty default value", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: false, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: true});
 
                 scope.dispose();
 
@@ -538,8 +743,7 @@ define([
               });
 
               it("should serialize a non-empty list", function() {
-                var spec = value.toSpecInContext({
-                  includeType: false, preferPropertyArray: false, includeDefaults: true});
+                var spec = value.toSpecInContext({preferPropertyArray: false, includeDefaults: true});
 
                 scope.dispose();
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -592,7 +592,7 @@ define([
               expect(complex.y.at(0).value).toBe(1);
               expect(complex.y.at(1).value).toBe(2);
             });
-          }); //end with listeners
+          }); // end with listeners
         });
       }); // end set
 

--- a/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ define([
 
   /* global describe:true, it:true, expect:true, beforeEach:true*/
 
-  describe("pentaho.type.filter.Or", function() {
+  describe("pentaho.type.filter.And", function() {
 
     var context = new Context();
     var AbstractFilter = context.get(abstractFactory);
@@ -48,9 +48,9 @@ define([
 
     describe("#kind", function() {
 
-      it("should return 'or'", function() {
-        var filter  = new OrFilter();
-        expect(filter.kind).toBe("or");
+      it("should return 'and'", function() {
+        var filter  = new AndFilter();
+        expect(filter.kind).toBe("and");
       });
     });
 
@@ -58,13 +58,13 @@ define([
 
       var elem = new ProductSummary({name: "A", sales: 12000, inStock: true});
 
-      it("should return `false` if `operands` is empty", function() {
+      it("should return `true` if `operands` is empty", function() {
 
-        var filter  = new OrFilter();
+        var filter  = new AndFilter();
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
 
       it("should return `true` if all operand filters contain the element", function() {
@@ -75,14 +75,14 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(true);
 
-        var filter  = new OrFilter({operands: [oper1, oper2]});
+        var filter  = new AndFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
         expect(result).toBe(true);
       });
 
-      it("should return `true` if only one of the operand filters contains the element", function() {
+      it("should return `false` if one of the operand filters does not contain the element", function() {
 
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
@@ -90,11 +90,11 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new OrFilter({operands: [oper1, oper2]});
+        var filter  = new AndFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
 
       it("should be commutative", function() {
@@ -105,17 +105,17 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new OrFilter({operands: [oper1, oper2]});
+        var filter  = new AndFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
 
-        filter  = new OrFilter({operands: [oper2, oper1]});
+        filter  = new AndFilter({operands: [oper2, oper1]});
 
         result = filter.contains(elem);
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
 
       it("should return `false` if none of the operand filters contains the element", function() {
@@ -126,7 +126,7 @@ define([
         spyOn(oper1, "_contains").and.returnValue(false);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new OrFilter({operands: [oper1, oper2]});
+        var filter  = new AndFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
@@ -135,15 +135,15 @@ define([
     }); // #contains
 
     describe("#negate()", function() {
-      it("should return an `And` of negated operands", function() {
+      it("should return an `Or` of negated operands", function() {
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        var filter = new OrFilter({operands: [oper1, oper2]});
+        var filter = new AndFilter({operands: [oper1, oper2]});
 
         var invFilter = filter.negate();
 
-        expect(invFilter instanceof AndFilter);
+        expect(invFilter instanceof OrFilter);
 
         var opers = invFilter.operands;
         expect(opers.count).toBe(2);
@@ -156,79 +156,147 @@ define([
       });
     }); // #negate
 
-    describe("#or(filter, ...)", function() {
+    describe("#and(filter, ...)", function() {
 
       it("should return itself when no operands are given", function() {
-        var filter = new OrFilter();
-        var result = filter.or();
+        var filter = new AndFilter();
+        var result = filter.and();
 
         expect(result).toBe(filter);
       });
 
       it("should return itself when only null operands are given", function() {
-        var filter = new OrFilter();
-        var result = filter.or(null, null);
+        var filter = new AndFilter();
+        var result = filter.and(null, null);
 
         expect(result).toBe(filter);
       });
 
       it("should return the single operand when given an operand and initially empty", function() {
-        var filter = new OrFilter();
+        var filter = new AndFilter();
         var oper1  = new CustomFilter();
 
-        var result = filter.or(oper1);
+        var result = filter.and(oper1);
 
         expect(result).toBe(oper1);
       });
 
-      it("should return an `Or` filter when given an operand and initially not empty", function() {
+      it("should return an `And` filter when given an operand and initially not empty", function() {
         var oper1  = new CustomFilter();
-        var filter = new OrFilter({operands: [oper1]});
+        var filter = new AndFilter({operands: [oper1]});
         var oper2  = new CustomFilter();
 
-        var result = filter.or(oper2);
+        var result = filter.and(oper2);
 
-        expect(result instanceof OrFilter).toBe(true);
+        expect(result instanceof AndFilter).toBe(true);
       });
 
       it("should return a new filter when given an operand", function() {
         var oper1  = new CustomFilter();
-        var filter = new OrFilter({operands: [oper1]});
+        var filter = new AndFilter({operands: [oper1]});
         var oper2  = new CustomFilter();
 
-        var result = filter.or(oper2);
+        var result = filter.and(oper2);
 
         expect(result).not.toBe(filter);
         expect(result).not.toBe(oper1);
         expect(result).not.toBe(oper2);
       });
 
-      it("should add elements instead of creating a tree of Ors", function() {
+      it("should add elements instead of creating a tree of Ands", function() {
         var oper1  = new CustomFilter();
         var oper2  = new CustomFilter();
-        var filter = new OrFilter({operands: [oper1, oper2]});
+        var filter = new AndFilter({operands: [oper1, oper2]});
         var oper3  = new CustomFilter();
 
-        var result = filter.or(oper3);
+        var result = filter.and(oper3);
 
         expect(result.operands.count).toBe(3);
       });
 
-      it("should flatten operands of a given Or argument", function() {
+      it("should flatten operands of a given And argument", function() {
         var oper1  = new CustomFilter();
         var oper2  = new CustomFilter();
-        var filter1 = new OrFilter({operands: [oper1, oper2]});
+        var filter1 = new AndFilter({operands: [oper1, oper2]});
 
         var oper3  = new CustomFilter();
-        var filter2 = new OrFilter({operands: [oper3]});
+        var filter2 = new AndFilter({operands: [oper3]});
 
-        var result = filter1.or(filter2);
+        var result = filter1.and(filter2);
 
         expect(result.operands.count).toBe(3);
         expect(result.operands.at(0)).toBe(oper1);
         expect(result.operands.at(1)).toBe(oper2);
         expect(result.operands.at(2)).toBe(oper3);
       });
-    }); // #or
-  }); // pentaho.type.filter.Or
+    }); // #and
+
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        var oper1 = new CustomFilter();
+        var oper2 = new CustomFilter();
+
+        filter = new AndFilter({operands: [oper1, oper2]});
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+
+        it("should specify the operands by their #nameAlias 'o' instead of their #name 'operands", function() {
+
+          expect(filterSpec.o.length).toBe(2);
+          expect(filterSpec.operands).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `noAlias` set to `true`", function() {
+        it("should specify the operands by their #name 'operands", function() {
+
+          var filterSpec = filter.toSpec({
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBeUndefined();
+          expect(filterSpec.o).toBeUndefined();
+          expect(filterSpec.operands.length).toBe(2);
+
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("and");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/and");
+        });
+      });
+
+    }); // #toSpec
+
+  }); // pentaho.type.filter.And
+
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,25 @@ define([
 
     describe("new ({property, value})", function() {
 
-      it("should be possible to create an instance", function() {
+      it("should be possible to create an instance " +
+        "by specifying the properties by #name and value specification", function() {
 
         var filter = new IsEqualFilter({property: "foo", value: {_: "string", v: "bar"}});
+
+        expect(filter instanceof IsEqualFilter).toBe(true);
+      });
+
+      it("should be possible to create an instance " +
+        "by specifying the properties by #nameAlias and value specification", function() {
+
+        var filter = new IsEqualFilter({p: "foo", v: {_: "string", v: "bar"}});
+
+        expect(filter instanceof IsEqualFilter).toBe(true);
+      });
+
+      it("should be possible to create an instance by specifying the properties by #nameAlias and value", function() {
+
+        var filter = new IsEqualFilter({p: "foo", v: "bar"});
 
         expect(filter instanceof IsEqualFilter).toBe(true);
       });
@@ -65,7 +81,81 @@ define([
 
         expect(filter.property).toBe("foo");
       });
-    }); //#property
+
+      it("should return the property name specified at construction via #nameAlias", function() {
+
+        var filter = new IsEqualFilter({p: "foo"});
+
+        expect(filter.property).toBe("foo");
+      });
+    }); // #property
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        filter = new IsEqualFilter({property: "foo", value: {_: "string", v: "bar"}});
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+
+        it("should specify the properties by their #nameAlias instead of their #name", function() {
+
+          expect(filterSpec.p).toBe("foo");
+          expect(filterSpec.v).toBe("bar");
+          expect(filterSpec.property).toBeUndefined();
+          expect(filterSpec.value).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `noAlias` set to `true`", function() {
+        it("should specify the properties by their #name", function() {
+
+          var filterSpec = filter.toSpec({
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBeUndefined();
+
+          expect(filterSpec.p).toBeUndefined();
+          expect(filterSpec.v).toBeUndefined();
+
+          expect(filterSpec.property).toBe("foo");
+          expect(filterSpec.value).toBe("bar");
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("=");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/isEqual");
+        });
+      });
+
+    }); // #toSpec
 
     describe("#value", function() {
 
@@ -75,7 +165,14 @@ define([
 
         expect(filter.value).toBe("bar");
       });
-    }); //#value
+
+      it("should return the value specified at construction via #nameAlias", function() {
+
+        var filter = new IsEqualFilter({v: {_: "string", v: "bar"}});
+
+        expect(filter.value).toBe("bar");
+      });
+    }); // #value
 
     describe("#contains(elem)", function() {
 

--- a/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,26 @@ define([
 
     describe("new ({property, values})", function() {
 
-      it("should be possible to create an instance", function() {
+      it("should be possible to create an instance " +
+        "by specifying the properties by #name and list of value specifications", function() {
 
         var filter = new IsInFilter({property: "foo", values: [{_: "string", v: "bar"}]});
+
+        expect(filter instanceof IsInFilter).toBe(true);
+      });
+
+      it("should be possible to create an instance " +
+        "by specifying the properties by #nameAlias and list of value specifications", function() {
+
+        var filter = new IsInFilter({p: "foo", v: [{_: "string", v: "bar"}]});
+
+        expect(filter instanceof IsInFilter).toBe(true);
+      });
+
+      it("should be possible to create an instance " +
+        "by specifying the properties by #nameAlias and list of values", function() {
+
+        var filter = new IsInFilter({p: "foo", v: ["bar", "mux"]});
 
         expect(filter instanceof IsInFilter).toBe(true);
       });
@@ -65,7 +82,7 @@ define([
 
         expect(filter.property).toBe("foo");
       });
-    }); //#property
+    }); // #property
 
     describe("#values", function() {
 
@@ -78,7 +95,17 @@ define([
         expect(values.at(0).value).toBe("bar");
         expect(values.at(1).value).toBe("foo");
       });
-    }); //#values
+
+      it("should return a values list with the values specified via the nameAlias 'v' at construction", function() {
+
+        var filter = new IsInFilter({v: ["bar", "foo"]});
+
+        var values = filter.values;
+        expect(values.count).toBe(2);
+        expect(values.at(0).value).toBe("bar");
+        expect(values.at(1).value).toBe("foo");
+      });
+    }); // #values
 
     describe("#contains(elem)", function() {
 
@@ -155,5 +182,72 @@ define([
         expect(result).toBe(false);
       });
     }); // #contains
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+
+        filter = new IsInFilter({property: "sales", values: [
+          {_: "number", v: 14000},
+          {_: "number", v: 12000}
+        ]});
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+
+        it("should specify the values by the #nameAlias 'v' instead of the #name 'values", function() {
+
+          expect(filterSpec.v.length).toBe(2);
+          expect(filterSpec.values).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `noAlias` set to `true`", function() {
+        it("should specify the operands by their #name 'operands", function() {
+
+          var filterSpec = filter.toSpec({
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBeUndefined();
+          expect(filterSpec.v).toBeUndefined();
+          expect(filterSpec.values.length).toBe(2);
+
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("isIn");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/isIn");
+        });
+      });
+
+    }); // #toSpec
+
   }); // pentaho.type.filter.IsIn
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,18 @@ define([
 
         expect(filter instanceof NotFilter).toBe(true);
       });
-    });
+
+      it("should be possible to create an instance by specifying the alias `o`", function() {
+        var oper1 = new CustomFilter();
+
+        var filter = new NotFilter({o: oper1});
+
+        expect(filter instanceof NotFilter).toBe(true);
+
+        expect(filter.operand).toBe(oper1);
+      });
+
+    }); // new
 
     describe("#kind", function() {
 
@@ -71,7 +82,7 @@ define([
 
         expect(filter.operand).toBe(oper1);
       });
-    }); //#operand
+    }); // #operand
 
     describe("#contains(elem)", function() {
 
@@ -166,6 +177,70 @@ define([
         expect(result).toBe(filter);
       });
     }); // #_visitDefault
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        var oper = new CustomFilter();
+
+        filter = new NotFilter({operand: oper});
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+
+        it("should specify the operands by their #nameAlias 'o' instead of their #name 'operands", function() {
+
+          expect(filterSpec.o).toBeDefined();
+          expect(filterSpec.operand).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `noAlias` set to `true`", function() {
+        it("should specify the operands by their #name 'operands", function() {
+
+          var filterSpec = filter.toSpec({
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBeUndefined();
+          expect(filterSpec.o).toBeUndefined();
+          expect(filterSpec.operand).toBeDefined();
+
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("not");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/not");
+        });
+      });
+
+    }); // #toSpec
 
   }); // pentaho.type.filter.Not
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ define([
 
   /* global describe:true, it:true, expect:true, beforeEach:true*/
 
-  describe("pentaho.type.filter.And", function() {
+  describe("pentaho.type.filter.Or", function() {
 
     var context = new Context();
     var AbstractFilter = context.get(abstractFactory);
@@ -48,9 +48,9 @@ define([
 
     describe("#kind", function() {
 
-      it("should return 'and'", function() {
-        var filter  = new AndFilter();
-        expect(filter.kind).toBe("and");
+      it("should return 'or'", function() {
+        var filter  = new OrFilter();
+        expect(filter.kind).toBe("or");
       });
     });
 
@@ -58,13 +58,13 @@ define([
 
       var elem = new ProductSummary({name: "A", sales: 12000, inStock: true});
 
-      it("should return `true` if `operands` is empty", function() {
+      it("should return `false` if `operands` is empty", function() {
 
-        var filter  = new AndFilter();
+        var filter  = new OrFilter();
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
 
       it("should return `true` if all operand filters contain the element", function() {
@@ -75,14 +75,14 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(true);
 
-        var filter  = new AndFilter({operands: [oper1, oper2]});
+        var filter  = new OrFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
         expect(result).toBe(true);
       });
 
-      it("should return `false` if one of the operand filters does not contain the element", function() {
+      it("should return `true` if only one of the operand filters contains the element", function() {
 
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
@@ -90,11 +90,11 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new AndFilter({operands: [oper1, oper2]});
+        var filter  = new OrFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
 
       it("should be commutative", function() {
@@ -105,17 +105,17 @@ define([
         spyOn(oper1, "_contains").and.returnValue(true);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new AndFilter({operands: [oper1, oper2]});
+        var filter  = new OrFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
 
-        filter  = new AndFilter({operands: [oper2, oper1]});
+        filter  = new OrFilter({operands: [oper2, oper1]});
 
         result = filter.contains(elem);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
 
       it("should return `false` if none of the operand filters contains the element", function() {
@@ -126,7 +126,7 @@ define([
         spyOn(oper1, "_contains").and.returnValue(false);
         spyOn(oper2, "_contains").and.returnValue(false);
 
-        var filter  = new AndFilter({operands: [oper1, oper2]});
+        var filter  = new OrFilter({operands: [oper1, oper2]});
 
         var result = filter.contains(elem);
 
@@ -135,15 +135,15 @@ define([
     }); // #contains
 
     describe("#negate()", function() {
-      it("should return an `Or` of negated operands", function() {
+      it("should return an `And` of negated operands", function() {
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        var filter = new AndFilter({operands: [oper1, oper2]});
+        var filter = new OrFilter({operands: [oper1, oper2]});
 
         var invFilter = filter.negate();
 
-        expect(invFilter instanceof OrFilter);
+        expect(invFilter instanceof AndFilter);
 
         var opers = invFilter.operands;
         expect(opers.count).toBe(2);
@@ -156,81 +156,145 @@ define([
       });
     }); // #negate
 
-    describe("#and(filter, ...)", function() {
+    describe("#or(filter, ...)", function() {
 
       it("should return itself when no operands are given", function() {
-        var filter = new AndFilter();
-        var result = filter.and();
+        var filter = new OrFilter();
+        var result = filter.or();
 
         expect(result).toBe(filter);
       });
 
       it("should return itself when only null operands are given", function() {
-        var filter = new AndFilter();
-        var result = filter.and(null, null);
+        var filter = new OrFilter();
+        var result = filter.or(null, null);
 
         expect(result).toBe(filter);
       });
 
       it("should return the single operand when given an operand and initially empty", function() {
-        var filter = new AndFilter();
+        var filter = new OrFilter();
         var oper1  = new CustomFilter();
 
-        var result = filter.and(oper1);
+        var result = filter.or(oper1);
 
         expect(result).toBe(oper1);
       });
 
-      it("should return an `And` filter when given an operand and initially not empty", function() {
+      it("should return an `Or` filter when given an operand and initially not empty", function() {
         var oper1  = new CustomFilter();
-        var filter = new AndFilter({operands: [oper1]});
+        var filter = new OrFilter({operands: [oper1]});
         var oper2  = new CustomFilter();
 
-        var result = filter.and(oper2);
+        var result = filter.or(oper2);
 
-        expect(result instanceof AndFilter).toBe(true);
+        expect(result instanceof OrFilter).toBe(true);
       });
 
       it("should return a new filter when given an operand", function() {
         var oper1  = new CustomFilter();
-        var filter = new AndFilter({operands: [oper1]});
+        var filter = new OrFilter({operands: [oper1]});
         var oper2  = new CustomFilter();
 
-        var result = filter.and(oper2);
+        var result = filter.or(oper2);
 
         expect(result).not.toBe(filter);
         expect(result).not.toBe(oper1);
         expect(result).not.toBe(oper2);
       });
 
-      it("should add elements instead of creating a tree of Ands", function() {
+      it("should add elements instead of creating a tree of Ors", function() {
         var oper1  = new CustomFilter();
         var oper2  = new CustomFilter();
-        var filter = new AndFilter({operands: [oper1, oper2]});
+        var filter = new OrFilter({operands: [oper1, oper2]});
         var oper3  = new CustomFilter();
 
-        var result = filter.and(oper3);
+        var result = filter.or(oper3);
 
         expect(result.operands.count).toBe(3);
       });
 
-      it("should flatten operands of a given And argument", function() {
+      it("should flatten operands of a given Or argument", function() {
         var oper1  = new CustomFilter();
         var oper2  = new CustomFilter();
-        var filter1 = new AndFilter({operands: [oper1, oper2]});
+        var filter1 = new OrFilter({operands: [oper1, oper2]});
 
         var oper3  = new CustomFilter();
-        var filter2 = new AndFilter({operands: [oper3]});
+        var filter2 = new OrFilter({operands: [oper3]});
 
-
-        var result = filter1.and(filter2);
+        var result = filter1.or(filter2);
 
         expect(result.operands.count).toBe(3);
         expect(result.operands.at(0)).toBe(oper1);
         expect(result.operands.at(1)).toBe(oper2);
         expect(result.operands.at(2)).toBe(oper3);
       });
-    }); // #and
+    }); // #or
 
-  }); // pentaho.type.filter.And
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        var oper1 = new CustomFilter();
+        var oper2 = new CustomFilter();
+
+        filter = new OrFilter({operands: [oper1, oper2]});
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+
+        it("should specify the operands by their #nameAlias 'o' instead of their #name 'operands", function() {
+
+          expect(filterSpec.o.length).toBe(2);
+          expect(filterSpec.operands).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `noAlias` set to `true`", function() {
+        it("should specify the operands by their #name 'operands", function() {
+
+          var filterSpec = filter.toSpec({
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBeUndefined();
+          expect(filterSpec.o).toBeUndefined();
+          expect(filterSpec.operands.length).toBe(2);
+
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("or");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/or");
+        });
+      });
+
+    }); // #toSpec
+
+  }); // pentaho.type.filter.Or
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,14 @@ define([
 
         expect(filter instanceof CustomTreeFilter).toBe(true);
       });
+
+      it("should be possible to create an instance by specifying nameAlias `args`", function() {
+        var oper1 = new CustomFilter();
+
+        var filter = new CustomTreeFilter({o: [oper1]});
+
+        expect(filter instanceof CustomTreeFilter).toBe(true);
+      });
     });
 
     describe("#operands", function() {
@@ -56,7 +64,20 @@ define([
         expect(opers.at(0)).toBe(oper1);
         expect(opers.at(1)).toBe(oper2);
       });
-    }); //#operands
+
+      it("should return a list of operands with the filters " +
+        "specified via the nameAlias 'args' at construction", function() {
+        var oper1 = new CustomFilter();
+        var oper2 = new CustomFilter();
+
+        var filter = new CustomTreeFilter({o: [oper1, oper2]});
+
+        var opers = filter.operands;
+        expect(opers.count).toBe(2);
+        expect(opers.at(0)).toBe(oper1);
+        expect(opers.at(1)).toBe(oper2);
+      });
+    }); // #operands
 
     describe("#_visitDefault(transformer)", function() {
 

--- a/impl/client/src/test/javascript/pentaho/type/function.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/function.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl/client/src/test/javascript/pentaho/type/list.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.Type.serialization.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ define([
       });
 
       describe("#id", function() {
-        it("should serialize the #id of a type using #shortId", function() {
+        it("should serialize the #id of a type using #id when no alias is defined", function() {
           var derivedType = List.extend({type: {id: "pentaho/type/test"}}).type;
 
           var scope = new SpecificationScope();
@@ -91,7 +91,20 @@ define([
           scope.dispose();
 
           expect(spec instanceof Object).toBe(true);
-          expect(spec.id).toBe("test");
+          expect(spec.id).toBe(derivedType.id);
+        });
+
+        it("should serialize the #id of a type using #alias when an alias is defined", function() {
+          var derivedType = List.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+
+          var scope = new SpecificationScope();
+
+          var spec = derivedType.toSpecInContext();
+
+          scope.dispose();
+
+          expect(spec instanceof Object).toBe(true);
+          expect(spec.id).toBe(derivedType.alias);
         });
 
         it("should serialize with an anonymous #id when the type is anonymous", function() {

--- a/impl/client/src/test/javascript/pentaho/type/list.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.serialization.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,35 +30,97 @@ define([
 
     describe("#toSpec(keyArgs)", function() {
 
-      describe("when includeType is false", function() {
+      describe("when keyArgs.declaredType is unspecified", function() {
 
         it("should return an empty array for an empty list", function() {
           var list = new List();
-          var spec = list.toSpec({includeType: false});
+          var spec = list.toSpec({});
 
           expect(spec).toEqual([]);
         });
 
         it("should return an array of serialized elements for a list of elements", function() {
           var list = new NumberList([1, 2, 3]);
-          var spec = list.toSpec({includeType: false});
+          var spec = list.toSpec({});
 
           expect(spec).toEqual([1, 2, 3]);
         });
+
+        describe("when keyArgs.forceType is true", function() {
+
+          it("should return a spec with an inline type and an empty 'd' property, for an empty list", function() {
+
+            var list = new List();
+            var spec = list.toSpec({forceType: true});
+
+            expect(spec).toEqual({_: jasmine.any(String), d: []});
+          });
+
+          it("should return a spec with an inline type and a 'd' property with an " +
+              "array of serialized elements for a list of elements", function() {
+
+            var list = new NumberList([1, 2, 3]);
+            var spec = list.toSpec({forceType: true});
+
+            expect(spec).toEqual({_: jasmine.any(Object), d: [1, 2, 3]});
+          });
+        });
       });
 
-      describe("when includeType is true", function() {
+      describe("when keyArgs.declaredType is the list's type", function() {
 
-        it("should return a spec with an empty d property, for an empty list", function() {
+        it("should return an empty array for an empty list", function() {
+
           var list = new List();
-          var spec = list.toSpec({includeType: true});
+          var spec = list.toSpec({declaredType: list.type});
+
+          expect(spec).toEqual([]);
+        });
+
+        it("should return an array of serialized elements for a list of elements", function() {
+
+          var list = new NumberList([1, 2, 3]);
+          var spec = list.toSpec({declaredType: list.type});
+
+          expect(spec).toEqual([1, 2, 3]);
+        });
+
+        describe("when keyArgs.forceType is true", function() {
+
+          it("should return a spec with an inline type and an empty 'd' property, for an empty list", function() {
+
+            var list = new List();
+            var spec = list.toSpec({forceType: true, declaredType: list.type});
+
+            expect(spec).toEqual({_: jasmine.any(String), d: []});
+          });
+
+          it("should return a spec with an inline type and a 'd' property with an " +
+              "array of serialized elements for a list of elements", function() {
+
+            var list = new NumberList([1, 2, 3]);
+            var spec = list.toSpec({forceType: true, declaredType: list.type});
+
+            expect(spec).toEqual({_: jasmine.any(Object), d: [1, 2, 3]});
+          });
+        });
+      });
+
+      describe("when keyArgs.declaredType is the list's type's ancestor", function() {
+
+        it("should return a spec with an inline type and an empty 'd' property, for an empty list", function() {
+
+          var list = new List();
+          var spec = list.toSpec({declaredType: list.type.ancestor});
 
           expect(spec).toEqual({_: jasmine.any(String), d: []});
         });
 
-        it("should return an array of serialized elements for a list of elements", function() {
+        it("should return a spec with an inline type and a 'd' property with an " +
+           "array of serialized elements for a list of elements", function() {
+
           var list = new NumberList([1, 2, 3]);
-          var spec = list.toSpec({includeType: true});
+          var spec = list.toSpec({declaredType: list.type.ancestor});
 
           expect(spec).toEqual({_: jasmine.any(Object), d: [1, 2, 3]});
         });
@@ -78,7 +140,6 @@ define([
           "is of the list's representation element type", function() {
         var Refined = PentahoNumber.refine();
         var RefinedList = context.get([Refined.type]);
-
 
         var list = new RefinedList([1, 2, 3]);
         var spec = list.toSpec();

--- a/impl/client/src/test/javascript/pentaho/type/number.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/number.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ define([
 
       it("should throw and not accept a 'non-numeric' argument", function() {
         expect(function() {
-          var foo = new PentahoNumber('one');
+          var foo = new PentahoNumber("one");
         }).toThrow(errorMatch.argInvalid("value"));
       });
 

--- a/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,20 @@ define([
       });
 
       describe("#id", function() {
-        it("should serialize the #id of a type using #shortId", function() {
+        it("should serialize the #id of a type using #alias, if defined", function() {
+          var derivedType = Value.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+
+          var scope = new SpecificationScope();
+
+          var spec = derivedType.toSpecInContext();
+
+          scope.dispose();
+
+          expect(spec instanceof Object).toBe(true);
+          expect(spec.id).toBe(derivedType.alias);
+        });
+
+        it("should serialize the #id of a type using #shortId, if an #alias is not defined", function() {
           var derivedType = Value.extend({type: {id: "pentaho/type/test"}}).type;
 
           var scope = new SpecificationScope();
@@ -108,7 +121,22 @@ define([
           scope.dispose();
 
           expect(spec instanceof Object).toBe(true);
-          expect(spec.id).toBe("test");
+          expect(spec.id).toBe(derivedType.shortId);
+        });
+
+        it("should serialize the #id of a type using #id when an #alias is defined but #toSpecInContext is invoked with `noAlias`", function() {
+          var derivedType = Value.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+
+          var scope = new SpecificationScope();
+
+          var spec = derivedType.toSpecInContext({
+            noAlias: true
+          });
+
+          scope.dispose();
+
+          expect(spec instanceof Object).toBe(true);
+          expect(spec.id).toBe(derivedType.id);
         });
 
         it("should serialize with an anonymous #id when the type is anonymous", function() {


### PR DESCRIPTION
Marked pentaho.type.element as abstract. Updated documentation.
Added unit tests around instantiation and serialisation of filters using aliases.
Replaced the `pentaho.type.Instance#toSpec`’s option, `includeType`, by two equivalent options, `declaredType` and `forceType`.
Implemented special number, string and boolean serialization under an abstract declaredType.