### PR TITLE
[BACKLOG-14324] Restoring Analyzer tooltip footer in CCC vizs.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
@@ -1315,9 +1315,16 @@ define([
         }, this);
 
         if(!complex.isVirtual) {
-          // TODO: container double click tooltip
-          // msg = this._vizHelper.getDoubleClickTooltip();
-          if(msg) tooltipLines.push(msg);
+
+          // TODO: Generalize getDoubleClickTooltip somehow.
+          var app = this.model.application;
+          if(app && app.getDoubleClickTooltip) {
+            var pointFilter = this._complexToFilter(complex);
+            msg = app.getDoubleClickTooltip(pointFilter);
+            if(msg) {
+              tooltipLines.push(msg);
+            }
+          }
         }
 
         /* Add selection information */


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.

"Depends" on https://github.com/pentaho/pentaho-analyzer/pull/1417.