### PR TITLE
[BACKLOG-14622] Ignore vizApiVersion chart option

### DIFF
--- a/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
+++ b/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
@@ -4447,7 +4447,9 @@ define([
         'maxValues',
         'metrics',
         'palette',
-        'selections'
+        'selections',
+
+        'vizApiVersion'
     ],
     def.retTrue);
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.