### PR TITLE
[BACKLOG-14324] Implemented `pentaho.type.Filter#toDnf` and several supporting features and optimizations.

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/type/PropertyDynamicAttribute.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/PropertyDynamicAttribute.jsdoc
@@ -20,7 +20,7 @@
  * Examples of dynamic property attributes:
  *
  * * {@link pentaho.type.Property.Type#isApplicable}
- * * {@link pentaho.type.Property.Type#isReadOnly}
+ * * {@link pentaho.type.Property.Type#isEnabled}
  * * {@link pentaho.type.Property.Type#isRequired}
  * * {@link pentaho.type.Property.Type#countMin}
  * * {@link pentaho.type.Property.Type#countMax}

--- a/impl/client/src/main/doc-js/pentaho/type/filter/spec/IIsIn.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/filter/spec/IIsIn.jsdoc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// TODO: Opted to keep isIn @private, undocumented, for 7.1.
+
 /**
  * The `spec.IIsIn` interface describes the information of a membership filter.
  *
@@ -23,6 +25,8 @@
  * @extends pentaho.type.filter.spec.IProperty
  *
  * @see pentaho.type.filter.IsIn
+ *
+ * @private
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IPropertyTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IPropertyTypeProto.jsdoc
@@ -250,10 +250,10 @@
  */
 
 /**
- * Indicates if properties of this type _cannot_ be changed by a user
+ * Indicates if properties of this type _can_ be changed by a user
  * in a user interface.
  *
- * A property should be marked read-only whenever its value is implied/imposed somehow,
+ * A property should be marked disabled whenever its value is implied/imposed somehow,
  * and thus cannot not be changed, directly, by the user in a user interface.
  *
  * ### This attribute is *Dynamic*
@@ -266,8 +266,8 @@
  *
  * The value of a _monotonic_ attribute can change, but only in some, predetermined _monotonic_ direction.
  *
- * In this case, a _property type_ marked as _not read-only_ can later be marked as _read-only_.
- * However, a _property type_ marked as _read-only_ can no longer go back to being _not read-only_.
+ * In this case, a _property type_ marked as _enabled_ can later be marked as _not enabled_.
+ * However, a _property type_ marked as _not enabled_ can no longer go back to being _enabled_.
  *
  * ### This attribute is *Inherited*
  *
@@ -277,13 +277,13 @@
  *
  * When a {@link Nully} value is specified, it is ignored.
  *
- * The default (root) `isReadOnly` attribute value is `false`.
+ * The default (root) `isEnabled` attribute value is `true`.
  *
- * @name isReadOnly
+ * @name isEnabled
  * @memberOf pentaho.type.spec.IPropertyTypeProto#
  * @type {boolean | pentaho.type.PropertyDynamicAttribute.<boolean>}
  *
- * @see pentaho.type.Property.Type#isReadOnly
+ * @see pentaho.type.Property.Type#isEnabled
  */
 
 /**

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
@@ -1530,18 +1530,23 @@ define([
           return memo;
         }.bind(this), []);
 
-        var Or = this.type.context.get("or");
+        var actionSpec;
 
-        var keyArgs = {};
-
-        // Replace with empty selection when the user selects nothing.
-        if(operands && operands.length === 0) keyArgs.selectionMode = SelectionModes.replace;
+        if (operands.length === 0) {
+          // Replace with empty selection when the user selects nothing.
+          actionSpec = {
+            selectionMode: SelectionModes.replace,
+            dataFilter: this.type.context.get("false").instance
+          };
+        } else {
+          var Or = this.type.context.get("or");
+          actionSpec = {
+            dataFilter: new Or({operands: operands})
+          };
+        }
 
         var SelectAction = this.type.context.get(selectActionFactory);
-
-        this.act(new SelectAction({
-          dataFilter: new Or({operands: operands})
-        }));
+        this.act(new SelectAction(actionSpec));
 
         // Explicitly cancel CCC's native selection handling.
         return [];

--- a/impl/client/src/main/javascript/web/pentaho/type/ContainerMixin.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/ContainerMixin.js
@@ -156,6 +156,7 @@ define([
      *
      * @private
      * @friend {pentaho.type.changes.Changeset}
+     * @friend {pentaho.type.filter.Abstract}
      */
     _setVersionInternal: function(version) {
       this._vers = version;
@@ -207,6 +208,7 @@ define([
      * @return {pentaho.type.changes.Changeset} A changeset of appropriate type.
      *
      * @abstract
+     * @protected
      */
 
     /**

--- a/impl/client/src/main/javascript/web/pentaho/type/Context.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/Context.js
@@ -244,6 +244,10 @@ define([
     },
 
     // region Type Registry
+
+    // TODO: Removed from docs, below, until isIn is made public.
+    // [pentaho/type/filter/isIn]{@link pentaho.type.filter.IsIn}
+
     /**
      * Gets the **configured instance constructor** of a type.
      *
@@ -285,7 +289,6 @@ define([
      *     * [pentaho/type/filter/not]{@link pentaho.type.filter.Not}
      *     * [pentaho/type/filter/property]{@link pentaho.type.filter.Property}
      *       * [pentaho/type/filter/isEqual]{@link pentaho.type.filter.IsEqual}
-     *       * [pentaho/type/filter/isIn]{@link pentaho.type.filter.IsIn}
      *
      * If it is not known whether all non-standard types that are referenced by identifier have already been loaded,
      * the asynchronous method version, [getAsync]{@link pentaho.type.Context#getAsync},

--- a/impl/client/src/main/javascript/web/pentaho/type/_type.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/_type.js
@@ -1184,6 +1184,7 @@ define([
        * });
        *
        * @param {pentaho.type.spec.UInstance} [instSpec] An instance specification.
+       * @param {Object} [keyArgs] - The keyword arguments passed to the instance constructor.
        *
        * @return {!pentaho.type.Instance} The created instance.
        *
@@ -1199,7 +1200,7 @@ define([
        * @throws {pentaho.lang.OperationInvalidError} When the determined type for the specified `instSpec`
        * is an [abstract]{@link pentaho.type.Value.Type#isAbstract} type.
        */
-      create: function(instSpec) {
+      create: function(instSpec, keyArgs) {
         var Instance;
         var typeSpec;
 
@@ -1251,6 +1252,7 @@ define([
        * the type is assumed to be `this` type.
        *
        * @param {pentaho.type.spec.UInstance} [instSpec] - An instance specification.
+       * @param {Object} [keyArgs] - The keyword arguments passed to `create`.
        *
        * @return {!Promise.<pentaho.type.Instance>} A promise to the created instance.
        *
@@ -1267,7 +1269,7 @@ define([
        * @see pentaho.type.Type#isSubtypeOf
        * @see pentaho.type.Context#get
        */
-      createAsync: function(instSpec) {
+      createAsync: function(instSpec, keyArgs) {
 
         var customTypeIds = Object.keys(this._collectInstSpecTypeIds(instSpec));
 
@@ -1279,7 +1281,7 @@ define([
             : promiseUtil.wrapCall(resolveSync, this);
 
         function resolveSync() {
-          return this.create(instSpec);
+          return this.create(instSpec, keyArgs);
         }
       },
 
@@ -1364,12 +1366,14 @@ define([
        * [create]{@link pentaho.type.Type#create}.
        *
        * @param {?any} value - The value to convert.
+       * @param {Object} [keyArgs] - The keyword arguments passed to `create`, when a new instance is created.
+       *
        * @return {?pentaho.type.Instance} The converted value or `null`.
        */
-      to: function(value) {
-        return value == null   ? null  :
-               this.is(value)  ? value :
-               this.create(value);
+      to: function(value, keyArgs) {
+        return value == null ? null :
+               this.is(value) ? value :
+               this.create(value, keyArgs);
       },
 
       // region serialization

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
@@ -72,12 +72,12 @@ define([
 
     _prepareRefs: function(txn, target) {
       var elem = this.element;
-      if(elem._addReference) txn._ensureChangeRef(elem).addReference(target);
+      if(!target.isBoundary && elem._addReference) txn._ensureChangeRef(elem).addReference(target);
     },
 
     _cancelRefs: function(txn, target) {
       var elem = this.element;
-      if(elem._addReference) txn._ensureChangeRef(elem).removeReference(target);
+      if(!target.isBoundary && elem._addReference) txn._ensureChangeRef(elem).removeReference(target);
     },
 
     _apply: function(target) {

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ChangeRef.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ChangeRef.js
@@ -108,16 +108,25 @@ define([
           refs = ReferenceList.to(refs.slice());
         }
 
+        var i;
+        var L;
+        var aref;
         if(refsRem) {
-          refsRem.forEach(function(aref) {
+          i = -1;
+          L = refsRem.length;
+          while(++i < L) {
+            aref = refsRem[i];
             refs.remove(aref.container, aref.property);
-          });
+          }
         }
 
         if(refsAdd) {
-          refsAdd.forEach(function(aref) {
+          i = -1;
+          L = refsAdd.length;
+          while(++i < L) {
+            aref = refsAdd[i];
             refs.add(aref.container, aref.property);
-          });
+          }
         }
       }
 

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
@@ -48,20 +48,29 @@ define([
 
     _prepareRefs: function(txn, target) {
       if(target.type.of.isComplex) {
-        target._elems.forEach(function(elem) {
-          if(elem._addReference)
+        var i = -1;
+        var elems = target._elems;
+        var L = elems.length;
+        var elem;
+        while(++i < L) {
+          if((elem = elems[i])._addReference) {
             txn._ensureChangeRef(elem).removeReference(target);
-        });
+          }
+        }
       }
     },
 
     _cancelRefs: function(txn, target) {
       if(target.type.of.isComplex) {
-
-        target._elems.forEach(function(elem) {
-          if(elem._addReference)
+        var i = -1;
+        var elems = target._elems;
+        var L = elems.length;
+        var elem;
+        while(++i < L) {
+          if((elem = elems[i])._addReference) {
             txn._ensureChangeRef(elem).addReference(target);
-        });
+          }
+        }
       }
     },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
@@ -47,7 +47,7 @@ define([
     },
 
     _prepareRefs: function(txn, target) {
-      if(target.type.of.isComplex) {
+      if(!target.isBoundary && target.type.of.isComplex) {
         var i = -1;
         var elems = target._elems;
         var L = elems.length;
@@ -61,7 +61,7 @@ define([
     },
 
     _cancelRefs: function(txn, target) {
-      if(target.type.of.isComplex) {
+      if(!target.isBoundary && target.type.of.isComplex) {
         var i = -1;
         var elems = target._elems;
         var L = elems.length;

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
@@ -69,7 +69,7 @@ define([
     },
 
     _prepareRefs: function(txn, target) {
-      if(target.type.of.isComplex) {
+      if(!target.isBoundary && target.type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem._addReference)
             txn._ensureChangeRef(elem).removeReference(target);
@@ -78,7 +78,7 @@ define([
     },
 
     _cancelRefs: function(txn, target) {
-      if(target.type.of.isComplex) {
+      if(!target.isBoundary && target.type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem._addReference)
             txn._ensureChangeRef(elem).addReference(target);

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Replace.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Replace.js
@@ -83,8 +83,10 @@ define([
     },
 
     _replaceRefs: function(txn, complex, v1, v2) {
-      if(v1 && v1._addReference) txn._ensureChangeRef(v1).removeReference(complex, this.property);
-      if(v2 && v2._addReference) txn._ensureChangeRef(v2).addReference(complex, this.property);
+      if(!this.property.isBoundary) {
+        if(v1 && v1._addReference) txn._ensureChangeRef(v1).removeReference(complex, this.property);
+        if(v2 && v2._addReference) txn._ensureChangeRef(v2).addReference(complex, this.property);
+      }
     },
 
     /**

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -155,6 +155,10 @@ define([
        * nor should its construction time property values be restored to... what? default values?
        * So, references added should also not be subject to the ambient transaction.
        *
+       * Lists have special semantics: isBoundary applies to the relation between the list and its elements.
+       * Adding/Removing elements in an isList and isBoundary property
+       * still generates events in the containing complex.
+       * We could, however, not addRef is the prop (and, thus, the list) is also isReadOnly?
        *
        * @param {!pentaho.type.Property.Type} propType - The property type.
        * @param {!pentaho.type.ContainerMixin} value - The container value.
@@ -163,7 +167,9 @@ define([
        */
       __initValueRelation: function(propType, value) {
 
+        if(propType.isList || !propType.isBoundary) {
           value._addReference(this, propType);
+        }
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -617,18 +617,18 @@ define([
       },
       // endregion
 
-      // region isReadOnly attribute
+      // region isEnabled attribute
       /**
-       * Gets a value that indicates if a given property is currently read-only.
+       * Gets a value that indicates if a given property is currently enabled.
        *
        * @param {string|pentaho.type.Property.Type} name - The property name or property type object.
        *
-       * @return {boolean} Returns `true` if the property is read-only; `false` if the value is other.
+       * @return {boolean} Returns `true` if the property is enabled; `false`, otherwise.
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      isReadOnly: function(name) {
-        return this.type.get(name).isReadOnlyEval(this);
+      isEnabled: function(name) {
+        return this.type.get(name).isEnabledEval(this);
       },
       // endregion
 

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/KnownFilterKind.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/KnownFilterKind.js
@@ -55,7 +55,19 @@ define(function() {
      * The [IsIn]{@link pentaho.type.filter.IsIn} filter kind.
      * @default
      */
-    IsIn: "isIn"
+    IsIn: "isIn",
+
+    /**
+     * The [True]{@link pentaho.type.filter.True} filter kind.
+     * @default
+     */
+    True: "true",
+
+    /**
+     * The [False]{@link pentaho.type.filter.False} filter kind.
+     * @default
+     */
+    False: "false"
   };
 
   return KnownFilterKind;

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/KnownFilterKind.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/KnownFilterKind.js
@@ -54,6 +54,7 @@ define(function() {
     /**
      * The [IsIn]{@link pentaho.type.filter.IsIn} filter kind.
      * @default
+     * @private
      */
     IsIn: "isIn",
 

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/false.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/false.js
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "../KnownFilterKind"
+], function(KnownFilterKind) {
+
+  "use strict";
+
+  return function(filter) {
+
+    /**
+     * @name pentaho.type.filter.False.Type
+     * @class
+     * @extends pentaho.type.Abstract.Type
+     *
+     * @classDesc The type class of the `False` filter type.
+     *
+     * For more information see {@link pentaho.type.filter.False}.
+     */
+
+    /**
+     * @name pentaho.type.filter.False
+     * @class
+     * @extends pentaho.type.filter.Abstract
+     *
+     * @amd {pentaho.type.Factory<pentaho.type.filter.False>} pentaho/type/filter/true
+     *
+     * @classDesc The `False` type represents a filter that encompasses no data.
+     *
+     * In terms of set operations, the `False` filter corresponds to the _empty_ set.
+     */
+
+    filter.False = filter.Abstract.extend("pentaho.type.filter.False", /** @lends pentaho.type.filter.False# */{
+
+      get kind() {
+        return KnownFilterKind.False;
+      },
+
+      get isTerminal() {
+        return true;
+      },
+
+      _buildContentKey: function() {
+        return "";
+      },
+
+      _contains: function(elem) {
+        return false;
+      },
+
+      negate: function() {
+        return new filter.True();
+      },
+
+      type: /** @lends pentaho.type.filter.False.Type# */{
+        id: "pentaho/type/filter/false",
+        alias: "false"
+      }
+    });
+  };
+});

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/false.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/false.js
@@ -21,6 +21,8 @@ define([
 
   return function(filter) {
 
+    var _false = null;
+
     /**
      * @name pentaho.type.filter.False.Type
      * @class
@@ -45,6 +47,14 @@ define([
 
     filter.False = filter.Abstract.extend("pentaho.type.filter.False", /** @lends pentaho.type.filter.False# */{
 
+      constructor: function() {
+        if(_false) return _false;
+
+        _false = this;
+
+        this.base();
+      },
+
       get kind() {
         return KnownFilterKind.False;
       },
@@ -62,12 +72,22 @@ define([
       },
 
       negate: function() {
-        return new filter.True();
+        return filter.True.instance;
       },
 
       type: /** @lends pentaho.type.filter.False.Type# */{
         id: "pentaho/type/filter/false",
         alias: "false"
+      }
+    }, /** @lends pentaho.type.filter.False */{
+      /**
+       * Gets the _false_ filter instance.
+       *
+       * @type {!pentaho.type.filter.False}
+       * @readOnly
+       */
+      get instance() {
+        return _false || (_false = new this());
       }
     });
   };

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -58,6 +58,10 @@ define([
         return KnownFilterKind.Not;
       },
 
+      get isTerminal() {
+        return false;
+      },
+
       /**
        * Gets the operand of this filter.
        *

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -62,6 +62,11 @@ define([
         return false;
       },
 
+      _buildContentKey: function() {
+        var o = this.operand;
+        return o ? o.contentKey : "";
+      },
+
       /**
        * Gets the operand of this filter.
        *

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -62,6 +62,10 @@ define([
         return false;
       },
 
+      get isNot() {
+        return true;
+      },
+
       _buildContentKey: function() {
         var o = this.operand;
         return o ? o.contentKey : "";

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -129,7 +129,8 @@ define([
             nameAlias: "o",
             type: filter.Abstract,
             isRequired: true,
-            isReadOnly: true
+            isReadOnly: true,
+            isBoundary: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/not.js
@@ -128,7 +128,8 @@ define([
             name: "operand",
             nameAlias: "o",
             type: filter.Abstract,
-            isRequired: true
+            isRequired: true,
+            isReadOnly: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -54,6 +54,10 @@ define([
 
     filter.Tree = filter.Abstract.extend("pentaho.type.filter.Tree", /** @lends pentaho.type.filter.Tree# */{
 
+      get isTerminal() {
+        return false;
+      },
+
       /**
        * Gets the list of operands of this filter.
        *
@@ -140,7 +144,7 @@ define([
        */
       _visitDefault: function(transformer) {
         var opersOut = this.visitOperands(transformer);
-        return opersOut ? new this.constructor({operands: opersOut}) : this;
+        return opersOut ? new this.constructor({operands: opersOut}) : this.clone();
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -58,6 +58,11 @@ define([
         return false;
       },
 
+      _buildContentKey: function() {
+        // Sorting makes content equality be independent of operand order.
+        return this.operands.toArray(function(o) { return o.contentKey; }).sort().join(" ");
+      },
+
       /**
        * Gets the list of operands of this filter.
        *

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -199,7 +199,8 @@ define([
           {
             name: "operands",
             nameAlias: "o",
-            type: [filter.Abstract]
+            type: [filter.Abstract],
+            isReadOnly: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -192,6 +192,32 @@ define([
         return opersOut;
       },
 
+      // region literalsByPropertyName
+      get literalsByPropertyName() {
+        return this.__literalsByName || (this.__literalsByName = Object.freeze(this.__buildLiteralsByName()));
+      },
+
+      __literalsByName: null,
+
+      __buildLiteralsByName: function() {
+        var literalsByName = {};
+        var os = this.operands;
+        var i = os.count;
+        var o;
+        var p;
+
+        while(i--) {
+          o = os.at(i);
+          p = (o.isNot ? o.operand : o);
+          if(p.isProperty) {
+            literalsByName[o.property] = {operand: o, index: i};
+          }
+        }
+
+        return literalsByName;
+      },
+      // endregion
+
       type: /** @lends pentaho.type.filter.Tree.Type# */{
         id: "pentaho/type/filter/tree",
         isAbstract: true,

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/tree.js
@@ -149,7 +149,7 @@ define([
        */
       _visitDefault: function(transformer) {
         var opersOut = this.visitOperands(transformer);
-        return opersOut ? new this.constructor({operands: opersOut}) : this.clone();
+        return opersOut ? new this.constructor({operands: opersOut}) : this;
       },
 
       /**
@@ -200,7 +200,8 @@ define([
             name: "operands",
             nameAlias: "o",
             type: [filter.Abstract],
-            isReadOnly: true
+            isReadOnly: true,
+            isBoundary: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/true.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/true.js
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "../KnownFilterKind"
+], function(KnownFilterKind) {
+
+  "use strict";
+
+  return function(filter) {
+
+    /**
+     * @name pentaho.type.filter.True.Type
+     * @class
+     * @extends pentaho.type.Abstract.Type
+     *
+     * @classDesc The type class of the `True` filter type.
+     *
+     * For more information see {@link pentaho.type.filter.True}.
+     */
+
+    /**
+     * @name pentaho.type.filter.True
+     * @class
+     * @extends pentaho.type.filter.Abstract
+     *
+     * @amd {pentaho.type.Factory<pentaho.type.filter.True>} pentaho/type/filter/true
+     *
+     * @classDesc The `True` type represents a filter that encompasses all and any data.
+     *
+     * In terms of set operations, the `True` filter corresponds to the _universal_ set.
+     */
+
+    filter.True = filter.Abstract.extend("pentaho.type.filter.True", /** @lends pentaho.type.filter.True# */{
+
+      get kind() {
+        return KnownFilterKind.True;
+      },
+
+      get isTerminal() {
+        return true;
+      },
+
+      _buildContentKey: function() {
+        return "";
+      },
+
+      _contains: function(elem) {
+        return true;
+      },
+
+      negate: function() {
+        return new filter.False();
+      },
+
+      type: /** @lends pentaho.type.filter.True.Type# */{
+        id: "pentaho/type/filter/true",
+        alias: "true"
+      }
+    });
+  };
+});

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/_core/true.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/_core/true.js
@@ -21,6 +21,8 @@ define([
 
   return function(filter) {
 
+    var _true;
+
     /**
      * @name pentaho.type.filter.True.Type
      * @class
@@ -45,6 +47,14 @@ define([
 
     filter.True = filter.Abstract.extend("pentaho.type.filter.True", /** @lends pentaho.type.filter.True# */{
 
+      constructor: function() {
+        if(_true) return _true;
+
+        _true = this;
+
+        this.base();
+      },
+
       get kind() {
         return KnownFilterKind.True;
       },
@@ -62,12 +72,22 @@ define([
       },
 
       negate: function() {
-        return new filter.False();
+        return filter.False.instance;
       },
 
       type: /** @lends pentaho.type.filter.True.Type# */{
         id: "pentaho/type/filter/true",
         alias: "true"
+      }
+    }, /** @lends pentaho.type.filter.True */{
+      /**
+       * Gets the _true_ filter instance.
+       *
+       * @type {!pentaho.type.filter.True}
+       * @readOnly
+       */
+      get instance() {
+        return _true || (_true = new this());
       }
     });
   };

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
@@ -87,6 +87,35 @@ define([
       },
 
       /**
+       * Gets a key that identifies the content of this filter.
+       *
+       * @type {string}
+       * @readOnly
+       */
+      get contentKey() {
+        return this.__contentKey || (this.__contentKey = "(" + this.type.shortId + " " + this._buildContentKey() + ")");
+      },
+
+      /**
+       * Builds the content key.
+       *
+       * The kind of filter is already added around what is returned by this method.
+       *
+       * @name _buildContentKey
+       * @memberOf pentaho.type.filter.Abstract#
+       * @method
+       * @return {string} The content key.
+       * @protected
+       * @abstract
+       */
+
+      _setVersionInternal: function(version) {
+        this.base(version);
+
+        this.__contentKey = null;
+      },
+
+      /**
        * Determines if an element is selected by this filter.
        *
        * When the filter is not valid, an error is thrown.

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
@@ -764,9 +764,12 @@ define([
               }
 
               // TODO: replace ai by not in(va,vb) ? IsIn is even not defined...
+              throw error.notImplemented("This case is not supported.");
+              /*
               resulti = a.operands.toArray();
               resulti[aiInfo.index] = new filter.IsIn({property: pa.property, values: [pa.value, pb.value]}).negate();
               results.push(new filter.And({operands: resulti}));
+              */
             }
           } else if(isPbNot) {
             // (va - -vb) <=> (va + vb) <=> (p = va and p = vb)

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
@@ -124,13 +124,6 @@ define([
        * @abstract
        */
 
-      _setVersionInternal: function(version) {
-        this.base(version);
-
-        this.__contentKey = null;
-        this.__toDnfCache = null;
-      },
-
       /**
        * Determines if an element is selected by this filter.
        *
@@ -322,7 +315,7 @@ define([
           var excludeKey = excludeKeysArray[j];
           var excludeAnd = excludeKeys[excludeKey];
 
-          //var excludeAndNeg = excludeAnd.negate();
+          // var excludeAndNeg = excludeAnd.negate();
 
           // Match this against every `remainings`.
 
@@ -472,8 +465,8 @@ define([
         }
       } else {
         ands.push(new filter.And({operands: andOperands.slice()}));
-        }
       }
+    }
 
     function flattenTree(f) {
 

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
@@ -194,7 +194,7 @@ define([
        * @see pentaho.type.filter.Tree#_visitDefault
        */
       _visitDefault: function(transformer) {
-        return this.clone();
+        return this;
       },
 
       /**
@@ -271,7 +271,7 @@ define([
         var excludeDnf = exclude.toDnf();
         switch(excludeDnf.kind) {
           case "false": return this; // ? \ false = ?
-          case "true": return new filter.False(); // ? \ true = false
+          case "true": return filter.False.instance; // ? \ true = false
         }
 
         // Remove from `current`, any `and` that also exists in exclude.
@@ -333,7 +333,7 @@ define([
 
         return remainings.length
             ? new filter.Or({operands: remainings})
-            : new filter.False();
+            : filter.False.instance;
       },
 
       toDnf: function() {
@@ -392,7 +392,7 @@ define([
 
           case "true":
             // 3. NOT(TRUE) <=> FALSE
-            return new filter.False();
+            return filter.False.instance;
 
           case "false":
             // 3. NOT(FALSE) <=> TRUE
@@ -485,9 +485,9 @@ define([
             // recurse in pre-order
             var o = os.at(i).visit(flattenTree);
             if(o.kind === kind) {
-              osFlattened.push.apply(osFlattened, o.operands.toArray(function(f) { return f.clone(); }));
+              osFlattened.push.apply(osFlattened, o.operands.toArray());
             } else {
-              osFlattened.push(o.clone());
+              osFlattened.push(o);
             }
           }
 
@@ -513,11 +513,11 @@ define([
             var o = os.at(i);
             switch(o.kind) {
               // early true/false detection
-              case "true": return new filter.True();
+              case "true": return filter.True.instance;
               case "false": continue;
-              case "and": osAnds.push(o.clone()); break;
+              case "and": osAnds.push(o); break;
               default:
-                osAnds.push(new filter.And({operands: [o.clone()]}));
+                osAnds.push(new filter.And({operands: [o]}));
             }
           }
 
@@ -587,7 +587,7 @@ define([
 
         var o = ands.at(i).visit(simplifyDnfAnd);
         switch(o.kind) {
-          case "true": return new filter.True(); // 6)
+          case "true": return filter.True.instance; // 6)
           case "false": continue; // 4)
         }
 
@@ -602,7 +602,7 @@ define([
         andsNew.push(o);
       }
 
-      if(!andsNew.length) return new filter.False(); // 12)
+      if(!andsNew.length) return filter.False.instance; // 12)
 
       return new filter.Or({operands: andsNew});
     }
@@ -633,7 +633,7 @@ define([
         var isNot = false;
         var p;
         switch(o.kind) {
-          case "false": return new filter.False(); // 5)
+          case "false": return filter.False.instance; // 5)
           case "true": continue; // 3)
           case "not": isNot = true; break;
         }
@@ -649,7 +649,7 @@ define([
             // 9) Law of non-contradiction
             if(O.hasOwn(osByKey, oo.contentKey)) {
               // Already have non-negated operand
-              return new filter.False();
+              return filter.False.instance;
             }
 
             if(oo.kind === "isEqual" && (p = oo.property)) {
@@ -666,7 +666,7 @@ define([
           // 9) Law of non-contradiction
           if(O.hasOwn(osByKey, "(not " + key + ")")) {
             // Already have negated operand
-            return new filter.False();
+            return filter.False.instance;
           }
 
           if(o.kind === "isEqual" && (p = o.property)) {
@@ -675,7 +675,7 @@ define([
             //     If present in equalsByPropName, then it must be for a != value, or the key test above, (2),
             //     would have caught it.
             if(O.hasOwn(equalsByPropName, "+" + p)) {
-              return new filter.False();
+              return filter.False.instance;
             }
 
             (equalsByPropName["+" + p] || (equalsByPropName["+" + p] = [])).push(o);
@@ -699,7 +699,7 @@ define([
         osNew.push(o);
       }
 
-      if(!osNew.length) return new filter.True(); // 11)
+      if(!osNew.length) return filter.True.instance; // 11)
 
       return new filter.And({operands: osNew});
     }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/abstract.js
@@ -361,6 +361,8 @@ define([
               .visit(flattenTree)
               .visit(ensureDnfTopLevel)
               .visit(simplifyDnfTopLevel);
+
+          result.__toDnfCache = result;
         }
         return result;
       },

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/false.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/false.js
@@ -14,32 +14,15 @@
  * limitations under the License.
  */
 define([
-  "./abstract",
-  "./tree",
-  "./property",
-  "./and",
-  "./or",
-  "./not",
-  "./isEqual",
-  "./isIn",
-  "./true",
-  "./false"
-], function(
-    abstractFactory, treeFactory, propFactory,
-    andFactory, orFactory, notFactory, isEqFactory, isInFactory, trueFactory, falseFactory) {
+  "./abstract"
+], function(abstractFactory) {
 
   "use strict";
 
-  return {
-    "abstract": abstractFactory,
-    "tree": treeFactory,
-    "property": propFactory,
-    "and": andFactory,
-    "or": orFactory,
-    "not": notFactory,
-    "isEqual": isEqFactory,
-    "isIn": isInFactory,
-    "true": trueFactory,
-    "false": falseFactory
+  return function(context) {
+
+    var Abstract = context.get(abstractFactory);
+
+    return Abstract._core.False;
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
@@ -75,6 +75,11 @@ define([
         return this.value === value;
       },
 
+      _buildContentKey: function() {
+        var v = this.get("value");
+        return (this.property || "") + " " + (v ? v.key : "");
+      },
+
       type: /** @lends pentaho.type.filter.IsEqual.Type# */{
         id: module.id,
         alias: "=",

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
@@ -88,7 +88,8 @@ define([
             // may be `null`
             name: "value",
             nameAlias: "v",
-            type: "value"
+            type: "value",
+            isReadOnly: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isEqual.js
@@ -89,7 +89,8 @@ define([
             name: "value",
             nameAlias: "v",
             type: "value",
-            isReadOnly: true
+            isReadOnly: true,
+            isBoundary: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
@@ -82,6 +82,10 @@ define([
         return false;
       },
 
+      _buildContentKey: function() {
+        return (this.property || "") + " " + this.values.toArray(function(v) { return v.key; }).join(" ");
+      },
+
       type: /** @lends pentaho.type.filter.IsIn.Type# */{
         id: module.id,
         alias: "in",

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
@@ -94,7 +94,8 @@ define([
             // may be empty
             name: "values",
             nameAlias: "v",
-            type: ["element"]
+            type: ["element"],
+            isReadOnly: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
@@ -25,6 +25,10 @@ define([
 
     var PropertyFilter = context.get(propertyFactory);
 
+    // TODO: Opted to keep isIn @private, undocumented, for 7.1. Currently its use could cause problems with the
+    // DNF algorithm (simplifications are not performed).
+    // Also, existing containers don't currently generate filters with isIn.
+
     /**
      * @name pentaho.type.filter.IsIn.Type
      * @class
@@ -33,6 +37,8 @@ define([
      * @classDesc The type class of the membership filter type.
      *
      * For more information see {@link pentaho.type.filter.IsIn}.
+     *
+     * @private
      */
 
     /**
@@ -49,6 +55,8 @@ define([
      *
      * @constructor
      * @param {pentaho.type.filter.spec.IIsIn} [spec] - A membership filter specification.
+     *
+     * @private
      */
 
     return PropertyFilter.extend("pentaho.type.filter.IsIn", /** @lends pentaho.type.filter.IsIn# */{

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/isIn.js
@@ -95,7 +95,8 @@ define([
             name: "values",
             nameAlias: "v",
             type: ["element"],
-            isReadOnly: true
+            isReadOnly: true,
+            isBoundary: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
@@ -65,6 +65,10 @@ define([
         return this.getv("property");
       },
 
+      get isProperty() {
+        return true;
+      },
+
       // TODO: In the future, review if value argument should be of type pentaho.type.Value.
       /**
        * Determines if a property value is such that its element is selected by this filter.

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/property.js
@@ -103,7 +103,8 @@ define([
             name: "property",
             nameAlias: "p",
             type: "string",
-            isRequired: true
+            isRequired: true,
+            isReadOnly: true
           }
         ]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/filter/true.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/filter/true.js
@@ -14,32 +14,15 @@
  * limitations under the License.
  */
 define([
-  "./abstract",
-  "./tree",
-  "./property",
-  "./and",
-  "./or",
-  "./not",
-  "./isEqual",
-  "./isIn",
-  "./true",
-  "./false"
-], function(
-    abstractFactory, treeFactory, propFactory,
-    andFactory, orFactory, notFactory, isEqFactory, isInFactory, trueFactory, falseFactory) {
+  "./abstract"
+], function(abstractFactory) {
 
   "use strict";
 
-  return {
-    "abstract": abstractFactory,
-    "tree": treeFactory,
-    "property": propFactory,
-    "and": andFactory,
-    "or": orFactory,
-    "not": notFactory,
-    "isEqual": isEqFactory,
-    "isIn": isInFactory,
-    "true": trueFactory,
-    "false": falseFactory
+  return function(context) {
+
+    var Abstract = context.get(abstractFactory);
+
+    return Abstract._core.True;
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -67,6 +67,7 @@ define([
      * @constructor
      * @param {pentaho.type.spec.UList} [spec] The list specification or another compatible list instance.
      * @param {Object} [keyArgs] - The keyword arguments.
+     * @param {boolean} [keyArgs.isBoundary] - Indicates if the list should be a _boundary list_.
      * @param {boolean} [keyArgs.isReadOnly] - Indicates if the list should be a _read-only list_.
      *
      * @see pentaho.type.spec.IList
@@ -83,6 +84,7 @@ define([
         this._keys  = {};
 
         if(keyArgs) {
+          if(keyArgs.isBoundary) this._isBoundary = true;
           if(keyArgs.isReadOnly) this._isReadOnly = true;
         }
 
@@ -100,6 +102,7 @@ define([
       },
 
       _load: function(elemSpecs) {
+        var isBoundary = this._isBoundary;
         var i = -1;
         var L = elemSpecs.length;
         var elemType = this.type.of;
@@ -112,7 +115,7 @@ define([
             elems.push(elem);
             keys[key] = elem;
 
-            if(elem._addReference) elem._addReference(this);
+            if(!isBoundary && elem._addReference) elem._addReference(this);
           }
         }
       },
@@ -138,6 +141,24 @@ define([
       __assertEditable: function() {
         if(this._isReadOnly) throw new TypeError("The list is read-only.");
       },
+      // endregion
+
+      // region isBoundary
+      _isBoundary: false,
+
+      /**
+       * Gets a value that indicates if this list is a _boundary list_.
+       *
+       * A boundary list isolates the list holder from the list's elements.
+       *
+       * The validity of a _boundary list_ is not affected by the validity of its elements,
+       * Changes within the elements of _boundary list_ do not bubble to it.
+       *
+       * @type {boolean}
+       * @readOnly
+       */
+      get isBoundary() {
+        return this._isBoundary;
       },
       // endregion
 

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -95,8 +95,6 @@ define([
               (spec instanceof List) ? spec._elems :
               null;
 
-          // TODO: should not be created this way so that any current transaction is ignored.
-          // If and when changed, activate commented ou test "should be called when added to a list container".
           if(elemSpecs) this._load(elemSpecs);
         }
       },

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -688,6 +688,7 @@ define([
 
           if(!this.isRoot)
             throw error.operInvalid("Cannot only change the isBoundary attribute on a root property type.");
+
           if(this.hasDescendants)
             throw error.operInvalid("Cannot change the isBoundary attribute of a property type that has descendants.");
 

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -30,7 +30,7 @@ define([
   "use strict";
 
   var _defaultTypeMid = "string";
-  var _dynamicAttrNames = ["isRequired", "countMin", "countMax", "isApplicable", "isReadOnly"];
+  var _dynamicAttrNames = ["isRequired", "countMin", "countMax", "isApplicable", "isEnabled"];
 
   return function(context) {
 
@@ -1089,22 +1089,22 @@ define([
           },
 
           /**
-           * Evaluates the value of the `isReadOnly` attribute of a property of this type
+           * Evaluates the value of the `isEnabled` attribute of a property of this type
            * on a given owner complex value.
            *
-           * @name isReadOnlyEval
+           * @name isEnabledEval
            * @memberOf pentaho.type.Property.Type#
            * @param {pentaho.type.Complex} owner - The complex value that owns a property of this type.
-           * @return {boolean} The evaluated value of the `isReadOnly` attribute.
+           * @return {boolean} The evaluated value of the `isEnabled` attribute.
            *
            * @ignore
            */
 
           /**
            * Gets or sets a value, or function, that indicates if properties of this type
-           * _cannot_ be changed by a user, in a user interface.
+           * _can_ be changed by a user, in a user interface.
            *
-           * A property should be set read-only whenever its value is implied/imposed somehow,
+           * A property should be set disabled whenever its value is implied/imposed somehow,
            * and thus cannot be changed directly by the user through a user interface.
            *
            * ### This attribute is *Dynamic*
@@ -1119,11 +1119,11 @@ define([
            *
            * The value of a _monotonic_ attribute can change, but only in some, predetermined _monotonic_ direction.
            *
-           * In this case, a _property type_ marked as _not read-only_ can later be marked as _read-only_.
-           * However, a _property type_ marked as _read-only_ can no longer go back to being _not read-only_.
+           * In this case, a _property type_ marked as _enabled_ can later be marked as _not enabled_.
+           * However, a _property type_ marked as _not enabled_ can no longer go back to being _enabled_.
            *
            * Because this attribute is also _dynamic_,
-           * the actual `isReadOnly` values are only known
+           * the actual `isEnabled` values are only known
            * when evaluated for specific complex instances.
            * This behavior ensures that monotonic changes are deferred until evaluation.
            * No errors are thrown; non-monotonic changes simply don't take any effect.
@@ -1144,22 +1144,22 @@ define([
            * When set and the property already has [descendant]{@link pentaho.type.Type#hasDescendants} properties,
            * an error is thrown.
            *
-           * The default (root) `isReadOnly` attribute value is `false`.
+           * The default (root) `isEnabled` attribute value is `true`.
            *
-           * @name isReadOnly
+           * @name isEnabled
            * @memberOf pentaho.type.Property.Type#
            * @type undefined | boolean | pentaho.type.PropertyDynamicAttribute.<boolean>
            *
-           * @see pentaho.type.Complex#isReadOnly
-           * @see pentaho.type.spec.IPropertyTypeProto#isReadOnly
+           * @see pentaho.type.Complex#isEnabled
+           * @see pentaho.type.spec.IPropertyTypeProto#isEnabled
            */
-          isReadOnly: {
-            value: false,
+          isEnabled: {
+            value: true,
             cast: Boolean,
             combine: function(baseEval, localEval) {
               return function() {
-                // localEval is skipped if base is true.
-                return baseEval.call(this) || localEval.call(this);
+                // localEval is skipped if base is false.
+                return baseEval.call(this) && localEval.call(this);
               };
             }
           }

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -460,8 +460,7 @@ define([
 
         return Refinement.extend(name || "", instSpec);
       }
-    },
-    /* keyArgs: */{
+    }, /* keyArgs: */{
       isRoot: true
     }).implement({
       type: bundle.structured.value

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/SelectionModes.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/SelectionModes.js
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(function() {
+define([
+  "module",
+  "pentaho/util/logger",
+  "pentaho/debug",
+  "pentaho/debug/Levels"
+], function(module, logger, debugMgr, DebugLevels) {
   "use strict";
 
   /* eslint valid-jsdoc: 0 */
+
+  var _isDebugMode = debugMgr.testLevel(DebugLevels.debug, module);
 
   /**
    * The `SelectionModes` enumeration contains the collection of standard selection mode functions.
@@ -39,17 +46,27 @@ define(function() {
      * Otherwise, removes the input filter from the current selection filter.
      */
     toggle: function(current, input) {
+
+      if(_isDebugMode) logger.log("TOGGLE BEGIN");
+
       if(!input) return current;
 
       // Determine if all rows in input are currently selected.
       // current.include(input) ?
       // input \ current = 0
+      var unselectedInput = input.andNot(current).toDnf();
 
-      return input.andNot(current).toDnf().kind === "false"
+      if(_isDebugMode) logger.log(unselectedInput.kind === "false" ? "removing" : "adding");
+
+      var result = unselectedInput.kind === "false"
           // all input is already selected, so, actually, toggle it all
           ? SelectionModes.remove.call(this, current, input)
           // not all input is already selected, so, add what's missing first, before actually toggling.
-          : SelectionModes.add.call(this, current, input);
+          : SelectionModes.add.call(this, current, unselectedInput);
+
+      if(_isDebugMode) logger.log("TOGGLE END");
+
+      return result;
     },
 
     /**

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/SelectionModes.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/SelectionModes.js
@@ -41,20 +41,15 @@ define(function() {
     toggle: function(current, input) {
       if(!input) return current;
 
-      // TODO: Evaluating the filter on the current data is cheating...
-      // Should achieve this without leaving the _intensional_ realm.
-
       // Determine if all rows in input are currently selected.
-      var data = this.model.data;
-      if(!data) return current;
+      // current.include(input) ?
+      // input \ current = 0
 
-      var inputData = data.filter(input);
-      var currentInputData = inputData.filter(current);
-      var isAllInputSelected = (inputData.getNumberOfRows() === currentInputData.getNumberOfRows());
-
-      var selectionMode = isAllInputSelected ? SelectionModes.remove : SelectionModes.add;
-
-      return selectionMode.call(this, current, input);
+      return input.andNot(current).toDnf().kind === "false"
+          // all input is already selected, so, actually, toggle it all
+          ? SelectionModes.remove.call(this, current, input)
+          // not all input is already selected, so, add what's missing first, before actually toggling.
+          : SelectionModes.add.call(this, current, input);
     },
 
     /**
@@ -68,7 +63,7 @@ define(function() {
      * Removes the input filter from the current selection filter.
      */
     remove: function(current, input) {
-      return input ? current.and(input.negate()) : current;
+      return current.andNot(input);
     }
   };
 

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
@@ -127,7 +127,9 @@ define([
 
         var view = this.target;
 
-        view.selectionFilter = this.selectionMode.call(view, view.selectionFilter, this.dataFilter);
+        var selectionFilter = this.selectionMode.call(view, view.selectionFilter, this.dataFilter);
+
+        view.selectionFilter = selectionFilter && selectionFilter.toDnf();
 
         return null;
       }

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
@@ -42,7 +42,28 @@ define([
     return DataAction.extend(/** @lends  pentaho.visual.action.Select# */{
       type: {
         id: module.id,
-        alias: "select"
+        alias: "select",
+
+        /**
+         * Gets or sets the _default selection mode_ of this action.
+         *
+         * The default selection mode is {@link pentaho.visual.action.SelectionModes.replace}.
+         *
+         * Setting to a {@link Nully} value assumes the default selection mode.
+         *
+         * @type {!pentaho.visual.action.SelectionMode}
+         *
+         * @throws {pentaho.lang.ArgumentInvalidError} When attempting to set an invalid selection mode.
+         */
+        __defaultSelectionMode: null,
+
+        set defaultSelectionMode(value) {
+          this.__defaultSelectionMode = getSelectionMode(value);
+        },
+
+        get defaultSelectionMode() {
+          return this.__defaultSelectionMode || SelectionModes.replace;
+        }
       },
 
       /**
@@ -88,24 +109,12 @@ define([
        */
       get selectionMode() {
 
-        return this.__selectionMode || SelectionModes.replace;
+        return this.__selectionMode;
       },
 
       set selectionMode(value) {
 
         this._assertEditable();
-
-        if(value != null) {
-          if(typeof value === "string") {
-            if(!O.hasOwn(SelectionModes, value)) {
-              throw new ArgumentInvalidError("selectionMode", "Not one of the standard selection mode names.");
-            }
-            value = SelectionModes[value];
-
-          } else if(!F.is(value)) {
-            throw new ArgumentInvalidTypeError("selectionMode", ["string", "function"], typeof value);
-          }
-        }
 
         /**
          * The selection mode of the action.
@@ -113,7 +122,7 @@ define([
          * @type {?pentaho.visual.action.SelectionMode}
          * @private
          */
-        this.__selectionMode = value || null;
+        this.__selectionMode = getSelectionMode(value) || null;
       },
 
       /**
@@ -127,7 +136,8 @@ define([
 
         var view = this.target;
 
-        var selectionFilter = this.selectionMode.call(view, view.selectionFilter, this.dataFilter);
+        var selectionMode = this.selectionMode || getSelectionMode(this.type.defaultSelectionMode);
+        var selectionFilter = selectionMode.call(view, view.selectionFilter, this.dataFilter);
 
         view.selectionFilter = selectionFilter && selectionFilter.toDnf();
 
@@ -135,4 +145,19 @@ define([
       }
     });
   };
+
+  function getSelectionMode(value){
+    if(value != null) {
+      if(typeof value === "string") {
+        if(!O.hasOwn(SelectionModes, value)) {
+          throw new ArgumentInvalidError("selectionMode", "Not one of the standard selection mode names.");
+        }
+        value = SelectionModes[value];
+
+      } else if(!F.is(value)) {
+        throw new ArgumentInvalidTypeError("selectionMode", ["string", "function"], typeof value);
+      }
+    }
+    return value;
+  }
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
@@ -57,22 +57,11 @@ define([
      */
     var VisualModel = Model.extend(/** @lends pentaho.visual.base.Model# */{
 
-      constructor: function() {
-
-        this.base.apply(this, arguments);
-
-        // Create default visual role mappings
-        this.type.each(function(propType) {
-          if(propType.type.isSubtypeOf(Mapping.type)) {
-            // Visual role
-            var mapping = this.get(propType);
-            if(!mapping) {
-              // Create default instance without firing events
-              this._values[propType.name] = mapping = propType.toValue({});
-              mapping._addReference(this, propType);
-            }
-          }
-        }, this);
+      _initValue: function(value, propType) {
+        // Empty visual role mapping?
+        return !value && propType.type.isSubtypeOf(Mapping.type)
+            ? propType.toValue({})
+            : value;
       },
 
       // region serialization

--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.views.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.views.conf.js
@@ -24,6 +24,7 @@ define([
   var vizApiFont = "10px OpenSansRegular";
   var maxHorizontalTextWidth = 117;
   var pvc = null;
+  var pv = null;
   var numberFormatCache = {};
 
   var numberStyle = {
@@ -96,7 +97,7 @@ define([
                 item: {
                   // Trim label text
                   labelText: function() {
-                    if (!pvc) {
+                    if(!pvc) {
                       pvc = require("cdf/lib/CCC/pvc");
                     }
                     var text = this.base();
@@ -158,7 +159,7 @@ define([
             },
             // Disable "smart" Date value type on discrete cartesian axis formatting...
             discreteAxisTickFormatter: function(value, absLabel) {
-              if (arguments.length > 2) {
+              if(arguments.length > 2) {
                 // Being called for discrete scale / Date formatting...
                 return String(value);
               }
@@ -269,7 +270,31 @@ define([
             dot_lineWidth: 0,
             dot_fillStyle: function() {
               var c = this.delegate();
-              return this.finished(c && !this.scene.isActive ? c.alpha(0.5) : c);
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                if(sign.mayShowNotAmongSelected(scene)) {
+
+                  if(sign.mayShowActive(scene, true)) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                } else if(sign.mayShowActive(scene, true)) {
+                  // active || (active & selected)
+                } else {
+                  c = c.alpha(0.5);
+                }
+                // else (normal || selected)
+              }
+
+              return this.finished(c);
             }
           }
         }
@@ -348,13 +373,37 @@ define([
             barSizeSpacing: 2,
             barSizeMin:     4,
             barSizeMax:     150,
+
             // No stroke
             bar_lineWidth: function() {
               return this.finished(0);
             },
             bar_fillStyle: function() {
+
               var c = this.delegate();
-              return this.finished(c && this.scene.isActive ? c.alpha(0.5) : c);
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                if(sign.mayShowNotAmongSelected(scene)) {
+                  if(scene.isActive) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                } else if(sign.mayShowActive(scene, true)) {
+                  // active || (active & selected)
+                  c = c.alpha(0.5);
+                }
+                // else (normal || selected)
+              }
+
+              return this.finished(c);
             }
           }
         }
@@ -375,14 +424,14 @@ define([
 
             // . centered grid lines
             xAxisGrid_visible: function() {
-              if (this.panel.axes.base.isDiscrete()) {
+              if(this.panel.axes.base.isDiscrete()) {
                 return this.index > 0;
               }
               return this.delegate();
             },
             xAxisGrid_left: function() {
               var left = this.delegate();
-              if (this.panel.axes.base.isDiscrete()) {
+              if(this.panel.axes.base.isDiscrete()) {
                 var halfStep = this.panel.axes.base.scale.range().step / 2;
                 return left - halfStep;
               }
@@ -394,10 +443,60 @@ define([
             dotsVisible: false,
 
             // . visible only on hover
-            dot_fillStyle:   function() { return this.finished(this.scene.isActive ? "white" : this.delegate()); },
+            dot_fillStyle:   function() {
+              var c = this.delegate();
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                if(sign.mayShowNotAmongSelected(scene)) {
+
+                  if(sign.mayShowActive(scene, true)) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                } else if(sign.mayShowActive(scene, true)) {
+                  // active || (active & selected)
+                  c = "white";
+                }
+                // else (normal || selected)
+              }
+
+              return this.finished(c);
+            },
+
+            dot_strokeStyle: function() {
+              var c = this.delegate();
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                // Not among selected
+                if(sign.mayShowNotAmongSelected(scene)) {
+
+                  if(sign.mayShowActive(scene, true)) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                }
+              }
+
+              return this.finished(c);
+            },
             dot_lineWidth:   function() { return this.finished(2); },
             dot_shapeRadius: function() { return this.finished(5); },
-            dot_strokeStyle: function() { return this.finished(this.delegate()); },
 
             // . line
             linesVisible: true,
@@ -442,11 +541,31 @@ define([
             activeSliceRadius: 0,
 
             // . slice
-            slice_ibits: 0,
-            slice_imask: "ShowsActivity",
             slice_fillStyle: function() {
               var c = this.delegate();
-              return this.finished(c && this.scene.isActive ? c.alpha(0.5) : c);
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                if(sign.mayShowNotAmongSelected(scene)) {
+                  if(scene.isActive) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                } else if(sign.mayShowActive(scene, true)) {
+                  // active || (active & selected)
+                  c = c.alpha(0.85);
+                }
+                // else (normal || selected)
+              }
+
+              return this.finished(c);
             }
           }
         }
@@ -512,7 +631,29 @@ define([
             dot_lineWidth: 0,
             dot_fillStyle: function() {
               var c = this.delegate();
-              return this.finished(c && this.scene.isActive ? c.alpha(0.5) : c);
+              var scene = this.scene;
+              var sign = this.sign;
+
+              if(sign.showsInteraction()) {
+
+                if(sign.mayShowNotAmongSelected(scene)) {
+                  if(scene.isActive) {
+                    // not selected & active
+                    if(!pv) pv = require("cdf/lib/CCC/protovis");
+
+                    c = pv.Color.names.darkgray.darker(2).alpha(0.8);
+                  } else {
+                    // not selected
+                    c = pvc.toGrayScale(c, -0.3);
+                  }
+                } else if(sign.mayShowActive(scene, true)) {
+                  // active || (active & selected)
+                  c = c.alpha(0.5);
+                }
+                // else (normal || selected)
+              }
+
+              return this.finished(c);
             }
           }
         }
@@ -521,14 +662,14 @@ define([
   };
 
   function getNumberFormatter(precision, base) {
-    if (!pvc) {
+    if(!pvc) {
       pvc = require("cdf/lib/CCC/pvc");
     }
 
     var useAbrev = (base >= 1000);
     var key = useAbrev + "|" + precision;
     var numberFormat = numberFormatCache[key];
-    if (!numberFormat) {
+    if(!numberFormat) {
       // #,0 A
       // #,0.0 A
       // #,0.00 A

--- a/impl/client/src/test/config/javascript/context-begin.js
+++ b/impl/client/src/test/config/javascript/context-begin.js
@@ -107,4 +107,4 @@ var KARMA_DEBUG = false;
  * // Only pentaho/type spec files
  * var DEV_SPEC_FILTER = /^pentaho\/type/;
  */
-var DEV_SPEC_FILTER = null;
+var DEV_SPEC_FILTER = /filter.abstract/;

--- a/impl/client/src/test/config/javascript/context-begin.js
+++ b/impl/client/src/test/config/javascript/context-begin.js
@@ -107,4 +107,4 @@ var KARMA_DEBUG = false;
  * // Only pentaho/type spec files
  * var DEV_SPEC_FILTER = /^pentaho\/type/;
  */
-var DEV_SPEC_FILTER = /filter.abstract/;
+var DEV_SPEC_FILTER = null;

--- a/impl/client/src/test/javascript/pentaho/type/_type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/_type.spec.js
@@ -1594,7 +1594,7 @@ define([
         subSubType.to(value);
 
         expect(createSpy).not.toHaveBeenCalled();
-        expect(subSubType.create).toHaveBeenCalledWith(value);
+        expect(subSubType.create).toHaveBeenCalledWith(value, undefined);
       });
 
       it("casts a nully into `null`", function() {

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -381,6 +381,21 @@ define([
           expect(value.value).toBe("1");
         });
 
+        it("should throw a TypeError if the property is read-only", function() {
+
+          var Derived = Complex.extend({
+            type: {props: [{name: "x", type: "string", isReadOnly: true, value: "2"}]}
+          });
+
+          var derived = new Derived();
+
+          expect(function() {
+            derived.set("x", "1");
+          }).toThrowError(TypeError);
+
+          expect(derived.x).toBe("2");
+        });
+
         it("should set the value of an existing list property", function() {
           var Derived = Complex.extend({
             type: {props: [{name: "x", type: ["string"]}]}
@@ -1171,6 +1186,31 @@ define([
     });
 
     describe("Property Attributes", function() {
+
+      describe("Property#isReadOnly", function() {
+
+        it("should make the list of a read-only list property, read-only", function() {
+
+          var Derived = Complex.extend({
+            type: {props: [{name: "x", type: ["string"], isReadOnly: true}]}
+          });
+
+          var derived = new Derived();
+
+          expect(derived.x.isReadOnly).toBe(true);
+        });
+
+        it("should make the list of a writable list property, writable", function() {
+
+          var Derived = Complex.extend({
+            type: {props: [{name: "x", type: ["string"]}]}
+          });
+
+          var derived = new Derived();
+
+          expect(derived.x.isReadOnly).toBe(false);
+        });
+      });
 
       describe("#isApplicable(name)", function() {
         it("should return the evaluated static value of an existing property", function() {

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -1233,22 +1233,22 @@ define([
         });
       }); // end applicable
 
-      describe("#isReadOnly(name)", function() {
+      describe("#isEnabled(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", isReadOnly: false}]}
+            type: {props: [{name: "x", isEnabled: true}]}
           });
 
           var derived = new Derived();
 
-          expect(derived.isReadOnly("x")).toBe(false);
+          expect(derived.isEnabled("x")).toBe(true);
         });
 
         it("should return the evaluated dynamic value of an existing property", function() {
           var Derived = Complex.extend({
             type: {
               props: [{
-                name: "x", isReadOnly: function() {
+                name: "x", isEnabled: function() {
                   return this.foo;
                 }
               }]
@@ -1257,13 +1257,13 @@ define([
 
           var derived = new Derived();
 
-          derived.foo = true;
-
-          expect(derived.isReadOnly("x")).toBe(true);
-
           derived.foo = false;
 
-          expect(derived.isReadOnly("x")).toBe(false);
+          expect(derived.isEnabled("x")).toBe(false);
+
+          derived.foo = true;
+
+          expect(derived.isEnabled("x")).toBe(true);
         });
 
         it("should throw when given the name of an undefined property", function() {
@@ -1274,7 +1274,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isReadOnly("y");
+            derived.isEnabled("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1289,10 +1289,10 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isReadOnly(Other.type.get("x"));
+            derived.isEnabled(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end isReadOnly
+      }); // end isEnabled
 
       describe("#isRequired(name)", function() {
         it("should return the evaluated static value of an existing property", function() {

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -1690,20 +1690,17 @@ define([
         expect(value._addReference).toHaveBeenCalledWith(container, Container.type.get("a"));
       });
 
-      // TODO: if an when lists are created without a changeset/txn, uncomment this.
-      /*
       it("should be called when added to a list container", function() {
         var Derived = Complex.extend();
         var Container = Complex.extend({type: {props: [{name: "as", type: [Derived]}]}});
 
+        spyOn(Derived.prototype, "_addReference");
+
         var value = new Derived();
         var container = new Container({as: [value]});
 
-        spyOn(Derived.prototype, "_addReference");
-
-        expect(value._addReference).toHaveBeenCalledWith(container.as, null);
+        expect(value._addReference).toHaveBeenCalledWith(container.as);
       });
-      */
     });
   }); // pentaho.type.Complex
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
@@ -193,7 +193,7 @@ define([
         });
       });
 
-      it("should convert an empty `and` to false", function() {
+      it("should convert an empty `and` to true", function() {
 
         expectDnf({
           _: "and"

--- a/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
@@ -166,7 +166,7 @@ define([
       });
     }); // #visit
 
-    fdescribe("#toDnf()", function() {
+    describe("#toDnf()", function() {
 
       function createFilter(spec) {
         return AbstractFilter.type.create(spec);

--- a/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/abstract.spec.js
@@ -184,15 +184,47 @@ define([
         }
       }
 
-      it("should preserve a filter already in DNF", function() {
+      it("should convert an empty `or` to false", function() {
+
         expectDnf({
           _: "or"
         }, {
-          _: "or"
+          _: "false"
+        });
+      });
+
+      it("should convert an empty `and` to false", function() {
+
+        expectDnf({
+          _: "and"
+        }, {
+          _: "true"
+        });
+      });
+
+      it("should preserve a filter already in DNF", function() {
+
+        expectDnf({
+          _: "or",
+          o: [
+            {
+              _: "and",
+              o: [{_: "=", p: "a", v: 1}]
+            }
+          ]
+        }, {
+          _: "or",
+          o: [
+            {
+              _: "and",
+              o: [{_: "=", p: "a", v: 1}]
+            }
+          ]
         });
       });
 
       it("should apply De Morgan Rule 1 - NOT over AND", function() {
+
         expectDnf({
           _: "not",
           o: {_: "and", o: [{_: "=", p: "a", v: 1}]}
@@ -210,6 +242,7 @@ define([
       });
 
       it("should apply De Morgan Rule 2 - NOT over OR", function() {
+
         expectDnf({
           _: "not",
           o: {
@@ -235,6 +268,7 @@ define([
       });
 
       it("should eliminate double-negations", function() {
+
         expectDnf({
           _: "not",
           o: {
@@ -260,6 +294,7 @@ define([
       });
 
       it("should distribute AND over OR", function() {
+
         expectDnf({
           _: "and",
           o: [
@@ -290,6 +325,7 @@ define([
       });
 
       it("should distribute AND over OR - multiple OR terms", function() {
+
         expectDnf({
           _: "and",
           o: [
@@ -321,6 +357,7 @@ define([
       });
 
       it("should distribute AND over OR - multiple AND and OR terms", function() {
+
         expectDnf({
           _: "and",
           o: [
@@ -375,6 +412,7 @@ define([
       });
 
       it("should allow subtraction", function() {
+
         expectDnf({
           _: "and",
           o: [
@@ -391,25 +429,49 @@ define([
             }
           ]
         }, {
-          _: "or"
+          _: "false"
         });
+      });
 
-        var result = {
-          _: 'or',
+      it("should allow subtraction ii", function() {
+        // tuple 1 - {a: 1, b: 2}
+        var tuple1 = {
+          _: "and",
           o: [
-            {
-              _: 'and',
-              o: [
-                {_: '=', p: 'a', v: 1 },
-                { _: 'not', o: { _: '=', p: 'a', v: 1 }},
-                { _: 'not', o: { _: '=', p: 'b', v: 2 }}
-              ]
-            }
+            {_: "=", p: "a", v: 1},
+            {_: "=", p: "b", v: 2}
           ]
         };
 
+        // tuple 2 - {a: 3, b: 4}
+        var tuple2 = {
+          _: "and",
+          o: [
+            {_: "=", p: "a", v: 3},
+            {_: "=", p: "b", v: 4}
+          ]
+        };
+
+        // tuple 3 - {a: 5, b: 6}
+        var tuple3 = {
+          _: "and",
+          o: [
+            {_: "=", p: "a", v: 5},
+            {_: "=", p: "b", v: 6}
+          ]
+        };
+
+        var originalDnf = {_: "or", o: [tuple1, tuple2]}
+
+        var removeDnf = {
+          _: "or",
+          o: [tuple1, tuple3]
+        };
+
+        expectDnf(
+          {_: "and", o: [originalDnf, {_: "not", o: removeDnf}]},
+          {_: "or", o: [tuple2]});
       });
     });
-
   }); // pentaho.type.filter.Abstract
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
@@ -231,7 +231,6 @@ define([
       });
     }); // #and
 
-
     describe("#toSpec", function() {
       var filter;
 
@@ -297,6 +296,32 @@ define([
 
     }); // #toSpec
 
+    describe("#contentKey", function() {
+
+      it("should return '(and filter1 filter2)'", function() {
+        var filter  = new AndFilter({operands: [
+          {_: "=", p: "a", v: 1},
+          {_: "=", p: "b", v: 2}
+        ]});
+
+        expect(filter.contentKey).toBe("(and (= a 1) (= b 2))");
+      });
+
+      it("should return '(and ) when there are no operands'", function() {
+        var filter  = new AndFilter({});
+
+        expect(filter.contentKey).toBe("(and )");
+      });
+
+      it("should sort child content keys alphabetically", function() {
+        var filter  = new AndFilter({operands: [
+          {_: "=", p: "b", v: 2},
+          {_: "=", p: "a", v: 1}
+        ]});
+
+        expect(filter.contentKey).toBe("(and (= a 1) (= b 2))");
+      });
+    });
   }); // pentaho.type.filter.And
 
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/and.spec.js
@@ -307,10 +307,10 @@ define([
         expect(filter.contentKey).toBe("(and (= a 1) (= b 2))");
       });
 
-      it("should return '(and ) when there are no operands'", function() {
+      it("should return '(and) when there are no operands'", function() {
         var filter  = new AndFilter({});
 
-        expect(filter.contentKey).toBe("(and )");
+        expect(filter.contentKey).toBe("(and)");
       });
 
       it("should sort child content keys alphabetically", function() {

--- a/impl/client/src/test/javascript/pentaho/type/filter/false.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/false.spec.js
@@ -1,0 +1,132 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/type/filter/true",
+  "pentaho/type/filter/false",
+  "pentaho/type/Context",
+  "pentaho/type/complex"
+], function(trueFactory, falseFactory, Context, complexFactory) {
+
+  "use strict";
+
+  /* global describe:true, it:true, expect:true, beforeEach:true*/
+
+  describe("pentaho.type.filter.False", function() {
+
+    var context = new Context();
+    var TrueFilter = context.get(trueFactory);
+    var FalseFilter = context.get(falseFactory);
+    var Complex = context.get(complexFactory);
+
+    var ProductSummary = Complex.extend({
+      type: {
+        props: [
+          {name: "name", type: "string", label: "Name"},
+          {name: "sales", type: "number", label: "Sales"},
+          {name: "inStock", type: "boolean", label: "In Stock"}
+        ]
+      }
+    });
+
+    describe("#kind", function() {
+
+      it("should return 'false'", function() {
+        var filter = new FalseFilter();
+        expect(filter.kind).toBe("false");
+      });
+    });
+
+    describe("#contains(elem)", function() {
+
+      it("should return `false` for any element", function() {
+
+        var filter  = new FalseFilter();
+
+        var elem = new ProductSummary({name: "A", sales: 12000, inStock: true});
+        var result = filter.contains(elem);
+
+        expect(result).toBe(false);
+
+        // ---
+
+        elem = new ProductSummary({name: "B", sales: 0, inStock: false});
+        result = filter.contains(elem);
+
+        expect(result).toBe(false);
+      });
+    }); // #contains
+
+    describe("#negate()", function() {
+      it("should return a `True` filter", function() {
+        var filter = new FalseFilter();
+
+        var invFilter = filter.negate();
+
+        expect(invFilter instanceof TrueFilter);
+      });
+    }); // #negate
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        filter = new FalseFilter();
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("false");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/false");
+        });
+      });
+    }); // #toSpec
+
+    describe("#contentKey", function() {
+
+      it("should return '(false)'", function() {
+        var filter  = new FalseFilter();
+
+        expect(filter.contentKey).toBe("(false)");
+      });
+    });
+  }); // pentaho.type.filter.False
+});

--- a/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
@@ -205,5 +205,26 @@ define([
         expect(result).toBe(false);
       });
     }); // #contains
+
+    describe("#contentKey", function() {
+
+      it("should return '(= propName valueKey)'", function() {
+        var filter  = new IsEqualFilter({property: "name", value: 1});
+
+        expect(filter.contentKey).toBe("(= name 1)");
+      });
+
+      it("should return '(= propName ) when no value is set'", function() {
+        var filter  = new IsEqualFilter({property: "name"});
+
+        expect(filter.contentKey).toBe("(= name )");
+      });
+
+      it("should return '(=  valueKey) when no property is set'", function() {
+        var filter  = new IsEqualFilter({value: 1});
+
+        expect(filter.contentKey).toBe("(=  1)");
+      });
+    });
   }); // pentaho.type.filter.IsEqual
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isEqual.spec.js
@@ -225,6 +225,12 @@ define([
 
         expect(filter.contentKey).toBe("(=  1)");
       });
+
+      it("should return '(=  ) when no property or value are set'", function() {
+        var filter  = new IsEqualFilter();
+
+        expect(filter.contentKey).toBe("(=  )");
+      });
     });
   }); // pentaho.type.filter.IsEqual
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
@@ -249,5 +249,25 @@ define([
 
     }); // #toSpec
 
+    describe("#contentKey", function() {
+
+      it("should return '(= propName value1Key value2Key)'", function() {
+        var filter  = new IsInFilter({property: "name", values: [1, 2]});
+
+        expect(filter.contentKey).toBe("(in name 1 2)");
+      });
+
+      it("should return '(= propName ) when no values are set'", function() {
+        var filter  = new IsInFilter({property: "name"});
+
+        expect(filter.contentKey).toBe("(in name )");
+      });
+
+      it("should return '(=  valueKey) when no property is set'", function() {
+        var filter  = new IsInFilter({values: [1, 2]});
+
+        expect(filter.contentKey).toBe("(in  1 2)");
+      });
+    });
   }); // pentaho.type.filter.IsIn
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/isIn.spec.js
@@ -268,6 +268,12 @@ define([
 
         expect(filter.contentKey).toBe("(in  1 2)");
       });
+
+      it("should return '(in  ) when no property or values are set'", function() {
+        var filter  = new IsInFilter();
+
+        expect(filter.contentKey).toBe("(in  )");
+      });
     });
   }); // pentaho.type.filter.IsIn
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
@@ -174,8 +174,7 @@ define([
 
         var result = filter.visit(transf);
 
-        expect(result).not.toBe(filter);
-        expect(result.toSpec()).toEqual(filter.toSpec());
+        expect(result).toBe(filter);
       });
     }); // #_visitDefault
 

--- a/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
@@ -251,10 +251,10 @@ define([
         expect(filter.contentKey).toBe("(not (= a 1))");
       });
 
-      it("should return '(not ) when operand is not set'", function() {
+      it("should return '(not) when operand is not set'", function() {
         var filter  = new NotFilter({});
 
-        expect(filter.contentKey).toBe("(not )");
+        expect(filter.contentKey).toBe("(not)");
       });
 
       it("should refresh contentKey when operand is changed", function() {

--- a/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
@@ -256,28 +256,6 @@ define([
 
         expect(filter.contentKey).toBe("(not)");
       });
-
-      it("should refresh contentKey when operand is changed", function() {
-        var filter  = new NotFilter({operand: {_: "=", p: "a", v: "1"}});
-
-        var contentKey0 = filter.contentKey;
-
-        filter.operand = {_: "=", p: "b", v: "2"};
-
-        expect(filter.contentKey).not.toBe(contentKey0);
-        expect(filter.contentKey).toBe("(not (= b 2))");
-      });
-
-      it("should refresh contentKey when the operand's properties are changed", function() {
-        var filter  = new NotFilter({operand: {_: "=", p: "a", v: "1"}});
-
-        var contentKey0 = filter.contentKey;
-
-        filter.operand.value = 2;
-
-        expect(filter.contentKey).not.toBe(contentKey0);
-        expect(filter.contentKey).toBe("(not (= a 2))");
-      });
     });
   }); // pentaho.type.filter.Not
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/not.spec.js
@@ -36,8 +36,8 @@ define([
     var ProductSummary = Complex.extend({
       type: {
         props: [
-          {name: "name",    type: "string",  label: "Name"    },
-          {name: "sales",   type: "number",  label: "Sales"   },
+          {name: "name", type: "string", label: "Name"},
+          {name: "sales", type: "number", label: "Sales"},
           {name: "inStock", type: "boolean", label: "In Stock"}
         ]
       }
@@ -166,15 +166,16 @@ define([
         expect(result.operand).toBe(oper2);
       });
 
-      it("should return `this` when the operand is not transformed by the transformer", function() {
-        var oper1  = new CustomFilter();
+      it("should return a clone when the operand is not transformed by the transformer", function() {
+        var oper1 = new CustomFilter();
         var filter = new NotFilter({operand: oper1});
 
         var transf = function() { return null; };
 
         var result = filter.visit(transf);
 
-        expect(result).toBe(filter);
+        expect(result).not.toBe(filter);
+        expect(result.toSpec()).toEqual(filter.toSpec());
       });
     }); // #_visitDefault
 
@@ -242,5 +243,41 @@ define([
 
     }); // #toSpec
 
+    describe("#contentKey", function() {
+
+      it("should return '(not filter)'", function() {
+        var filter  = new NotFilter({operand: {_: "=", p: "a", v: 1}});
+
+        expect(filter.contentKey).toBe("(not (= a 1))");
+      });
+
+      it("should return '(not ) when operand is not set'", function() {
+        var filter  = new NotFilter({});
+
+        expect(filter.contentKey).toBe("(not )");
+      });
+
+      it("should refresh contentKey when operand is changed", function() {
+        var filter  = new NotFilter({operand: {_: "=", p: "a", v: "1"}});
+
+        var contentKey0 = filter.contentKey;
+
+        filter.operand = {_: "=", p: "b", v: "2"};
+
+        expect(filter.contentKey).not.toBe(contentKey0);
+        expect(filter.contentKey).toBe("(not (= b 2))");
+      });
+
+      it("should refresh contentKey when the operand's properties are changed", function() {
+        var filter  = new NotFilter({operand: {_: "=", p: "a", v: "1"}});
+
+        var contentKey0 = filter.contentKey;
+
+        filter.operand.value = 2;
+
+        expect(filter.contentKey).not.toBe(contentKey0);
+        expect(filter.contentKey).toBe("(not (= a 2))");
+      });
+    });
   }); // pentaho.type.filter.Not
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
@@ -307,10 +307,10 @@ define([
         expect(filter.contentKey).toBe("(or (= a 1) (= b 2))");
       });
 
-      it("should return '(or ) when there are no operands'", function() {
+      it("should return '(or) when there are no operands'", function() {
         var filter  = new OrFilter({});
 
-        expect(filter.contentKey).toBe("(or )");
+        expect(filter.contentKey).toBe("(or)");
       });
 
       it("should sort child content keys alphabetically", function() {

--- a/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/or.spec.js
@@ -296,5 +296,31 @@ define([
 
     }); // #toSpec
 
+    describe("#contentKey", function() {
+
+      it("should return '(or filter1 filter2)'", function() {
+        var filter  = new OrFilter({operands: [
+          {_: "=", p: "a", v: 1},
+          {_: "=", p: "b", v: 2}
+        ]});
+
+        expect(filter.contentKey).toBe("(or (= a 1) (= b 2))");
+      });
+
+      it("should return '(or ) when there are no operands'", function() {
+        var filter  = new OrFilter({});
+
+        expect(filter.contentKey).toBe("(or )");
+      });
+
+      it("should sort child content keys alphabetically", function() {
+        var filter  = new OrFilter({operands: [
+          {_: "=", p: "b", v: 2},
+          {_: "=", p: "a", v: 1}
+        ]});
+
+        expect(filter.contentKey).toBe("(or (= a 1) (= b 2))");
+      });
+    });
   }); // pentaho.type.filter.Or
 });

--- a/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
@@ -98,7 +98,7 @@ define([
         expect(filter3.operands.at(0)).toBe(filter2);
       });
 
-      it("should return this when no operand is transformed by the transformer", function() {
+      it("should return a clone when no operand is transformed by the transformer", function() {
         var filter1 = new CustomTreeFilter();
 
         var transf = jasmine.createSpy().and.returnValue(null);
@@ -107,7 +107,8 @@ define([
 
         var filter2 = filter1.visit(transf);
 
-        expect(filter2).toBe(filter1);
+        expect(filter2).not.toBe(filter1);
+        expect(filter2.toSpec()).toEqual(filter1.toSpec());
       });
     }); // #_visitDefault
 
@@ -120,7 +121,7 @@ define([
         }).toThrow(errorMatch.argRequired("transformer"));
       });
 
-      it("should return null if none of the operands is transformed", function() {
+      it("should return null when there are no operands", function() {
         var filter = new CustomTreeFilter();
 
         var transf = jasmine.createSpy().and.returnValue(null);
@@ -151,9 +152,11 @@ define([
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(3);
 
-        expect(result[0]).toBe(oper1);
+        expect(result[0]).not.toBe(oper1);
+        expect(result[0].toSpec()).toEqual(oper1.toSpec());
         expect(result[1]).toBe(oper4);
-        expect(result[2]).toBe(oper3);
+        expect(result[2]).not.toBe(oper3);
+        expect(result[2].toSpec()).toEqual(oper3.toSpec());
       });
 
       it("should consider elements filtered out by `keyArgs.where` as a modification and " +
@@ -170,8 +173,10 @@ define([
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(2);
 
-        expect(result[0]).toBe(oper1);
-        expect(result[1]).toBe(oper3);
+        expect(result[0]).not.toBe(oper1);
+        expect(result[0].toSpec()).toEqual(oper1.toSpec());
+        expect(result[1]).not.toBe(oper3);
+        expect(result[1].toSpec()).toEqual(oper3.toSpec());
       });
     }); // #visitOperands
   }); // pentaho.type.filter.Tree

--- a/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/tree.spec.js
@@ -98,7 +98,7 @@ define([
         expect(filter3.operands.at(0)).toBe(filter2);
       });
 
-      it("should return a clone when no operand is transformed by the transformer", function() {
+      it("should return `this` when no operand is transformed by the transformer", function() {
         var filter1 = new CustomTreeFilter();
 
         var transf = jasmine.createSpy().and.returnValue(null);
@@ -107,8 +107,7 @@ define([
 
         var filter2 = filter1.visit(transf);
 
-        expect(filter2).not.toBe(filter1);
-        expect(filter2.toSpec()).toEqual(filter1.toSpec());
+        expect(filter2).toBe(filter1);
       });
     }); // #_visitDefault
 
@@ -152,11 +151,9 @@ define([
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(3);
 
-        expect(result[0]).not.toBe(oper1);
-        expect(result[0].toSpec()).toEqual(oper1.toSpec());
+        expect(result[0]).toBe(oper1);
         expect(result[1]).toBe(oper4);
-        expect(result[2]).not.toBe(oper3);
-        expect(result[2].toSpec()).toEqual(oper3.toSpec());
+        expect(result[2]).toBe(oper3);
       });
 
       it("should consider elements filtered out by `keyArgs.where` as a modification and " +
@@ -173,10 +170,8 @@ define([
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(2);
 
-        expect(result[0]).not.toBe(oper1);
-        expect(result[0].toSpec()).toEqual(oper1.toSpec());
-        expect(result[1]).not.toBe(oper3);
-        expect(result[1].toSpec()).toEqual(oper3.toSpec());
+        expect(result[0]).toBe(oper1);
+        expect(result[1]).toBe(oper3);
       });
     }); // #visitOperands
   }); // pentaho.type.filter.Tree

--- a/impl/client/src/test/javascript/pentaho/type/filter/true.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/filter/true.spec.js
@@ -1,0 +1,132 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "pentaho/type/filter/true",
+  "pentaho/type/filter/false",
+  "pentaho/type/Context",
+  "pentaho/type/complex"
+], function(trueFactory, falseFactory, Context, complexFactory) {
+
+  "use strict";
+
+  /* global describe:true, it:true, expect:true, beforeEach:true*/
+
+  describe("pentaho.type.filter.True", function() {
+
+    var context = new Context();
+    var TrueFilter = context.get(trueFactory);
+    var FalseFilter = context.get(falseFactory);
+    var Complex = context.get(complexFactory);
+
+    var ProductSummary = Complex.extend({
+      type: {
+        props: [
+          {name: "name", type: "string", label: "Name"},
+          {name: "sales", type: "number", label: "Sales"},
+          {name: "inStock", type: "boolean", label: "In Stock"}
+        ]
+      }
+    });
+
+    describe("#kind", function() {
+
+      it("should return 'true'", function() {
+        var filter = new TrueFilter();
+        expect(filter.kind).toBe("true");
+      });
+    });
+
+    describe("#contains(elem)", function() {
+
+      it("should return `true` for any element", function() {
+
+        var filter  = new TrueFilter();
+
+        var elem = new ProductSummary({name: "A", sales: 12000, inStock: true});
+        var result = filter.contains(elem);
+
+        expect(result).toBe(true);
+
+        // ---
+
+        elem = new ProductSummary({name: "B", sales: 0, inStock: false});
+        result = filter.contains(elem);
+
+        expect(result).toBe(true);
+      });
+    }); // #contains
+
+    describe("#negate()", function() {
+      it("should return a `False` filter", function() {
+        var filter = new TrueFilter();
+
+        var invFilter = filter.negate();
+
+        expect(invFilter instanceof FalseFilter);
+      });
+    }); // #negate
+
+    describe("#toSpec", function() {
+      var filter;
+
+      beforeEach(function() {
+        filter = new TrueFilter();
+      });
+
+      describe("when invoked without keyword arguments", function() {
+        var filterSpec;
+
+        beforeEach(function() {
+          filterSpec = filter.toSpec();
+        });
+
+        it("should omit the type", function() {
+          expect(filterSpec._).toBeUndefined();
+        });
+      });
+
+      describe("when invoked with the keyword argument `forceType` set to `true`", function() {
+        it("should specify the type by the #alias", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true
+          });
+
+          expect(filterSpec._).toBe("true");
+        });
+
+        it("should specify the type by the #id when the `noAlias` option is additionally specified", function() {
+
+          var filterSpec = filter.toSpec({
+            forceType: true,
+            noAlias: true
+          });
+
+          expect(filterSpec._).toBe("pentaho/type/filter/true");
+        });
+      });
+    }); // #toSpec
+
+    describe("#contentKey", function() {
+
+      it("should return '(true)'", function() {
+        var filter  = new TrueFilter();
+
+        expect(filter.contentKey).toBe("(true)");
+      });
+    });
+  }); // pentaho.type.filter.True
+});

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
@@ -579,9 +579,9 @@ define([
 
       });
 
-      describe("#isReadOnly", function() {
+      describe("#isEnabled", function() {
 
-        itDynamicAttribute("isReadOnly", true);
+        itDynamicAttribute("isEnabled", false);
 
       });
 

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.spec.js
@@ -1038,77 +1038,77 @@ define([
         });
       }); // end #isApplicable
 
-      describe("#isReadOnly - ", function() {
+      describe("#isEnabled - ", function() {
         it("should not allow changing the Property.type attribute value", function() {
           var propType = Property.type;
-          var isReadOnly = propType.isReadOnly;
-          propType.isReadOnly = true;
-          expect(propType.isReadOnly).toBe(isReadOnly);
+          var isEnabled = propType.isEnabled;
+          propType.isEnabled = false;
+          expect(propType.isEnabled).toBe(isEnabled);
         });
 
         it("should default to an unset local value", function() {
           var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo"});
-          expect(propType.isReadOnly).toBe(undefined);
+          expect(propType.isEnabled).toBe(undefined);
         });
 
         it("should ignore setting to undefined", function() {
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo", isReadOnly: true});
-          expect(propType.isReadOnly).toBe(true);
-          propType.isReadOnly = undefined;
-          expect(propType.isReadOnly).toBe(true);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo", isEnabled: false});
+          expect(propType.isEnabled).toBe(false);
+          propType.isEnabled = undefined;
+          expect(propType.isEnabled).toBe(false);
         });
 
         it("should ignore setting to null", function() {
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo", isReadOnly: true});
-          expect(propType.isReadOnly).toBe(true);
-          propType.isReadOnly = null;
-          expect(propType.isReadOnly).toBe(true);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo", isEnabled: false});
+          expect(propType.isEnabled).toBe(false);
+          propType.isEnabled = null;
+          expect(propType.isEnabled).toBe(false);
         });
 
         it("should cast other non-function spec values to boolean", function() {
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isReadOnly: 1});
-          expect(propType.isReadOnly).toBe(true);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isEnabled: 1});
+          expect(propType.isEnabled).toBe(true);
 
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo2", isReadOnly: 0});
-          expect(propType.isReadOnly).toBe(false);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo2", isEnabled: 0});
+          expect(propType.isEnabled).toBe(false);
 
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo3", isReadOnly: ""});
-          expect(propType.isReadOnly).toBe(false);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo3", isEnabled: ""});
+          expect(propType.isEnabled).toBe(false);
 
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo4", isReadOnly: true});
-          expect(propType.isReadOnly).toBe(true);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo4", isEnabled: true});
+          expect(propType.isEnabled).toBe(true);
 
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo5", isReadOnly: "yes"});
-          expect(propType.isReadOnly).toBe(true);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo5", isEnabled: "yes"});
+          expect(propType.isEnabled).toBe(true);
 
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo6", isReadOnly: "no"});
-          expect(propType.isReadOnly).toBe(true);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo6", isEnabled: "no"});
+          expect(propType.isEnabled).toBe(true);
         });
 
         it("should accept a function spec value", function() {
           var f = function() {};
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isReadOnly: f});
-          expect(propType.isReadOnly).toBe(f);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isEnabled: f});
+          expect(propType.isEnabled).toBe(f);
         });
 
         it("should evaluate a function spec value and return the default value if it returns nully", function() {
           var owner = {};
           var f = function() { return null; };
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isReadOnly: f});
-          expect(propType.isReadOnlyEval(owner)).toBe(false);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isEnabled: f});
+          expect(propType.isEnabledEval(owner)).toBe(true);
 
           // ----
 
           f = function() { return undefined; };
-          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo2", isReadOnly: f});
-          expect(propType.isReadOnlyEval(owner)).toBe(false);
+          propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo2", isEnabled: f});
+          expect(propType.isEnabledEval(owner)).toBe(true);
         });
 
         it("should evaluate a function spec value in the context of the owner value", function() {
           var owner = {};
           var f = jasmine.createSpy();
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isReadOnly: f});
-          propType.isReadOnlyEval(owner);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isEnabled: f});
+          propType.isEnabledEval(owner);
           expect(f.calls.count()).toBe(1);
           expect(f.calls.first().object).toBe(owner);
         });
@@ -1116,8 +1116,8 @@ define([
         it("should evaluate a function spec value without arguments", function() {
           var owner = {};
           var f = jasmine.createSpy();
-          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isReadOnly: f});
-          propType.isReadOnlyEval(owner);
+          var propType = propertyTypeUtil.createRoot(Derived.type, {name: "foo1", isEnabled: f});
+          propType.isEnabledEval(owner);
           expect(f.calls.count()).toBe(1);
           expect(f.calls.first().args.length).toBe(0);
         });
@@ -1133,10 +1133,10 @@ define([
               {declaringType: Derived2.type}); // keyArgs
 
           expect(function() {
-            propType.isReadOnly = true;
+            propType.isEnabled = false;
           }).toThrow(errorMatch.operInvalid());
         });
-      }); // end #isReadOnly
+      }); // end #isEnabled
 
       describe("#countRange -", function() {
         // 1. when !isList => min and max <= 1
@@ -2841,7 +2841,7 @@ define([
         });
       }); // end isApplicable
 
-      describe("isReadOnly -", function() {
+      describe("isEnabled -", function() {
         it("should default to an unset local value", function() {
           var Base = Complex.extend();
 
@@ -2851,13 +2851,13 @@ define([
 
           var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr"});
 
-          expect(propType.isReadOnly).toBe(undefined);
+          expect(propType.isEnabled).toBe(undefined);
         });
 
         it("should evaluate to the base value by default", function() {
           var Base = Complex.extend();
 
-          Base.type.add({name: "baseStr", isReadOnly: true});
+          Base.type.add({name: "baseStr", isEnabled: false});
 
           var Derived = Base.extend();
 
@@ -2865,7 +2865,7 @@ define([
 
           var owner = {};
 
-          expect(propType.isReadOnlyEval(owner)).toBe(true);
+          expect(propType.isEnabledEval(owner)).toBe(false);
         });
 
         it("should get the specification value", function() {
@@ -2875,9 +2875,9 @@ define([
 
           var Derived = Base.extend();
 
-          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: false});
+          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: true});
 
-          expect(propType.isReadOnly).toBe(false);
+          expect(propType.isEnabled).toBe(true);
         });
 
         it("should get the last set non-nully value", function() {
@@ -2887,17 +2887,17 @@ define([
 
           var Derived = Base.extend();
 
-          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: false});
+          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: true});
 
-          expect(propType.isReadOnly).toBe(false);
+          expect(propType.isEnabled).toBe(true);
 
-          propType.isReadOnly = true;
+          propType.isEnabled = false;
 
-          expect(propType.isReadOnly).toBe(true);
+          expect(propType.isEnabled).toBe(false);
 
-          propType.isReadOnly = false;
+          propType.isEnabled = true;
 
-          expect(propType.isReadOnly).toBe(false);
+          expect(propType.isEnabled).toBe(true);
         });
 
         it("should let change the local value, but all sets are combined monotonically " +
@@ -2908,17 +2908,17 @@ define([
 
           var Derived = Base.extend();
 
-          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: false});
+          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: true});
 
-          propType.isReadOnly = true;
+          propType.isEnabled = false;
 
           // non-monotonic change
-          propType.isReadOnly = false;
+          propType.isEnabled = true;
 
           var owner = {};
 
-          var isReadOnly = propType.isReadOnlyEval(owner);
-          expect(isReadOnly).toBe(true);
+          var isEnabled = propType.isEnabledEval(owner);
+          expect(isEnabled).toBe(false);
         });
 
         it("should evaluate a base function and, if false, only then the sub function", function() {
@@ -2927,40 +2927,46 @@ define([
           var Base = Complex.extend();
 
           var baseIndex = -1;
-          var baseSpy = jasmine.createSpy().and.callFake(function() { baseIndex = index++; return false; });
+          var baseSpy = jasmine.createSpy().and.callFake(function() {
+            baseIndex = index++;
+            return true;
+          });
 
-          Base.type.add({name: "baseStr", isReadOnly: baseSpy});
+          Base.type.add({name: "baseStr", isEnabled: baseSpy});
 
           var Derived = Base.extend();
 
           var subIndex = -1;
-          var subSpy = jasmine.createSpy().and.callFake(function() { subIndex = index++; return false; });
+          var subSpy = jasmine.createSpy().and.callFake(function() {
+            subIndex = index++;
+            return true;
+          });
 
-          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: subSpy});
+          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: subSpy});
 
           var owner = {};
 
-          propType.isReadOnlyEval(owner);
+          propType.isEnabledEval(owner);
           expect(baseIndex).toBe(1);
-          expect(subIndex ).toBe(2);
+          expect(subIndex).toBe(2);
         });
 
-        it("should not evaluate the sub function if the base function evaluates to true", function() {
+        it("should not evaluate the sub function if the base function evaluates to false", function() {
           var Base = Complex.extend();
 
-          var baseSpy = jasmine.createSpy().and.returnValue(true);
+          var baseSpy = jasmine.createSpy().and.returnValue(false);
 
-          Base.type.add({name: "baseStr", isReadOnly: baseSpy});
+          Base.type.add({name: "baseStr", isEnabled: baseSpy});
 
           var Derived = Base.extend();
 
-          var subSpy = jasmine.createSpy().and.returnValue(true);
+          var subSpy = jasmine.createSpy().and.returnValue(false);
 
-          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: subSpy});
+          var propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: subSpy});
 
           var owner = {};
 
-          expect(propType.isReadOnlyEval(owner)).toBe(true);
+          expect(propType.isEnabledEval(owner)).toBe(false);
           expect(baseSpy.calls.count()).toBe(1);
           expect(subSpy.calls.count()).toBe(0);
 
@@ -2968,20 +2974,20 @@ define([
 
           Base = Complex.extend();
 
-          Base.type.add({name: "baseStr", isReadOnly: true});
+          Base.type.add({name: "baseStr", isEnabled: false});
 
           Derived = Base.extend();
 
-          subSpy = jasmine.createSpy().and.returnValue(true);
+          subSpy = jasmine.createSpy().and.returnValue(false);
 
-          propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isReadOnly: subSpy});
+          propType = propertyTypeUtil.extend(Derived.type, "baseStr", {name: "baseStr", isEnabled: subSpy});
 
           owner = {};
 
-          expect(propType.isReadOnlyEval(owner)).toBe(true);
+          expect(propType.isEnabledEval(owner)).toBe(false);
           expect(subSpy.calls.count()).toBe(0);
         });
-      }); // end isReadOnly
+      }); // end isEnabled
       // endregion
     }); // end override a property
 

--- a/impl/client/src/test/javascript/pentaho/visual/action/SelectionModes.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/action/SelectionModes.spec.js
@@ -101,10 +101,10 @@ define([
         spyOn(SelectionModes, "add").and.callThrough();
         spyOn(SelectionModes, "remove").and.callThrough();
 
-        // Only the Portugal row is sales12k and inStock
+        var currentFilter = sales12k;
         var inputFilter = sales12k.and(inStock);
 
-        var result = SelectionModes.toggle.call(view, sales12k, inputFilter);
+        var result = SelectionModes.toggle.call(view, currentFilter, inputFilter);
 
         expect(SelectionModes.add.calls.count()).toBe(0);
 
@@ -112,10 +112,8 @@ define([
         expect(SelectionModes.remove.calls.first().object).toBe(view);
 
         var args = SelectionModes.remove.calls.first().args;
-        expect(args[0]).toBe(sales12k);
+        expect(args[0]).toBe(currentFilter);
         expect(args[1]).toBe(inputFilter);
-
-        expect(result instanceof AndFilter).toBe(true);
       });
 
       it("should add the input selection from the current selection when " +
@@ -185,10 +183,7 @@ define([
       it("should remove the input selection from the current selection", function() {
         var result = SelectionModes.remove.call(view, sales12k, inStock);
 
-        expect(result instanceof AndFilter).toBe(true);
-        expect(result.operands.at(0)).toBe(sales12k);
-        expect(result.operands.at(1) instanceof NotFilter).toBe(true);
-        expect(result.operands.at(1).operand).toBe(inStock);
+        expect(result.toDnf().contentKey).toBe("(or (and (in sales 12000) (not (= inStock true))))");
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/visual/action/SelectionModes.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/action/SelectionModes.spec.js
@@ -137,7 +137,7 @@ define([
 
         var args = SelectionModes.add.calls.first().args;
         expect(args[0]).toBe(currentFilter);
-        expect(args[1]).toBe(inputFilter);
+        expect(args[1]).not.toBe(inputFilter); // should be "not yet selected input"
 
         expect(result instanceof OrFilter).toBe(true);
       });
@@ -163,7 +163,7 @@ define([
 
         var args = SelectionModes.add.calls.first().args;
         expect(args[0]).toBe(currentFilter);
-        expect(args[1]).toBe(inputFilter);
+        expect(args[1]).not.toBe(inputFilter); // should be "not yet selected input"
 
         expect(result instanceof OrFilter).toBe(true);
       });


### PR DESCRIPTION
* `pentaho.type.filter.Abstract#contentKey` — allows comparing two filters for equality using a string.
* `pentaho.type.filter.Abstract#toDnf` — Converts any filter to DNF form. On certain filters, the algorithmic complexity reveals itself and blows up memory.
* `pentaho.type.filter.Abstract#andNot` — Optimized method for "subtracting" two filters that allows escaping the explosion of `(A and not B).toDnf() and provides an acceptable selection user experience.
* `pentaho.visual.action.SelectionModes#toggle` no longer needs to use to the model's data to determine if all of the input selection is already included in the current selection — it now does so extensionally (and so whether data is in crosstab or not is no longer relevant for filters).
* `pentaho.type.filter.True` and `pentaho.type.filter.False` — Along with singleton instances.
* `pentaho.type.filter` classes are now immutable, so no preventive clones need to be performed.
* `pentaho.type.filter` classes are now, each, a one type aggregate, so no preventive clones need to be performed to prevent forming inverse, bubbling references between filter objects — the cause of severe memory leaks in the `toDnf` algorithm.
* Feature — Renamed `pentaho.type.Property.Type#isReadOnly` to `isEnabled` to free the old name for another (the following) feature.
* Feature — Immutable Containers: `Complex` and `List`. Added `pentaho.type.Property.Type#isReadOnly` and `pentaho.type.List#isReadOnly`.
* Feature — Aggregates. The new attributes `pentaho.type.Property.Type#isBoundary` and `pentaho.type.List#isBoundary` allow controlling the extent of "aggregates", which are delimited by boundary properties. Change events bubble, and validation occurs, only within objects of the same aggregate. Also, objects of an aggregate prevent each other from being garbage collected (due to inverse references, that support bubbling).

@pentaho/millenniumfalcon please review.

Merge https://github.com/pentaho/pentaho-analyzer/pull/1432 afterwards.