### PR TITLE
[BACKLOG-15078] Decimal placeholders in axis tick formatting

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.views.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.views.conf.js
@@ -673,7 +673,7 @@ define([
       // #,0 A
       // #,0.0 A
       // #,0.00 A
-      var depPlacesMask = precision ? ("." + new Array(precision + 1).join("0")) : "";
+      var depPlacesMask = precision ? ("." + new Array(precision + 1).join("0")) : ".##";
       var mask = "#,0" + depPlacesMask + (useAbrev ? " A" : "");
 
       numberFormat = pvc.data.numberFormat(mask);


### PR DESCRIPTION
Add variable decimal digit placeholders to numeric axis tick formatting mask when precision is unspecified.

@pentaho/millenniumfalcon please review.