### PR TITLE
[BACKLOG-15223] Hidden sunburst labels don’t show on hover.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -721,7 +721,10 @@ define(function() {
             colorMode: "level",
 
             slice_strokeStyle: function() { return this.finished("white"); },
-            slice_lineWidth: function() { return this.finished(2); }
+            slice_lineWidth: function() { return this.finished(2); },
+
+            label_ibits: 0,
+            label_imask: "ShowsActivity"
           }
         }
       },

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/line.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/line.js
@@ -38,7 +38,6 @@ define([
           {
             name: "lineWidth",
             type: lineWidthFactory,
-            isApplicable: function() { return this.count("measures") > 0; },
             isRequired: true,
             value: 1
           },

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/sunburst.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/sunburst.js
@@ -71,6 +71,7 @@ define([
               base: labelsOptionFactory,
               domain: ["none", "center"]
             },
+            isApplicable: isSizeMapped,
             isRequired: true,
             value: "none"
           },
@@ -83,6 +84,7 @@ define([
           {
             name: "sliceOrder",
             type: sliceOrderFactory,
+            isApplicable: isSizeMapped,
             isRequired: true,
             value: "bySizeDescending"
           }
@@ -93,4 +95,8 @@ define([
     .implement({type: bundle.structured.settingsMultiChart})
     .implement({type: bundle.structured.sunburst});
   };
+
+  function isSizeMapped() {
+    return this.size.attributes.count > 0;
+  }
 });


### PR DESCRIPTION
Sunburst model properties “labelsOption” and “sliceOrder” are only applicable when “size” is bound.

@pentaho/millenniumfalcon please review.