### PR TITLE
[BACKLOG-15704] PIR Filter - parameter name label and text field over…

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/FilterDialog.css
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/FilterDialog.css
@@ -7,7 +7,7 @@
 }
 
 .filterDialogDetailsContainer {
-  height: 250px;
+  min-height: 250px;
 }
 
 .filterDialogPicklistFindInput {


### PR DESCRIPTION
…lap other controls

We should not limit height to avoid overlap parameter name and label (for example, when we have a long text in localized buttons)

Should be merged with https://github.com/pentaho/pentaho-commons-gwt-modules/pull/561
@pentaho/bobafett please review