### PR TITLE
[BACKLOG-14077]

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -809,6 +809,20 @@ define(function() {
             xAxisBandSizeMin: 30
           }
         }
+      }, 
+
+      // MetricDocAbstract
+      {
+        priority: RULE_PRIO_APP_DEFAULT,
+        select: {
+          application: "pentaho-cdf",
+          type: "pentaho/ccc/visual/metricDotAbstract"
+        },
+        apply: {
+          extension: {
+            continuousColorAxisColors: ["#FF0000", "#FFFF00", "#008000"]
+          }
+        }
       },
 
       // Bubble


### PR DESCRIPTION
 - Added default color config for MetricDotAbstract Chart

@dcleao please review