### PR TITLE
[BACKLOG-15788][BACKLOG-15789] Several styling fixes.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
@@ -441,7 +441,10 @@ define([
         value = model.getv("lineWidth", /* sloppy: */true);
         if(value != null) {
           options.line_lineWidth = value;
-          var radius = 3 + 6 * (value / 8); // 1 -> 8 => 3 -> 9,
+          // 1 -> 3.167
+          // 2 -> 4
+          // 8 -> 9
+          var radius = 5 / 6 * (value - 2) + 4;
           options.dot_shapeSize = radius * radius;
 
           options.plot2Line_lineWidth = options.line_lineWidth;
@@ -1174,8 +1177,13 @@ define([
 
           var value = model.trendLineWidth;
           if(value != null) {
-            options.trendLine_lineWidth = +value;      // + -> to number
-            var radius = 3 + 6 * ((+value) / 8); // 1 -> 8 => 3 -> 9,
+            value = +value; // + -> to number
+
+            options.trendLine_lineWidth = value;
+            // 1 -> 3.167
+            // 2 -> 4
+            // 8 -> 9
+            var radius = 5 / 6 * (value - 2) + 4;
             options.trendDot_shapeSize = radius * radius;
           }
         }
@@ -1372,9 +1380,10 @@ define([
         var legendPosition = options.legendPosition;
         var isTopOrBottom = legendPosition === "top" || legendPosition === "bottom";
 
-        if(!isTopOrBottom) {
-          options.legendAlignTo = "page-middle";
-          options.legendKeepInBounds = true; // ensure it is not placed off-page
+        if(isTopOrBottom) {
+          options.legendAlign = "left";
+        } else {
+          options.legendAlign = "top";
 
           if(this._hasMultiChartColumns) {
             // Ensure that legend margins is an object.
@@ -1395,9 +1404,20 @@ define([
           }
         }
 
-        // Calculate 'legendAlign' default value
-        if(!("legendAlign" in options))
-          options.legendAlign = isTopOrBottom ? "center" : "middle";
+        // Set, before, whenever lineWidth is defined.
+        var dotSize = options.dot_shapeSize;
+        if(dotSize == null || def.fun.is(dotSize)) {
+          dotSize = 16; // radius = 4
+        }
+
+        var dotRadius = Math.sqrt(dotSize);
+
+        // Unfortunately, diamonds are slightly bigger than other shapes, and would overflow or touch the text.
+        var shape = this.model.getv("shape", /* sloppy: */true);
+        var extraMargin = (shape === "diamond") ? 2 : 0;
+
+        options.legendMarkerSize = 2 * (dotRadius + extraMargin);
+        options.legend$Dot_shapeSize = dotSize;
       },
       // endregion
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
@@ -48,18 +48,6 @@ define([
           options.dotsVisible = true;
           options.dot_shape = shape;
         }
-      },
-
-      _configureLegend: function() {
-
-        this.base();
-
-        var options = this.options,
-            dotSize = options.dot_shapeSize;
-        if(dotSize != null) {
-          var dotRadius = Math.sqrt(dotSize);
-          options.legendMarkerSize = Math.max(15, 2 * (dotRadius + 3));
-        }
       }
     });
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -134,14 +134,14 @@ define(function() {
 
             // Legend
             // legend: true,
-            legendDrawLine:    false,
-            legendDrawMarker:  true,
+            legendDrawLine: false,
+            color2AxisLegendDrawLine: false, // Used by plot2
+            legendDrawMarker: true,
+            legendShape: "circle",
 
             legendItemCountMax: 20,
             legendSizeMax:      "30%",
             legendOverflow:     "collapse",
-
-            legendArea_overflow: "visible",
 
             legendPaddings:    0,
             legendMargins:     0,
@@ -156,8 +156,10 @@ define(function() {
             legendArea_strokeStyle: "#c0c0c0",
 
             // No hover effect
-            legendDot_ibits:  0,
-            legendDot_imask:  "Hoverable",
+            legend$Dot_ibits: 0,
+            legend$Dot_imask: "Hoverable",
+            legend$Rule_ibits: 0,
+            legend$Rule_imask: "Hoverable",
 
             legend: {
               scenes: {
@@ -226,8 +228,14 @@ define(function() {
             axisTitleVisible: true,
             axisTitleSizeMax: "20%",
             axisTitleLabel_textMargin: 0,
+
             xAxisTitleAlign: "left",
+            x2AxisTitleAlign: "left",
+            x3AxisTitleAlign: "left",
+
             yAxisTitleAlign: "top",
+            y2AxisTitleAlign: "top",
+            y3AxisTitleAlign: "top",
 
             // . label
             discreteAxisLabel_ibits: 0,
@@ -469,10 +477,30 @@ define(function() {
               return left;
             },
 
+            // . line
+            // Line chart actually forces this to true.
+            // Only takes effect on areaXyz
+            linesVisible: false
+          }
+        }
+      },
+
+      {
+        priority: RULE_PRIO_VIZ_DEFAULT,
+        select: {
+          type: [
+            "pentaho/ccc/visual/pointAbstract",
+            "pentaho/ccc/visual/barLine"
+          ]
+        },
+        apply: {
+          extension: {
+            // The point prefix covers both the main and the second plot (barLine).
+
             // Plot
             // . dot
             // . on hover
-            dot_fillStyle:   function() {
+            pointDot_fillStyle:   function() {
               var c = this.delegate();
               var scene = this.scene;
               var sign = this.sign;
@@ -498,7 +526,7 @@ define(function() {
               return this.finished(c);
             },
 
-            dot_strokeStyle: function() {
+            pointDot_strokeStyle: function() {
               var c = this.delegate();
               var scene = this.scene;
               var sign = this.sign;
@@ -520,12 +548,11 @@ define(function() {
 
               return this.finished(c);
             },
-            dot_lineWidth: function() { return this.finished(2); },
+            pointDot_lineWidth: function() { return this.finished(2); },
 
             // . line
-            linesVisible: false,
-            line_ibits: 0,
-            line_imask: "ShowsActivity"
+            pointLine_ibits: 0,
+            pointLine_imask: "ShowsActivity"
           }
         }
       },
@@ -578,7 +605,6 @@ define(function() {
             contentMargins: {top: 30},
 
             legendAlign: "center",
-            legendShape: "circle",
 
             // Plot
             activeSliceRadius: 0,
@@ -715,13 +741,8 @@ define(function() {
             legendPosition:    "top",
             legendAlign:       "left",
 
-            legendDot_shape:   "circle",
             legendFont:        vizApiFont,
-            legendLabel_textStyle: "#666",
-
-            legendArea_overflow: "hidden",
-
-            legendMarkerSize:  8
+            legendLabel_textStyle: "#666"
           }
         }
       },
@@ -735,7 +756,12 @@ define(function() {
           extension: {
             // Plot
             valuesVisible: false,
-            valuesFont: vizApiFont
+            valuesFont: vizApiFont,
+
+            // Legend defaults
+            // By UX design spec, line-width: 2 => radius: 4
+            legend$Dot_shapeSize: 16, // = radius * radius
+            legendMarkerSize:      8  // = diameter = 2 * radius
           }
         }
       },
@@ -829,7 +855,7 @@ define(function() {
             xAxisBandSizeMin: 30
           }
         }
-      }, 
+      },
 
       // MetricDocAbstract
       {


### PR DESCRIPTION
* Fixing size of line dots (main, plot2 and trend) and corresponding legend markers to match the UX spec for a lineWidth of 2px
* Legend alignment: when placed at top/bottom, align left; when placed at left/right, align top
* Fixing diamond shape, in legend markers, requiring a bit extra space to not overflow
* Removed legend_overflow extension point, as now the generated legend markers do not normally overflow anymore
* Fixed some configs like disabling marks being hoverable that were not being applied to all instances
  (only main plot / only 1st legend group / only 1st axes)
* Removed legend item rule that showed in the line series of Column/Line Combo

@pentaho/millenniumfalcon, @diogofscmariano please review.