### PR TITLE
[BACKLOG-14077] Added extra legend bullet margin when shape is “diamo…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
@@ -1414,7 +1414,7 @@ define([
 
         // Unfortunately, diamonds are slightly bigger than other shapes, and would overflow or touch the text.
         var shape = this.model.getv("shape", /* sloppy: */true);
-        var extraMargin = (shape === "diamond") ? 2 : 0;
+        var extraMargin = (shape === "diamond") || (shape === "triangle") ? 4 : 0;
 
         options.legendMarkerSize = 2 * (dotRadius + extraMargin);
         options.legend$Dot_shapeSize = dotSize;

--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -932,7 +932,7 @@ define(function() {
     return this.finished(c);
   }
 
-  // For Scatter/Bubble & NonStacked Area
+  // For Scatter/Bubble & NonStacked Area (CDF)
   function fillStyle2() {
 
     var c = this.delegate();


### PR DESCRIPTION
…nd” or “triangle”

@pentaho/millenniumfalcon please review.