### PR TITLE
[ANALYZER-3108]-Selecting a second chart item selects additional items

### DIFF
--- a/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
+++ b/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
@@ -3702,9 +3702,7 @@ define([
        //     return this.axes.row.getAxisLabel();
        // },
 
-        _doesSharedSeriesSelection: function(){
-            return false;
-        },
+        
 
         
     });


### PR DESCRIPTION
 - additinal fixing (for filter 'keep only')