### PR TITLE
[SP-3429][Backport of ANALYZER-3108 - Selecting a second chart item selects additional items (6.1 Suite)]

### DIFF
--- a/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
+++ b/package-res/resources/web/vizapi/ccc/ccc_wrapper.js
@@ -3702,9 +3702,6 @@ define([
        //     return this.axes.row.getAxisLabel();
        // },
 
-        _doesSharedSeriesSelection: function(){
-            return false;
-        },
 
     });
 


### PR DESCRIPTION
 - additional fixing (keep only filter)