### PR TITLE
[BACKLOG-14320] Added AbstractDataTable#filterRow method.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
@@ -247,7 +247,7 @@ define([
      * Returns a view for the subset of rows of a data table
      * that are selected by this filter.
      *
-     * @param {!pentaho.data.Table} dataTable - The data table to filter.
+     * @param {!pentaho.type.filter.Abstract} filter - The filter.
      *
      * @return {!pentaho.data.TableView} A view of the filtered data table.
      *
@@ -273,6 +273,25 @@ define([
       var dataView = new AbstractTable.core.TableView(this);
       dataView.setSourceRows(filteredRows);
       return dataView;
+    },
+
+    /**
+     * Gets a value that indicates if a given filter includes a given row.
+     *
+     * @param {!pentaho.type.filter.Abstract} filter - The filter.
+     * @param {number} rowIndex The row index (zero-based).
+     *
+     * @return {boolean} `true` if the filter includes the row; `false`, otherwise.
+     *
+     * @throws {pentaho.type.ValidationError} When the filter is not valid,
+     * the first error returned by the `validate` method.
+     */
+    filterRow: function(filter, rowIndex) {
+
+      filter.assertValid();
+
+      var elem = new ElementMock(this, rowIndex);
+      return filter._contains(elem);
     },
 
     /**


### PR DESCRIPTION
Without this method, one cannot easily know if filter includes a specific row.
Internal solutions use the `AbstractDataTable#filter` method, which is not useful in row by row scenarios or the private `pentaho/data/_ElementMock` wrapper.

The Sample documentation and third-party implementations need this to implement selection!

@pentaho/millenniumfalcon please review.