### PR TITLE
[BACKLOG-15858] Replacing the old names by which the “Pentaho Platfor…

### DIFF
--- a/assemblies/platform-plugin/src/main/resources/resources/web/common-ui-require-js-cfg.js
+++ b/assemblies/platform-plugin/src/main/resources/resources/web/common-ui-require-js-cfg.js
@@ -48,7 +48,7 @@
   requirePaths["pentaho/common"] = basePath + "/dojo/pentaho/common";
   // endregion
 
-  // region Pentaho Web-Client Platform
+  // region Pentaho Platform JavaScript APIs (Core, Data, Visual)
 
   // Unfortunately, *mantle* already maps the "pentaho" id to "/js",
   // so the paths of all of the following sub-modules must be configured individually.
@@ -275,7 +275,7 @@
   requireShim["common-ui/angular-directives"] = ["common-ui/angular-ui-bootstrap"];
   // endregion
 
-  // region Metadata Model and Visualizations Packages
+  // region Type API and Visualization Models Packages and Themes
   function mapTheme(mid, themeRoot, themes) {
     var theme = (typeof active_theme !== "undefined") ? active_theme : null;
     if(!theme || themes.indexOf(theme) < 0) theme = themes[0];
@@ -288,10 +288,10 @@
     requireTypes[name] = "pentaho/visual/base";
   }
 
-  // Metadata Model Base Theme
+  // Type API Base Theme
   mapTheme("pentaho/type", "themes", ["crystal"]);
 
-  // CCC Themes
+  // Visual Models Themes
   mapTheme("pentaho/visual/models", "themes", ["crystal", "sapphire", "onyx", "det"]);
 
   // sample/calc theme

--- a/impl/client/src/doc/javascript/template/vizApi/publish.js
+++ b/impl/client/src/doc/javascript/template/vizApi/publish.js
@@ -379,6 +379,7 @@ function registerTypeHelpers(view) {
   view._typeBuilder = typeBuilder;
 
   var mdnJsTypeBaseURL = "http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/";
+  var mdnJsWindowBaseURL = "https://developer.mozilla.org/en-US/docs/Web/API/Window/";
   var mdnJsTypes = {
     "string" : true,  "String": true,
     "number": true,   "Number": true,
@@ -409,6 +410,10 @@ function registerTypeHelpers(view) {
     "Map": true, "WeakMap": true,
     "Set": true, "WeakSet": true,
     "Math": true, "Symbol": true
+  };
+
+  var mdnJsWindow = {
+    "URL": true
   };
 
   var backboneTypeBaseURL = "http://backbonejs.org/#";
@@ -600,12 +605,16 @@ function registerTypeHelpers(view) {
     var jsTypeLower = jsType.toLowerCase();
 
     var isMdnJsType = mdnJsTypes[jsType];
+    var isMdnJsWindow = mdnJsWindow[jsType];
     var isJQueryType = typeof jQueryTypes[jsTypeLower] !== "undefined";
     var isBackboneType = BACKBONE_TYPE_REGX.exec(jsType) !== null;
 
     var link;
     if (isMdnJsType) {
       link = mdnJsTypeBaseURL + jsType;
+
+    } else if(isMdnJsWindow) {
+      link = mdnJsWindowBaseURL + jsType;
 
     } else if (isBackboneType) {
       link = backboneTypeBaseURL + jsType.split(".")[1];
@@ -716,15 +725,15 @@ exports.publish = function(taffyData, opts, tutorials) {
     });
 
     /*
-     * Handle the defaul values for non optional properties correctly. 
-     * 
+     * Handle the defaul values for non optional properties correctly.
+     *
      */
     data().each(function(doclet) {
         if (doclet.properties) {
             doclet.properties = doclet.properties.map(function(property) {
                 var separator = " - ",
                     separatorLength = separator.length;
-                
+
                 var defaultvalue = property.defaultvalue;
                 var description = property.description;
 
@@ -739,8 +748,8 @@ exports.publish = function(taffyData, opts, tutorials) {
                     description: description,
                     type: property.type,
                     name: property.name
-                }  
-            });                  
+                }
+            });
         }
     });
 
@@ -910,7 +919,7 @@ exports.publish = function(taffyData, opts, tutorials) {
             var split = function(str, sep) {
                 if(str) {
                     return str.split(sep).join('');
-                } 
+                }
             };
 
             //dont split for code
@@ -926,7 +935,7 @@ exports.publish = function(taffyData, opts, tutorials) {
             if(doclet.summary && doclet.summary.indexOf("syntax.javascript") === -1) {
                 doclet.summary = split(doclet.summary, '<br>');
             }
-            
+
             doclet.parsedName = split(doclet.name, '"');
             doclet.parsedLongname = split(doclet.longname, '"')
         }
@@ -934,14 +943,14 @@ exports.publish = function(taffyData, opts, tutorials) {
 
     var members = helper.getMembers(data);
     members.tutorials = tutorials.children;
-    
+
     // add template helpers
     view.find = find;
     view.linkto = linkto;
     view.resolveAuthorLinks = resolveAuthorLinks;
     view.tutoriallink = tutoriallink;
     view.htmlsafe = htmlsafe;
-    
+
     // once for all
     view.nav = buildNav(findMembers(data, 'namespace'));
     attachModuleSymbols( find({ longname: {left: 'module:'} }), members.modules );

--- a/impl/client/src/main/doc-js/pentaho/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,39 @@
  */
 
 /**
- * The pentaho namespace contains the
- * Pentaho Web Platform's classes and interfaces.
+ * The `pentaho` namespace contains the types of the **Pentaho Platform JavaScript APIs**.
+ *
+ * ## Overview
+ *
+ * The **Pentaho Platform JavaScript APIs** support the development of JavaScript components for the
+ * **Pentaho** platform:
+ * 1. Standardizes in cross-cutting areas, such as _data_ and _visualization_,
+ * but also on lower-level areas,
+ * such as configuration, localization and services.
+ * 2. Exposes key platform information and services to JavaScript components.
+ *
+ * Promoting common idioms in these core areas is advantageous in several ways:
+ * * allows other APIs to focus on their actual core concerns
+ * * increases interoperability between components of different frameworks,
+ *   and between applications and components
+ * * reduces the number of abstractions that developers need to learn
+ * * leads to uniformization across APIs, components and applications
+ * * communicates best practices
+ *
+ * The APIs are organized as follows:
+ *
+ * 1. Core
+ *   * Environment — {@link pentaho.context}
+ *   * Debugging — {@link pentaho.debug}
+ *   * Utilities — {@link pentaho.util}
+ *   * JavaScript Language support — {@link pentaho.lang}
+ *   * Configuration — {@link pentaho.config}
+ *   * Type information — {@link pentaho.typeInfo}
+ *   * Localization — {@link pentaho.i18n}
+ *   * Services — {@link pentaho.service}
+ * 2. Data — {@link pentaho.data}
+ * 3. Type — {@link pentaho.type}
+ * 4. Visualization — {@link pentaho.visual}
  *
  * @name pentaho
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/config/IService.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/config/IService.jsdoc
@@ -18,13 +18,6 @@
  * The `config.IService` interface describes a service
  * that manages configurations, usually of types.
  *
- * The platform's main configuration service instance can be obtained by requiring
- * the module `pentaho/service!pentaho.config.IService?single`.
- *
- * The platform registers an instance module that
- * loads all registered configuration rule set modules
- * (i.e., modules of type {@link pentaho.config.spec.IRuleSet}).
- *
  * The [add]{@link pentaho.config.IService#add} method
  * is used to register a [config.spec.IRuleSet]{@link pentaho.config.spec.IRuleSet}
  * to the service.
@@ -117,7 +110,7 @@
  * Variable values are matched against each value specified by a rule in its selection variables,
  * using JavaScript's strict equality operator, `===`.
  *
- * @return {!Object} The merged configuration specification,
+ * @return {Object} The merged configuration specification,
  * if any rule was selected; or `null`, if no rule was selected.
  */
 

--- a/impl/client/src/main/doc-js/pentaho/config/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/config/_namespace.jsdoc
@@ -20,24 +20,23 @@
  * ## Overview
  *
  * The Configuration API provides a means for _types_ to be configured by third-parties.
+ *
  * _Types_ are known by their _string_ identifier and are, for all other purposes, opaque entities
- * — these may or may not exist as actual classes, or may simply represent an interface type.
+ * — these may or may not exist as actual classes; these may simply represent an interface type.
  *
- * A configuration is a set of configuration rules, represented by the
- * [IRuleSet]{@link pentaho.config.IRuleSet} and
- * [IRule]{@link pentaho.config.IRule}
- * interfaces, respectively.
- * Each rule specifies the _type_ and the values of any
+ * **Configurations** are JavaScript objects that conform to the
+ * [IRuleSet]{@link pentaho.config.spec.IRuleSet} interface — essentially, a set of configuration rules,
+ * [IRule]{@link pentaho.config.spec.IRule}.
+ * Typically,
+ * configurations are provided as the value returned by an AMD/RequireJS module.
+ * This module needs to be advertised to the configuration system by registering it
+ * with [pentaho/service]{@link pentaho.service},
+ * as a service of type `pentaho.config.spec.IRuleSet`.
+ *
+ * **Configuration rules** specify the _type_ and the values of any
  * [Pentaho environmental variables]{@link pentaho.context.IContext}
- * to which it applies,
+ * to which they apply,
  * as well as the actual configuration properties that should be applied.
- *
- * Configuration modules — AMD/RequireJS modules that return an instance of
- * [IRuleSet]{@link pentaho.config.spec.IRuleSet}
- * — must be advertised to {@link pentaho/system}, using the service id `pentaho.config.spec.IRuleSet`,
- * to be visible to the configuration system.
- *
- * The configuration system merges multiple configurations that target the same type.
  *
  * Configurations can be obtained (and also registered)
  * through the [config.IService]{@link pentaho.config.IService} interface.
@@ -64,3 +63,5 @@
  * @name pentaho.config
  * @namespace
  */
+
+// TODO: The configuration system should use typeInfo to accept _aliases_ and allow for _configuration inheritance_.

--- a/impl/client/src/main/doc-js/pentaho/context/IContext.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/context/IContext.jsdoc
@@ -15,7 +15,7 @@
  */
 
 /**
- * The `IContext` interface allows access to contextual information of the Pentaho Web Client Platform.
+ * The `IContext` interface allows access to environmental information of the Pentaho Platform.
  * For example, it allows access to
  * [user]{@link pentaho.context.IContext#user},
  * [theme]{@link pentaho.context.IContext#theme},

--- a/impl/client/src/main/doc-js/pentaho/context/IServer.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/context/IServer.jsdoc
@@ -15,15 +15,14 @@
  */
 
 /**
- * The `IServer` interface allows access to the Pentaho Web Client Platform’s
- * contextual information that pertains to the server application.
+ * The `IServer` interface allows access to the Pentaho Platform’s
+ * environmental information that pertains to the server application.
  *
  * @name pentaho.context.IServer
  * @interface
  * @see pentaho.context.IContext
  */
 
-// Docs should point `URL` to https://developer.mozilla.org/en-US/docs/Web/API/Window/URL
 /**
  * Gets the base url of the web server application.
  *

--- a/impl/client/src/main/doc-js/pentaho/context/IUser.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/context/IUser.jsdoc
@@ -15,8 +15,8 @@
  */
 
 /**
- * The `IUser` interface allows access to the Pentaho Web Client Platform's
- * contextual information that pertains to the user.
+ * The `IUser` interface allows access to the Pentaho Platform's
+ * environmental information that pertains to the user.
  *
  * @name pentaho.context.IUser
  * @interface

--- a/impl/client/src/main/doc-js/pentaho/context/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/context/_namespace.jsdoc
@@ -15,7 +15,24 @@
  */
 
 /**
- * The `context` namespace contains types related to the platform environment.
+ * The `context` namespace contains types that allow access to environmental information of the Pentaho Platform.
+ *
+ * ## Overview
+ *
+ * The [IContext]{@link pentaho.context.IContext} interface is the top interface that represents the environment.
+ * Part of its information is described by the contained
+ * [IServer]{@link pentaho.context.IServer} and
+ * [IUser]{@link pentaho.context.IUser} interfaces.
+ *
+ * {@link pentaho.context.main} is the _main_ environment instance of the Pentaho Platform.
+ * Secondary environments can be derived from the main environment,
+ * by using its [IContext#createChild]{@link pentaho.context.IContext#createChild} method.
+ *
+ * The specification classes, in the {@link pentaho.context.spec} namespace,
+ * expose the raw environmental data in plain JavaScript objects or JSON format.
+ * These
+ * can be used in [IContext#createChild]{@link pentaho.context.IContext#createChild} or
+ * result from [IContext#toSpec]{@link pentaho.context.IContext#toSpec}.
  *
  * @name pentaho.context
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/context/spec/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/context/spec/_namespace.jsdoc
@@ -15,7 +15,7 @@
  */
 
 /**
- * The `spec` namespace contains specification interfaces.
+ * The `context.spec` namespace contains specification interfaces.
  *
  * @name pentaho.context.spec
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/data/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/data/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 /**
- * The data namespace contains classes and interfaces used for data representation.
+ * The `data` namespace contains the types of the **Pentaho Data API**.
+ *
+ * ## Overview
+ *
+ * The Pentaho Data API contains, at its core, a _data table_ abstraction that allows JavaScript APIs,
+ * components and applications to consume and exchange tabular data in a common way.
+ *
+ * The data table abstraction is the [ITable]{@link pentaho.data.ITable} interface and
+ * the data table class, [Table]{@link pentaho.data.Table}, provides a basic implementation of it.
  *
  * @name pentaho.data
  * @namespace
  */
+
+// TODO: pentaho.data.access, when made public, should be introduced here.

--- a/impl/client/src/main/doc-js/pentaho/lang/IEventSource.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/lang/IEventSource.jsdoc
@@ -48,7 +48,7 @@
  * that represents the specific event emission.
  * The specific type of this argument is not mandated,
  * however, the provided [Event]{@link pentaho.lang.Event} class is a reasonable choice for unstructured events,
- * and is used for events of many of the Web Client Framework classes.
+ * and is used for events of many of the Pentaho Platform JavaScript APIs' classes.
  *
  * This interface exposes methods for the registration and
  * unregistration of event observers (or listeners),

--- a/impl/client/src/main/doc-js/pentaho/lang/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/lang/_namespace.jsdoc
@@ -17,7 +17,7 @@
 /**
  * The `lang` namespace contains classes and interfaces used as
  * type system building blocks to form other classes and interfaces
- * of the Pentaho Web Platform.
+ * of the Pentaho Platform JavaScript APIs.
  *
  * @name pentaho.lang
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/type/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 
 /**
+ * The `type` namespace contains the classes and interfaces of the **Pentaho Type API**.
+ *
  * @name pentaho.type
  * @namespace
- *
- * @description
- *
- * The `type` namespace contains classes and interfaces of the Pentaho client metadata model.
  */

--- a/impl/client/src/main/doc-js/pentaho/util/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/util/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 /**
- * The `util` namespace contains a minimal set of supporting modules used by other platform classes.
+ * The `util` namespace contains a minimal set of supporting modules used by other types of
+ * the Pentaho Platform JavaScript APIs.
  *
  * @name pentaho.util
  * @namespace
- * @private
  */

--- a/impl/client/src/main/doc-js/pentaho/visual/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/_namespace.jsdoc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,50 @@
  */
 
 /**
- * The `visual` namespace contains the classes and interfaces that constitute the Visualization API.
+ * The `visual` namespace contains the types that constitute the **Pentaho Visualization API**.
+ *
+ * ## Overview
+ *
+ * The Visualization API provides a unified way to visualize data across the Pentaho suite
+ * (e.g. [Analyzer]{@link http://www.pentaho.com/product/business-visualization-analytics},
+ * [PDI]{@link http://www.pentaho.com/product/data-integration},
+ * [CDF]{@link http://community.pentaho.com/ctools/cdf/}).
+ *
+ * Essentially, it is a set of abstractions that enables safe, isolated operation between
+ * applications, visualizations and business logic.
+ *
+ * A **visualization** is constituted by:
+ *
+ * * One [Model]{@link pentaho.visual.base.Model},
+ *   which _identifies_ the visualization and
+ *   _defines_ it in terms of its data requirements,
+ *   such as the visual degrees of freedom it has (e.g. _X position_, _color_ and _size_) and
+ *   any major options that affect its rendering.
+ *
+ * * One [View]{@link pentaho.visual.base.View} (at least),
+ *   which implements the actual rendering using chosen technologies
+ *   (e.g. [HTML]{@link https://www.w3.org/TR/html/},
+ *   [SVG]{@link https://www.w3.org/TR/SVG/},
+ *   [D3]{@link https://d3js.org/}),
+ *   and handle user interaction,
+ *   dispatching [actions]{@link pentaho.visual.action} and, for example, showing tooltips.
+ *   The standard data actions are
+ *   [Select]{@link pentaho.visual.action.Select} and
+ *   [Execute]{@link pentaho.visual.action.Execute}.
+ *
+ * The Visualization API is built on top of other Platform JavaScript APIs:
+ * * The [Data API]{@link pentaho.data} ensures seamless integration with data sources in the Pentaho platform,
+ *   as well as with other client-side component frameworks.
+ *
+ * * The [Type API]{@link pentaho.type} provides to visualizations out-of-the-box features
+ *   such as class inheritance, metadata support, configuration, validation and serialization.
+ *
+ * * The [Core APIs]{@link pentaho} provide to visualizations features such as localization,
+ *   theming and service registration and consumption.
+ *
+ * A set of stock visualizations is included, covering the most common chart types.
+ * Based on the [CCC]{@link http://community.pentaho.com/ctools/ccc/} charting library,
+ * they're customizable and extensible to fit your organization's desired look and feel.
  *
  * @name pentaho.visual
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/visual/action/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/action/_namespace.jsdoc
@@ -17,7 +17,7 @@
  * @name pentaho.visual.action
  * @namespace
  *
- * @description The `action` namespace contains the action types used by the Visualization API.
+ * @description The `action` namespace contains the standard action types used by visualizations.
  */
 
 

--- a/impl/client/src/main/doc-js/pentaho/visual/base/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/base/_namespace.jsdoc
@@ -15,8 +15,7 @@
  */
 
 /**
- * The `base` namespace contains classes for developers to use
- * to build new visualizations that work with the Visualization API.
+ * The `base` namespace contains the types used to define the _base_ visualization.
  *
  * @name pentaho.visual.base
  * @namespace

--- a/impl/client/src/main/doc-js/pentaho/visual/base/spec/IModel.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/base/spec/IModel.jsdoc
@@ -54,5 +54,5 @@
  *
  * @name data
  * @memberOf pentaho.visual.base.spec.IModel#
- * @type {pentaho.data.Table}
+ * @type {pentaho.data.ITable}
  */

--- a/impl/client/src/main/doc-js/pentaho/visual/role/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/role/_namespace.jsdoc
@@ -15,8 +15,8 @@
  */
 
 /**
- * The `visual.role` namespace contains classes for describing visual roles -
- * an important type of property of visualization models in the Visualization API.
+ * The `role` namespace contains classes for describing visual roles —
+ * an important type of property of visualization models.
  *
  * @name pentaho.visual.role
  * @namespace

--- a/impl/client/src/main/javascript/web/pentaho/context.js
+++ b/impl/client/src/main/javascript/web/pentaho/context.js
@@ -24,9 +24,9 @@ define([
   // as it may be used in a bootstrapping phase.
 
   /**
-   * The Pentaho Web Client Platform's _main_ context.
+   * The _main_ environment of the JavaScript Pentaho Platform.
    *
-   * This instance is initialized with the context specification
+   * This instance is initialized with the environment specification
    * which is the value of this module's AMD configuration.
    *
    * @name pentaho.context.main

--- a/impl/client/src/main/javascript/web/pentaho/debug.js
+++ b/impl/client/src/main/javascript/web/pentaho/debug.js
@@ -29,8 +29,8 @@ define([
   if(level != null) spec.level = level;
 
   /**
-   * The `pentaho.debug.manager` singleton provides access to the main Pentaho Web Client Platform's
-   * debugging manager.
+   * The `pentaho.debug.manager` singleton provides access to the main debugging manager of
+   * the JavaScript Pentaho Platform.
    *
    * The debugging levels can be configured through AMD as shown in the following example:
    *

--- a/impl/client/src/main/javascript/web/pentaho/type/ContainerMixin.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/ContainerMixin.js
@@ -38,8 +38,8 @@ define([
    * @extends pentaho.lang.Base
    * @extends pentaho.lang.EventSource
    *
-   * @classDesc The `ContainerMixin` class contains functionality that is shared
-   * by the instance container classes [Complex]{@link pentaho.type.Complex} and [List]{@link pentaho.type.List}.
+   * @classDesc A mixin class that contains functionality shared by the
+   * instance container classes: [Complex]{@link pentaho.type.Complex} and [List]{@link pentaho.type.List}.
    *
    * @description This class was not designed to be constructed directly. It was designed to be used as a **mixin**.
    */

--- a/impl/client/src/main/javascript/web/pentaho/type/Context.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/Context.js
@@ -60,7 +60,7 @@ define([
      * @class
      * @amd pentaho/type/Context
      *
-     * @classDesc A `Context` object holds instance constructors of **configured** types.
+     * @classDesc A class that holds **configured** types.
      *
      * When a component, like a visualization, is being assembled,
      * it should not necessarily be unaware of the environment where it is going to be used.
@@ -71,7 +71,7 @@ define([
      * As such, besides holding contextual, environmental information,
      * a context object should contain the necessary logic to
      * facilitate the configuration of component types using that information.
-     * The Pentaho Metadata Model embraces this concept by defining types as
+     * The Pentaho Type API embraces this concept by defining types as
      * _type factories_ that take a context object as their argument.
      *
      * The instance constructors of types
@@ -85,8 +85,8 @@ define([
      * so that these are configured before being used.
      * This applies whether an instance constructor is used for creating an instance or to derive a subtype.
      *
-     * A type context holds environmental information in the form of a Pentaho web client context,
-     * {@link pentaho.context.IContext},
+     * A type context holds environmental information in the form of an environment of the
+     * [JavaScript Pentaho Platform]{@link pentaho.context.IContext},
      * which contains relevant information such as:
      * [application]{@link pentaho.context.IContext#application},
      * [user]{@link pentaho.context.IContext#user},
@@ -1150,9 +1150,9 @@ define([
   }, /** @lends pentaho.type.Context */{
 
     /**
-     * Gets the default type context of the Pentaho Web-Client Platform.
+     * Gets the default type context of the Pentaho Type API.
      *
-     * This type context instance is created with the Platform's default context variables,
+     * This type context instance is created with the Pentaho Platform's default context variables,
      * as given by {@link pentaho.context.main}.
      *
      * @type {!pentaho.type.Context}

--- a/impl/client/src/main/javascript/web/pentaho/type/SpecificationContext.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/SpecificationContext.js
@@ -33,8 +33,8 @@ define([
    *
    * @amd pentaho/type/SpecificationContext
    *
-   * @classDesc A `SpecificationContext` object holds information that is
-   * shared during the serialization (or conversion to specification) of an instance or type.
+   * @classDesc A class that holds information that is
+   * shared during the serialization (or conversion to specification) of instances and types.
    *
    * Specifically, a specification context tracks the temporary identifiers assigned to referenced anonymous types.
    *

--- a/impl/client/src/main/javascript/web/pentaho/type/SpecificationScope.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/SpecificationScope.js
@@ -31,7 +31,7 @@ define([
      *
      * @amd pentaho/type/SpecificationScope
      *
-     * @classDesc The `SpecificationScope` class manages the
+     * @classDesc A class that manages the
      * [ambient specification context]{@link pentaho.type.SpecificationContext.current}.
      *
      * @constructor

--- a/impl/client/src/main/javascript/web/pentaho/type/ValidationError.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/ValidationError.js
@@ -22,8 +22,7 @@ define([
   "use strict";
 
   /**
-   * @classDesc The `ValidationError` class is the base class of error objects associated with
-   * [value]{@link pentaho.type.Value} validation.
+   * @classDesc The base class of errors associated with [values]{@link pentaho.type.Value} validation.
    *
    * @name ValidationError
    * @memberOf pentaho.type

--- a/impl/client/src/main/javascript/web/pentaho/type/_type.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/_type.js
@@ -52,7 +52,7 @@ define([
      * @name pentaho.type.Type
      * @class
      *
-     * @classDesc The base **type class** of the types of the Pentaho client metadata model.
+     * @classDesc The root class of types that can be represented by the Pentaho Type API.
      *
      * For additional information, see the associated _instance class_, {@link pentaho.type.Instance}.
      */

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -61,7 +61,7 @@ define([
      *
      * @amd {pentaho.type.Factory<pentaho.type.Complex>} pentaho/type/complex
      *
-     * @classDesc The base class of complex types.
+     * @classDesc The base class of structured values.
      *
      * Example complex type:
      * ```js
@@ -75,7 +75,7 @@ define([
      *       type: {
      *         props: [
      *           {name: "name", type: "string", label: "Name"},
-     *           {name: "category", type: ["string"], label: "Category"},
+     *           {name: "categories", type: ["string"], label: "Categories"},
      *           {name: "price", type: "number", label: "Price"}
      *         ]
      *       }
@@ -93,6 +93,7 @@ define([
      * @constructor
      * @param {pentaho.type.spec.UComplex} [spec] A complex specification.
      *
+     * @see pentaho.type.Simple
      * @see pentaho.type.spec.IComplex
      * @see pentaho.type.spec.IComplexProto
      * @see pentaho.type.spec.IComplexTypeProto

--- a/impl/client/src/main/javascript/web/pentaho/type/date.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/date.js
@@ -32,7 +32,7 @@ define([
      * @extends pentaho.type.Simple
      * @amd {pentaho.type.Factory<pentaho.type.Date>} pentaho/type/date
      *
-     * @classDesc The class of a date value.
+     * @classDesc The class of date values.
      *
      * @description Creates a date instance.
      * @constructor

--- a/impl/client/src/main/javascript/web/pentaho/type/element.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/element.js
@@ -45,9 +45,11 @@ define([
      * @extends pentaho.type.Value
      * @amd {pentaho.type.Factory<pentaho.type.Element>} pentaho/type/element
      *
-     * @classDesc
+     * @classDesc The base class of singular values.
      *
      * @description Creates an element instance.
+     *
+     * @see pentaho.type.List
      */
     var Element = Value.extend({
 

--- a/impl/client/src/main/javascript/web/pentaho/type/function.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/function.js
@@ -45,7 +45,7 @@ define([
      * @extends pentaho.type.Simple
      * @amd {pentaho.type.Factory<pentaho.type.Function>} pentaho/type/function
      *
-     * @classDesc A primitive JavaScript function type.
+     * @classDesc The class that represents primitive, JavaScript {@link function} values.
      *
      * @description Creates a function instance.
      * @constructor

--- a/impl/client/src/main/javascript/web/pentaho/type/instance.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/instance.js
@@ -37,9 +37,9 @@ define([
      * @abstract
      * @amd {pentaho.type.Factory<pentaho.type.Instance>} pentaho/type/instance
      *
-     * @classDesc The base **instance class** of types in the Pentaho Client Metadata Model.
+     * @classDesc The root, abstract class of things that can be represented by the Pentaho Type API.
      *
-     * Types of the metadata model are constituted by two classes (or constructors):
+     * _Types_ are constituted by two classes (or constructors):
      * the **instance class** and the **type class**.
      *
      * The former creates the actual instances of the type.

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -41,7 +41,7 @@ define([
      * @class
      * @extends pentaho.type.Value.Type
      *
-     * @classDesc The base type class of *plural*, list value types.
+     * @classDesc The base type class of plural value types.
      *
      * For more information see {@link pentaho.type.List}.
      */
@@ -55,7 +55,10 @@ define([
      *
      * @amd {pentaho.type.Factory<pentaho.type.List>} pentaho/type/list
      *
-     * @classdesc A list of `Element` instances of some _common base_ type.
+     * @classDesc The base class of plural values.
+     *
+     * A list is an ordered set of [elements]{@link pentaho.type.Element} of
+     * a [common, base type]{@link pentaho.type.List.Type#of}.
      *
      * @description Creates a list instance.
      *
@@ -70,6 +73,7 @@ define([
      * @param {boolean} [keyArgs.isBoundary] - Indicates if the list should be a _boundary list_.
      * @param {boolean} [keyArgs.isReadOnly] - Indicates if the list should be a _read-only list_.
      *
+     * @see pentaho.type.Element
      * @see pentaho.type.spec.IList
      * @see pentaho.type.spec.IListProto
      * @see pentaho.type.spec.IListTypeProto

--- a/impl/client/src/main/javascript/web/pentaho/type/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/model.js
@@ -42,7 +42,9 @@ define([
      *
      * @amd {pentaho.type.Factory<pentaho.type.Model>} pentaho/type/model
      *
-     * @classDesc The base class of model types.
+     * @classDesc The base class of model values.
+     *
+     * Models are complex values that have an [application]{@link pentaho.type.Model#application} property.
      *
      * @description Creates a model instance.
      *

--- a/impl/client/src/main/javascript/web/pentaho/type/number.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/number.js
@@ -31,7 +31,7 @@ define([
      * @extends pentaho.type.Simple
      * @amd {pentaho.type.Factory<pentaho.type.Number>} pentaho/type/number
      *
-     * @classDesc The base class of numeric values.
+     * @classDesc The class of number values.
      *
      * @description Creates a number instance.
      */

--- a/impl/client/src/main/javascript/web/pentaho/type/object.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/object.js
@@ -41,7 +41,7 @@ define([
      * @extends pentaho.type.Simple
      * @amd {pentaho.type.Factory<pentaho.type.Object>} pentaho/type/object
      *
-     * @classDesc A primitive JavaScript object type.
+     * @classDesc The class that represents primitive, JavaScript {@link object} values.
      *
      * @description Creates an object instance.
      */

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -66,7 +66,7 @@ define([
      * @abstract
      * @amd {pentaho.type.Factory<pentaho.type.Property>} pentaho/type/property
      *
-     * @classDesc A property of a complex value.
+     * @classDesc The class of properties of complex values.
      *
      * @description This class was not designed to be constructed directly.
      *

--- a/impl/client/src/main/javascript/web/pentaho/type/simple.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/simple.js
@@ -47,12 +47,13 @@ define([
      * @extends pentaho.type.Element
      * @amd {pentaho.type.Factory<pentaho.type.Simple>} pentaho/type/simple
      *
-     * @classDesc The base abstract class of un-structured, indivisible values.
+     * @classDesc The base, abstract class of unstructured values.
      *
      * @description Creates a simple instance.
      * @constructor
      * @param {pentaho.type.spec.USimple} [spec] A simple specification.
      *
+     * @see pentaho.type.Complex
      * @see pentaho.type.spec.ISimple
      * @see pentaho.type.spec.ISimpleProto
      * @see pentaho.type.spec.ISimpleTypeProto

--- a/impl/client/src/main/javascript/web/pentaho/type/string.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/string.js
@@ -31,7 +31,7 @@ define([
      * @extends pentaho.type.Simple
      * @amd {pentaho.type.Factory<pentaho.type.String>} pentaho/type/string
      *
-     * @classDesc A textual type.
+     * @classDesc The class of textual values.
      *
      * @description Creates a string instance.
      */

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -55,12 +55,12 @@ define([
      * @implements pentaho.lang.ISpecifiable
      * @amd {pentaho.type.Factory<pentaho.type.Value>} pentaho/type/value
      *
-     * @classDesc A Value is an abstract class used as a base implementation and unifying type.
+     * @classDesc The base, abstract class of [instances]{@link pentaho.type.Instance} which
+     * are the _value of_ [properties]{@link pentaho.type.Property}.
      *
-     * A Value has a key that uniquely identifies the entity it represents.
+     * A `Value` has a key that uniquely identifies the entity it represents.
      *
-     *
-     * @description Creates a value instance.
+     * @description Creates a `Value` instance.
      * @constructor
      * @param {pentaho.type.spec.UValue} [spec] A value specification.
      *

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
@@ -41,6 +41,16 @@ define([
     var Mapping = context.get(mappingFactory);
 
     /**
+     * @name pentaho.visual.base.Model.Type
+     * @class
+     * @extends pentaho.type.Model.Type
+     *
+     * @classDesc The base class of visual model types.
+     *
+     * For more information see {@link pentaho.visual.base.Model}.
+     */
+
+    /**
      * @name Model
      * @memberOf pentaho.visual.base
      * @class

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
@@ -65,6 +65,16 @@ define([
       // * and can thus be safely constructed synchronously from View derived classes.
 
       /**
+       * @name pentaho.visual.base.View.Type
+       * @class
+       * @extends pentaho.type.Complex.Type
+       *
+       * @classDesc The base class of view types.
+       *
+       * For more information see {@link pentaho.visual.base.View}.
+       */
+
+      /**
        * @alias View
        * @memberOf pentaho.visual.base
        *

--- a/impl/client/src/test/config/javascript/require.config.js
+++ b/impl/client/src/test/config/javascript/require.config.js
@@ -166,7 +166,7 @@
     requireTypes[name] = "pentaho/visual/base";
   }
 
-  // Metadata Model Base Theme
+  // Type API Base Theme
   mapTheme("pentaho/type", "themes", ["crystal"]);
 
   // Visual Models Themes


### PR DESCRIPTION
…m JavaScript APIs” were known.

* Added overview to the `pentaho/visual` namespace, based on the user guide’s overview.
* Also added overviews to the `pentaho`, `pentaho/data`, `pentaho/context` and `pentaho/config` namespaces.
* Fixed doc reference to `pentaho.data.Table` to use the interface.

@pentaho/millenniumfalcon please review.