### PR TITLE
[BACKLOG-16390] It is not possible to filter a single row in the data table

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
@@ -247,7 +247,7 @@ define([
      * Returns a view for the subset of rows of a data table
      * that are selected by this filter.
      *
-     * @param {!pentaho.data.Table} dataTable - The data table to filter.
+     * @param {!pentaho.type.filter.Abstract} filter - The filter.
      *
      * @return {!pentaho.data.TableView} A view of the filtered data table.
      *
@@ -273,6 +273,25 @@ define([
       var dataView = new AbstractTable.core.TableView(this);
       dataView.setSourceRows(filteredRows);
       return dataView;
+    },
+
+    /**
+     * Gets a value that indicates if a given filter includes a given row.
+     *
+     * @param {!pentaho.type.filter.Abstract} filter - The filter.
+     * @param {number} rowIndex The row index (zero-based).
+     *
+     * @return {boolean} `true` if the filter includes the row; `false`, otherwise.
+     *
+     * @throws {pentaho.type.ValidationError} When the filter is not valid,
+     * the first error returned by the `validate` method.
+     */
+    filterMatchesRow: function(filter, rowIndex) {
+
+      filter.assertValid();
+
+      var elem = new ElementMock(this, rowIndex);
+      return filter._contains(elem);
     },
 
     /**

--- a/impl/client/src/test/javascript/pentaho/data/Table.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/Table.spec.js
@@ -368,6 +368,62 @@ define([
           expect(view.getValue(1, 1)).toBe(12000);
         });
       }); // #filter
+
+      describe("#filterMatchesRow(filter, rowIndex)", function() {
+
+        var context = new Context();
+        var AbstractFilter = context.get(abstractFilterFactory);
+        var CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+
+        var data = new DataTable({
+          model: [
+            {name: "product", type: "string", label: "Product"},
+            {name: "sales", type: "number", label: "Sales"},
+            {name: "inStock", type: "boolean", label: "In Stock"}
+          ],
+          rows: [
+            {c: [{v: "A"}, {v: 12000}, {v: true }]},
+            {c: [{v: "B"}, {v: 6000},  {v: true }]},
+            {c: [{v: "C"}, {v: 12000}, {v: false}]},
+            {c: [{v: "D"}, {v: 1000},  {v: false}]},
+            {c: [{v: "E"}, {v: 2000},  {v: false}]},
+            {c: [{v: "F"}, {v: 3000},  {v: false}]},
+            {c: [{v: "G"}, {v: 4000},  {v: false}]}
+          ]
+        });
+
+        it("should return `false` when a filter does not selects the row", function() {
+          var filter = new CustomFilter();
+
+          var result = data.filterMatchesRow(filter, 0);
+
+          expect(result).toBe(false);
+        });
+
+        it("should return `true` when a filter does select the row", function() {
+          var filter = new CustomFilter();
+
+          spyOn(filter, "_contains").and.callFake(function(elem) {
+            return elem.getv("product") === "A";
+          });
+
+          var result = data.filterMatchesRow(filter, 0);
+
+          expect(result).toBe(true);
+        });
+
+        it("should return `false` when a filter selects another row", function() {
+          var filter = new CustomFilter();
+
+          spyOn(filter, "_contains").and.callFake(function(elem) {
+            return elem.getv("product") === "A";
+          });
+
+          var result = data.filterMatchesRow(filter, 1);
+
+          expect(result).toBe(false);
+        });
+      }); // #filterMatchesRow
     });
 
     describe("columns -", function() {


### PR DESCRIPTION
* Added AbstractDataTable#filterMatchesRow method.

@pamval please review.
/cc @pentaho/millenniumfalcon