### PR TITLE
[BACKLOG-16452] Several changes

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,8 @@
 title: Pentaho Platform JavaScript APIs
-description: > # this means to ignore newlines until "theme:"
-  You can use the JavaScript APIs to develop components for the Pentaho platform.
+description: > # this means to ignore newlines in this property's value
+  JavaScript component development for the Pentaho platform.
+
+titleHtml: Platform JavaScript APIs <sup><em>beta</em></sup>
 
 theme: jekyll-theme-cayman
 

--- a/docs/_includes/default-page-header.html
+++ b/docs/_includes/default-page-header.html
@@ -1,6 +1,8 @@
   <section class="page-header default-page-header">
     <div class="page-header-wrapper">
+        {% if page.parent-title != '' %}
         <h1 class="parent-title"><a href="{{ page.parent-path | default: '.' }}">{{ page.parent-title | default: site.title | default: site.github.repository_name }}</a></h1><span>·</span>
+        {% endif %}
         <h2 class="page-title">{{ page.title }}</h2>
     </div>
   </section>

--- a/docs/_includes/default-site-header.html
+++ b/docs/_includes/default-site-header.html
@@ -2,5 +2,5 @@
     <a class="logo" href="{{ '/' | relative_url }}">
       <img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="Pentaho" onerror="this.src='http://www.pentaho.com/sites/all/themes/pentaho_resp/logo.svg';">
     </a>
-    <h1><a href="{{ '/' | relative_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+    <h1><a href="{{ '/' | relative_url }}">{{ site.titleHtml | default: site.github.repository_name }}</a></h1>
   </header>

--- a/docs/_layouts/intro.html
+++ b/docs/_layouts/intro.html
@@ -12,7 +12,7 @@
 
   <section class="page-header intro-page-header">
     <div class="page-header-wrapper">
-        <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
+        <h1 class="project-name">{{ site.titleHtml | default: site.github.repository_name }}</h1>
         <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
         {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>

--- a/docs/_sass/_api-list.scss
+++ b/docs/_sass/_api-list.scss
@@ -18,6 +18,11 @@
     background: 0 0;
     background-color: #FCFCFC;
 
+    dd {
+      color: #606c71;
+      font-size: 1rem;
+    }
+
     margin-bottom: 2em;
     padding: 0;
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,36 @@
 ---
-title: Pentaho Platform JavaScript APIs
+title: Platform JavaScript APIs
 description: The Pentaho Platform JavaScript APIs support the development of JavaScript components for the Pentaho platform.
 layout: intro
 ---
 
-The Pentaho Platform JavaScript APIs support the development of JavaScript components for the Pentaho platform, by standardizing in cross-cutting areas, such as data and visualization, but also on lower-level areas, such as configuration, localization, services and, even, control of debugging information; and exposing key Pentaho platform information and services to JavaScript components.
+The **Platform JavaScript APIs** support the development of JavaScript components for the **Pentaho** platform:
+1. Standardizes in cross-cutting areas, such as data and visualization, 
+   but also on lower-level areas, such as configuration, localization and services. 
+2. Exposes key platform information and services to JavaScript components.
 
 The APIs are organized as follows:
 <ul class="api-list">
     <li class="bigger">
         <dl>
             <dt>
-                <a title="Pentaho Visualization API" href="platform/visual">Pentaho Visualization API</a> ⭐ <em>3.0 beta</em>
+                <a title="Pentaho JavaScript Visualization API" href="platform/visual">Visualization</a>
             </dt>
-            <dd>
-                The Pentaho Visualization API provides a unified way to visualize data across the Pentaho suite 
-                (e.g. Analyzer, PDI, CDF).
-
-                Essentially, it is a set of abstractions that ensures isolation between applications, visualizations and configurations (that glue the two together).
-            </dd>
+            <dd>A unified way to visualize data across the Pentaho suite.</dd>
         </dl>
     </li>
     <li>
         <dl>
             <dt>
-                <a title="Pentaho Data API" 
-                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.data'}}">Pentaho Data API</a>
+                <a title="Pentaho JavaScript Data API" 
+                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.data'}}">Data</a>
             </dt>
-            <dd>The Pentaho Data API contains a <em>data table</em> abstraction that allows components and applications to consume and exchange tabular data in a common way.
+            <dd>Abstractions for data exchange among components, applications and data sources.
                 <ul style="display: none;">
                     <li>
                         <dl>
                             <dt>
-                                <a title="Pentaho Data Access API" 
-                                   href="data/access">Data Access API</a>
+                                <a title="Pentaho JavaScript Data Access API" href="data/access">Data Access</a>
                             </dt>
                             <dd>Unreleased</dd>
                         </dl>
@@ -45,56 +42,73 @@ The APIs are organized as follows:
     <li>
         <dl>
             <dt>
-                <a title="Pentaho Type API" 
-                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.type'}}">Type API</a>
+                <a title="Pentaho JavaScript Type API" 
+                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.type'}}">Type</a>
             </dt>
-            <dd>Pentaho Client Metadata Model.</dd>
+            <dd><em>Types</em> offer out-of-the-box features such as class inheritance, metadata support, 
+                configuration, validation and serialization.
+            </dd>
         </dl>
     </li>
     <li class="bigger">
         <dl>
-            <dt>
-                Pentaho Core APIs
+            <dt id="core">
+                Core
             </dt>
-            <dd>Pentaho Web Platform's base functionality.
+            <dd>
                 <ul>
                     <li>
                         <dl>
                             <dt>
-                                <a title="Environment" 
+                                <a title="Pentaho JavaScript Configuration API" 
+                                href="platform/configuration">Configuration</a>
+                            </dt>
+                            <dd>Allows <em>types</em> to be configured by third-parties.</dd>
+                        </dl>
+                    </li>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="Pentaho JavaScript Service API" 
+                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}">Service</a>
+                            </dt>
+                            <dd>Service provider AMD/RequireJS plugin.</dd>
+                        </dl>
+                    </li>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="Pentaho JavaScript Localization API"
+                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.i18n'}}">Localization</a>
+                            </dt>
+                            <dd>Resource bundle loader AMD/RequireJS plugin.</dd>
+                        </dl>
+                    </li>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="Pentaho JavaScript Language Support API"
+                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.lang'}}">Language Support</a>
+                            </dt>
+                            <dd>API building blocks for JavaScript.</dd>
+                        </dl>
+                    </li>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="Pentaho JavaScript Environment API" 
                                    href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.context'}}">Environment</a>
                             </dt>
-                            <dd>The Pentaho Web Client Platform's contextual information.</dd>
+                            <dd>Platform environmental information.</dd>
                         </dl>
                     </li>
                     <li>
                         <dl>
                             <dt>
-                                <a title="Services" 
-                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}">Services</a>
+                                <a title="Pentaho JavaScript Debugging Control API"
+                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.debug'}}">Debugging</a>
                             </dt>
-                            <dd>AMD plugin which maintains a collection of logical modules and their dependencies.</dd>
-                        </dl>
-                    </li>
-                    <li>
-                        <dl>
-                            <dt>
-                                <a title="Pentaho Core API Configuration" 
-                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.config'}}">Configuration System</a>
-                            </dt>
-                            <dd>Classes and interfaces related to the configuration of value types.</dd>
-                        </dl>
-                    </li>
-                    <li>
-                        <dl>
-                            <dt>
-                                <a title="Pentaho Core API Lang package" 
-                                   href="{{site.refDocsUrlPattern | replace: '$', 'pentaho.lang'}}">pentaho/lang</a>
-                            </dt>
-                            <dd>
-                                Classes and interfaces used as type system building blocks to form other classes and 
-                                interfaces of the Pentaho Web Platform.
-                             </dd>
+                            <dd>Controls the debugging level of components.</dd>
                         </dl>
                     </li>
                 </ul>
@@ -104,9 +118,9 @@ The APIs are organized as follows:
     <li>
         <dl>
             <dt>
-                <a title="Pentaho Web Package" href="platform/pentaho-web-package">Pentaho Web Package</a>
+                <a title="Pentaho Web Package" href="platform/web-package">Web Package</a>
             </dt>
-            <dd>How to package web resources into the Pentaho platform.</dd>
+            <dd>The deployment, dependency and versioning unit for web resources.</dd>
         </dl>
     </li>
 </ul>

--- a/docs/platform/bundling.md
+++ b/docs/platform/bundling.md
@@ -1,7 +1,7 @@
 ---
-title: Bundling a visualization
-description: Explains the core concepts and walks through the creation of a kar file for deploying a visualization in the Pentaho Platform.
-parent-title: Visualization API
+title: Bundling a web package and provisioning
+description: Explains the core concepts and walks through the creation of a kar file for deploying a web package in the Pentaho Platform.
+parent-title: ""
 layout: default
 ---
 

--- a/docs/platform/configuration.md
+++ b/docs/platform/configuration.md
@@ -1,8 +1,7 @@
 ---
 title: Configuration API
 description: The Configuration API provides a means for types to be configured by third-parties.
-parent-title: Pentaho Platform JavaScript APIs
-parent-path: ../..
+parent-title: ""
 layout: default
 ---
 
@@ -124,11 +123,11 @@ The configuration file is shipped with a small set of illustrative (but commente
 so you need to backup the file yourself before upgrading and restore it afterwards.
 
 As an alternative to using the global configuration file, 
-you can bundle and deploy your own [Pentaho Web Package](pentaho-web-package) 
+you can bundle and deploy your own [Pentaho Web Package](web-package) 
 containing a registered configuration module.
 
 Component authors may also wish to provide a default configuration beside the component,
-included and registered in the same [Pentaho Web Package](pentaho-web-package). 
+included and registered in the same [Pentaho Web Package](web-package). 
 
 
 ## Known Values of Pentaho Environment Variables

--- a/docs/platform/visual/analyzer-viz-api.md
+++ b/docs/platform/visual/analyzer-viz-api.md
@@ -13,7 +13,7 @@ layout: default
 [Pentaho Analyzer](http://www.pentaho.com/product/business-visualization-analytics) reports display visualizations that 
 are based on the [Pentaho Visualization API](.).
 
-As of 7.1, the Pentaho platform ships with the _new_ version of the Visualization API, still in **beta**, 
+As of version 7.1, the Pentaho platform ships with the _new_ version of the Visualization API, still in **beta**, 
 **side-by-side** with the _previous_ version.
  
 Analyzer supports visualizations of both formats,

--- a/docs/platform/visual/configuration.md
+++ b/docs/platform/visual/configuration.md
@@ -1,13 +1,11 @@
 ---
-title: Configuring your Visualization
+title: Configuring a visualization
 description: Shows how to use the Configuration API to configure a visualization.
 parent-title: Visualization API
 layout: default
 ---
 
-This article shows you how to create a configuration for a 
-[Visualization API](.) 
-visualization.
+This article shows you how to create a configuration for a [Visualization API](.) visualization.
 
 It is assumed that you have some basic knowledge on how to configure JavaScript _types_ on the Pentaho platform
 and on what constitutes a visualization.

--- a/docs/platform/visual/index.md
+++ b/docs/platform/visual/index.md
@@ -1,44 +1,60 @@
 ---
-title: Pentaho Visualization API
-description: The Pentaho Visualization API provides a unified way to visualize data across the Pentaho suite (Analyzer, PDI, CDF).
-parent-title: Pentaho Platform JavaScript APIs
-parent-path: ..
+title: Visualization API
+description: A unified way to visualize data across the Pentaho suite.
 layout: sub-intro
 ---
 
 # Overview
 
-As of 7.1, the Pentaho platform ships with a _new_ version of the Visualization API, still in **beta**, 
-**side-by-side** with the _previous_ version. This documentation relates to the new version.
+{% include callout.html content="<p>As of version 7.1, 
+the Pentaho platform ships with a <em>new</em>, <b>beta</b> version of the Visualization API, 
+<b>side-by-side</b> with the <em>previous</em> version. 
+This documentation relates to the new version.</p>
+" type="warning" %}
 
-The Pentaho Visualization API provides a unified way to visualize data across the Pentaho suite 
+The [Visualization API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual'}}) 
+provides a unified way to visualize data across the Pentaho suite 
 (e.g.
 [Analyzer](http://www.pentaho.com/product/business-visualization-analytics), 
 [PDI](http://www.pentaho.com/product/data-integration), 
 [CDF](http://community.pentaho.com/ctools/cdf/)).
 
-Essentially, it is a set of abstractions that ensures isolation between
-applications, visualizations and configurations (that glue the two together).
+Essentially, it is a set of abstractions that enables safe, isolated operation between 
+applications, visualizations and business logic.
 
-Visualizations are implemented on top of the Pentaho Core, Type and Data JavaScript APIs:
-- Using the [Type API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.type'}}) 
-  endows visualizations with out-of-the-box class inheritance, metadata support, type configuration, 
-  validation, serialization, among other features.
-- Using the [Data API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.data'}}) 
+A **visualization** is constituted by:
+
+- One [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}), 
+  which _identifies_ the visualization and 
+  _defines_ it in terms of its their data requirements, 
+  such as the visual degrees of freedom it has (e.g. _X position_, _color_ and _size_) and 
+  any major options that affect its rendering.
+
+- One [`View`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.View'}}) (at least), 
+  which implements the actual rendering using chosen technologies 
+  (e.g. [HTML](https://www.w3.org/TR/html/), [SVG](https://www.w3.org/TR/SVG/), [D3](https://d3js.org/)),
+  and handle user interaction, 
+  dispatching [actions]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.action'}}) and, 
+  for example, showing tooltips.
+
+The Visualization API is built on top of other Platform JavaScript APIs:
+
+- The [Data API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.data'}}) 
   ensures seamless integration with data sources in the Pentaho platform, 
   as well as with other client-side component frameworks.
-- Using [Core APIs]()
-  provides visualizations with features such as localization, theming and registration.
 
-The platform provides a set of stock visualizations, covering the most
-common chart-types.
-Based on the [CCC](http://community.pentaho.com/ctools/ccc/) charting
-library, they're customizable and extensible to fit your organization's
-desired look and feel.
-For more information on how to customize visualizations,
-see [Configuration](configuration).
+- The [Type API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.type'}}) 
+  provides to visualizations out-of-the-box features such as class inheritance, metadata support, configuration, 
+  validation and serialization.
 
-If you want to know more about how Pentaho Analyzer exposes the new Visualization API, 
+- The [Core APIs](../../#core) provide to visualizations features such as localization, theming and 
+  services registration and consumption.
+
+A set of stock visualizations is included, covering the most common chart types.
+Based on the [CCC](http://community.pentaho.com/ctools/ccc/) charting library, 
+they're customizable and extensible to fit your organization's desired look and feel.
+
+If you want to know more about the specifics of how Analyzer exposes the Visualization API, 
 read [Analyzer and the Visualization API](analyzer-viz-api).
 
 # Creating a visualization
@@ -56,7 +72,7 @@ For a better understanding, see the [Bar/D3 sample](samples/bar-d3-sandbox),
 that walks you through creating a custom visualization having a
 [D3](https://d3js.org/)-based view.
 
-# Packaging
+# Packaging the visualization
 
 Your visualization must be wrapped as a Pentaho Web Package. 
 All packages must contain a file `META-INF/js/package.json`, 
@@ -84,7 +100,7 @@ Finally, any third-party dependencies must be declared in the same file.
 }
 ```
 
-See [Pentaho Web Package description](../pentaho-web-package) for a more detailed view.
+See [Pentaho Web Package description](../web-package) for a more detailed view.
 
 # Bundling and provisioning
 
@@ -94,7 +110,7 @@ Additionally, the required client side dependencies must also be provided to the
 The recommended way is to put the visualization bundle, its dependencies, 
 and corresponding feature definition together into a single KAR file.
 
-See [Bundling](bundling) for instructions.
+See [Bundling a web package and provisioning](../bundling) for instructions.
 
 # Deploying the visualization
 
@@ -119,7 +135,7 @@ If every thing went well you should now see your visualization in Analyzer and/o
 
 > TODO: Explain how to distribute it using marketplace?
 
-# Configuring a visualization
+# Configuring the visualization
 
 Pentaho's JavaScript API allows users to declare _prioritized configuration rules_ 
 that configure the objects built using the Type API.
@@ -129,5 +145,4 @@ Typical configuration rules include:
 - adding validations, 
 - extending objects with environment-specific properties
 
-See [configuration](configuration) for more details.
-
+See [Configuring a visualization](configuration) for more details.

--- a/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
@@ -6,20 +6,7 @@ parent-title: Create a custom Bar chart visualization using D3
 layout: default
 ---
 
-## Quick background facts
-
-### On visualizations...
-
-A visualization is constituted by:
-
-- One **model**, which _identifies_ the visualization and _defines_ it 
-  in terms of the visual degrees of freedom it has (e.g. _X position_, _color_ and _size_) and 
-  any major options that affect its rendering.
-
-- One **view** (at least), which implements the actual rendering using chosen technologies 
-  (e.g. [HTML](https://www.w3.org/TR/html/), [SVG](https://www.w3.org/TR/SVG/), [D3](https://d3js.org/)).
-
-### On Bar charts...
+## Quick facts on Bar charts
 
 The simplest of Bar charts shows a single _series_ of data: 
 a list of pairs of a category and a measure, where each category can only occur in one of the pairs.
@@ -33,7 +20,6 @@ as they are called in the Visualization API, **visual roles**:
 _Category_ and _Measure_.
 The values of the attributes mapped to visual roles are visually encoded using visual variables/properties such as 
 position, size, orientation or color.
-
 
 ## Complete model code
 

--- a/docs/platform/web-package.md
+++ b/docs/platform/web-package.md
@@ -1,12 +1,11 @@
 ---
-title: Pentaho Web Package
+title: Web Package
 description: Describes how to package web client resources, including visualizations, into the Pentaho platform.
-parent-title: Pentaho Platform JavaScript APIs
-parent-path: ..
+parent-title: ""
 layout: default
 ---
 
-The Pentaho Platform detects and manages OSGi bundles that are Web Client Packages, 
+The Pentaho Platform detects and manages OSGi bundles that are Web Packages, 
 collecting the information needed to build the AMD/RequireJS configuration and 
 to setup the mappings needed to serve the package resources through HTTP.
 


### PR DESCRIPTION
* Removed the parent-title from 1st-level pages, where the site header would just be duplicated
* Removed the word “Pentaho” from a lot of places where it is implied, making the text look clearer
* Removed the word “API” where it could be implied and elsewhere clarified
* Simplified the summaries of the blocks in the top Platform page (and made the dd font lighter and smaller)
* Removed the New star and moved the beta modifier to the site title
* Moved bundling.md from visual to platform.
* In Visualization API promoted the “side-by-side versions” statement to a “warning callout”

@pentaho/millenniumfalcon please review.