### PR TITLE
[BACKLOG-16452] Improved Top Platform page by creating boxes for “Web…

### DIFF
--- a/docs/_includes/default-footer-learn-more.html
+++ b/docs/_includes/default-footer-learn-more.html
@@ -2,8 +2,8 @@
     <div class="footer-wrapper">
       <h2>Learn More:</h2>
       <ul>
-        <li><a href="" target="_blank">Reference documentation</a></li>
-        <li><a href="" target="_blank">Pentaho Forums</a></li>
+        <li><a href="{{site.refDocsUrlPattern | replace: '$', ''}}" target="_blank">Reference documentation</a></li>
+        <li><a href="http://forums.pentaho.com/" target="_blank">Pentaho Forums</a></li>
       </ul>
     </div>
   </footer>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -13,6 +13,10 @@
 
 a { color: #005DA6; text-decoration: none; }
 
+.api-list li.ground-layer {
+  background-color: #DDDDE1;
+}
+
 @import "site-header";
 @import "page-header";
 @import "footer-learn-more";

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,7 +127,7 @@ The APIs are organized as follows:
                             <dt>
                                 <a title="Pentaho Web Package" href="platform/web-package">Pentaho Web Package</a>
                             </dt>
-                            <dd>The dependency and versioning unit for JavaScript web resources
+                            <dd>The dependency and versioning unit for JavaScript resources
                                 in the Pentaho platform.</dd>
                         </dl>
                     </li>
@@ -136,10 +136,11 @@ The APIs are organized as follows:
                     <li>
                         <dl>
                             <dt>
-                                <a title="OSGi Bundle" href="platform/osgi-web-project">OSGi Web Project</a>
+                                <a title="Pentaho Web Project" href="platform/web-project">Pentaho Web Project</a>
                             </dt>
-                            <dd>Bundles a Pentaho Web Package and its dependencies and 
-                                compiles into an OSGi Artifact.</dd>
+                            <dd>A Maven project that contains a Pentaho Web Package and 
+                                information of WebJar dependencies, 
+                                and compiles into an OSGi Artifact.</dd>
                         </dl>
                     </li>
                 </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,12 +115,47 @@ The APIs are organized as follows:
             </dd>
         </dl>
     </li>
-    <li>
+    <li class="bigger ground-layer">
         <dl>
-            <dt>
-                <a title="Pentaho Web Package" href="platform/web-package">Web Package</a>
+            <dt id="ground">
+                Pentaho Web Platform
             </dt>
-            <dd>The deployment, dependency and versioning unit for web resources.</dd>
+            <dd>
+                <ul>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="Pentaho Web Package" href="platform/web-package">Pentaho Web Package</a>
+                            </dt>
+                            <dd>The dependency and versioning unit for JavaScript web resources
+                                in the Pentaho platform.</dd>
+                        </dl>
+                    </li>
+                </ul>
+                <ul>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="OSGi Bundle" href="platform/osgi-web-project">OSGi Web Project</a>
+                            </dt>
+                            <dd>Bundles a Pentaho Web Package and its dependencies and 
+                                compiles into an OSGi Artifact.</dd>
+                        </dl>
+                    </li>
+                </ul>
+                <ul>
+                    <li>
+                        <dl>
+                            <dt>
+                                <a title="OSGi Artifacts Deployment" href="platform/osgi-deployment">
+                                OSGi Artifacts Deployment
+                                </a>
+                            </dt>
+                            <dd>Deployment of OSGi artifacts on the Pentaho platform.</dd>
+                        </dl>
+                    </li>
+                </ul>
+            </dd>
         </dl>
     </li>
 </ul>

--- a/docs/platform/osgi-deployment.md
+++ b/docs/platform/osgi-deployment.md
@@ -1,0 +1,20 @@
+---
+title: OSGi/Karaf Artifacts Deployment
+description: Explains how to deploy OSGi/Karaf artifacts to the Pentaho Platform.
+parent-title: ""
+layout: default
+---
+
+The Pentaho platform is built on top of an [OSGi](https://www.osgi.org/) container 
+([Apache Karaf](https://karaf.apache.org)).
+It allows for a simple modular approach at both development time and runtime, 
+reducing complexity and facilitating deployment.
+
+The [OSGi/Karaf artifacts](osgi-web-project#osgikaraf-artifacts): bundle, feature file and KAR file, can be deployed to the Pentaho platform by 
+dropping them to the **Karaf deploy** directory. Hot deployment is generally supported.
+Artifacts are automatically installed and activated (and remain so, even after restarts of the product). 
+Replacing an artifact in the deploy folder will reinstall it. Deleting it, will uninstall it.
+
+Depending on the Pentaho product, the _Karaf deploy_ folder is located at:
+- PDI: `system/karaf/deploy`
+- Pentaho Server: `pentaho-solutions/system/karaf/deploy`.

--- a/docs/platform/osgi-deployment.md
+++ b/docs/platform/osgi-deployment.md
@@ -10,7 +10,7 @@ The Pentaho platform is built on top of an [OSGi](https://www.osgi.org/) contain
 It allows for a simple modular approach at both development time and runtime, 
 reducing complexity and facilitating deployment.
 
-The [OSGi/Karaf artifacts](osgi-web-project#osgikaraf-artifacts): bundle, feature file and KAR file, can be deployed to 
+The [OSGi/Karaf artifacts](web-project#osgikaraf-artifacts): bundle, feature file and KAR file, can be deployed to 
 the Pentaho platform by dropping them to the **Karaf deploy** directory. Hot deployment is generally supported.
 Artifacts are automatically installed and activated (and remain so, even after restarts of the product). 
 Replacing an artifact in the deploy folder will reinstall it. Deleting it, will uninstall it.

--- a/docs/platform/osgi-deployment.md
+++ b/docs/platform/osgi-deployment.md
@@ -1,5 +1,5 @@
 ---
-title: OSGi/Karaf Artifacts Deployment
+title: OSGi Artifacts Deployment
 description: Explains how to deploy OSGi/Karaf artifacts to the Pentaho Platform.
 parent-title: ""
 layout: default
@@ -10,8 +10,8 @@ The Pentaho platform is built on top of an [OSGi](https://www.osgi.org/) contain
 It allows for a simple modular approach at both development time and runtime, 
 reducing complexity and facilitating deployment.
 
-The [OSGi/Karaf artifacts](osgi-web-project#osgikaraf-artifacts): bundle, feature file and KAR file, can be deployed to the Pentaho platform by 
-dropping them to the **Karaf deploy** directory. Hot deployment is generally supported.
+The [OSGi/Karaf artifacts](osgi-web-project#osgikaraf-artifacts): bundle, feature file and KAR file, can be deployed to 
+the Pentaho platform by dropping them to the **Karaf deploy** directory. Hot deployment is generally supported.
 Artifacts are automatically installed and activated (and remain so, even after restarts of the product). 
 Replacing an artifact in the deploy folder will reinstall it. Deleting it, will uninstall it.
 

--- a/docs/platform/osgi-web-project.md
+++ b/docs/platform/osgi-web-project.md
@@ -1,13 +1,16 @@
 ---
-title: Bundling a web package and provisioning
-description: Explains the core concepts and walks through the creation of a kar file for deploying a web package in the Pentaho Platform.
+title: Create an OSGi project for a Web Package and its Dependencies
+description: Explains the core concepts and walks through the creation of a KAR file for deploying a web package and its dependencies in the Pentaho Platform.
 parent-title: ""
 layout: default
 ---
 
-The Pentaho platform is built on top of an OSGi container ([Apache Karaf](https://karaf.apache.org)).
+The Pentaho platform is built on top of an [OSGi](https://www.osgi.org/) container 
+([Apache Karaf](https://karaf.apache.org)).
 It allows for a simple modular approach at both development time and runtime, 
 reducing complexity and facilitating deployment.
+
+## OSGi/Karaf Artifacts
 
 A **bundle** is the deployment unit in OSGi. 
 Basically, a bundle is just a JAR file with special bundle headers in its `META-INF/MANIFEST.MF` file.
@@ -86,8 +89,13 @@ as these are provided by the platform.
 
 ## Building it
 
+To build the project, execute:
+
 ```shell
-mvn package
+mvn clean package
 ```
 
-...
+If everything went well, the KAR artifact will be located at `assemblies/target`.
+
+If you want to know how to deploy the built artifact to a Pentaho product,
+see [OSGi/Karaf Artifacts Deployment](osgi-deployment).

--- a/docs/platform/osgi-web-project.md
+++ b/docs/platform/osgi-web-project.md
@@ -1,5 +1,5 @@
 ---
-title: Create an OSGi project for a Web Package and its Dependencies
+title: Create an OSGi Web Project for a Web Package and its Dependencies
 description: Explains the core concepts and walks through the creation of a KAR file for deploying a web package and its dependencies in the Pentaho Platform.
 parent-title: ""
 layout: default

--- a/docs/platform/visual/configuration.md
+++ b/docs/platform/visual/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring a visualization
+title: Configuring a Visualization
 description: Shows how to use the Configuration API to configure a visualization.
 parent-title: Visualization API
 layout: default

--- a/docs/platform/visual/create.md
+++ b/docs/platform/visual/create.md
@@ -7,21 +7,6 @@ layout: default
 
 This walk-through guides you through the creation of a custom visualization for the Pentaho platform, 
 from developing the visualization itself to building an OSGi Artifact that can be deployed to Pentaho products.
- 
-## Fast-lane
-
-If you prefer, you can skip the walk-through and get the final OSGi Web Project, and build it.
-
-```shell
-# Clone the repository.
-git clone https://github.com/pentaho/pentaho-engineering-samples
-
-# Go to the sample's directory.
-cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-bundle
-
-# Build the OSGi Web Project
-mvn clean package
-```
 
 ## 1. Develop the Visualization in a Sandbox
 
@@ -35,13 +20,23 @@ which guides you through the development of a custom visualization having a [D3]
 ## 2. Create the Pentaho Web Package
 
 In the previous section you developed a custom visualization and tested it in a controlled sandbox environment.
-To use the visualization in Pentaho products, 
-it must take the form of a [Pentaho Web Package](../web-package). 
-This essentially means that you need to create a `package.json` file that describes the contained JavaScript resources.
 
-Apart from the mandatory `name` and `version` fields, and the D3 library dependency, 
-you must also advertise the existence of your visualization to the platform, 
-so that applications like Analyzer and PDI can offer it to users.
+If you exclude the sandbox specific files, 
+you are left with `model.js`, `view-d3.js`, `config.js` and a `css` folder.
+However, note, one important feature — the AMD/RequireJS configuration — was part of the sandbox `index.html` file.
+Also, the D3 dependency was declared in the sandbox's `npm` `package.json` file.
+ 
+When developing for the Pentaho platform, 
+equivalent information needs to be provided in a _Pentaho Web Package descriptor_ file, 
+which, not coincidentally, is called `package.json`.
+We call the set of web resources plus its package descriptor a [Pentaho Web Package](../web-package).
+
+At a minimum, the `package.json` file requires the `name` and `version` fields.
+We choose the package name to match the AMD/RequireJS identifier prefix by which we want the resources to be available.
+
+The D3 library dependency, is declared similarly to how it was declared.
+
+Your visualization must be advertised to the platform so that applications like Analyzer and PDI can offer it to users.
 This is done by registering 
 the visualization's [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}) module
 with [`pentaho/service`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}),
@@ -70,7 +65,7 @@ The result is the following `package.json` content:
 }
 ```
 
-## 3. Create the OSGi Web Project
+## 3. Create the Pentaho Web Project
 
 The Pentaho platform is built on top of an OSGi container, 
 so developers must provide their code as an OSGi/Karaf artifact. 
@@ -79,9 +74,9 @@ Additionally, any client-side dependencies must also be provided to the platform
 The recommended way is to put the visualization bundle, its dependencies, 
 and corresponding feature definition together into a single KAR file.
 
-See [Create an OSGi Web Project for a Web Package and its Dependencies](../osgi-web-project) for instructions.
+See [Create a Pentaho Web Project for a Web Package and its Dependencies](../web-project) for instructions.
 
 ## 4. Next Steps
 
 To learn how to deploy the visualization,
-continue reading at [Deploy the visualization](.#deploy-the-visualization).
+continue reading at [Deploy the visualization](.#deploying-the-visualization).

--- a/docs/platform/visual/create.md
+++ b/docs/platform/visual/create.md
@@ -1,0 +1,87 @@
+---
+title: Create a Custom Visualization
+description: Complete walk-through on how to create a visualization for the Pentaho platform.
+parent-title: Visualization API
+layout: default
+---
+
+This walk-through guides you through the creation of a custom visualization for the Pentaho platform, 
+from developing the visualization itself to building an OSGi Artifact that can be deployed to Pentaho products.
+ 
+## Fast-lane
+
+If you prefer, you can skip the walk-through and get the final OSGi Web Project, and build it.
+
+```shell
+# Clone the repository.
+git clone https://github.com/pentaho/pentaho-engineering-samples
+
+# Go to the sample's directory.
+cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-bundle
+
+# Build the OSGi Web Project
+mvn clean package
+```
+
+## 1. Develop the Visualization in a Sandbox
+
+You will start by developing the visualization in a controlled sandbox environment.
+Then, you will drop the sandbox and package the visualization's files in a way that
+it can be deployed to Pentaho products.
+
+Do the [Bar/D3 Visualization in Sandbox](samples/bar-d3-sandbox) walk-through, 
+which guides you through the development of a custom visualization having a [D3](https://d3js.org/)-based view.
+
+## 2. Create the Pentaho Web Package
+
+In the previous section you developed a custom visualization and tested it in a controlled sandbox environment.
+To use the visualization in Pentaho products, 
+it must take the form of a [Pentaho Web Package](../web-package). 
+This essentially means that you need to create a `package.json` file that describes the contained JavaScript resources.
+
+Apart from the mandatory `name` and `version` fields, and the D3 library dependency, 
+you must also advertise the existence of your visualization to the platform, 
+so that applications like Analyzer and PDI can offer it to users.
+This is done by registering 
+the visualization's [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}) module
+with [`pentaho/service`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}),
+as a service of type `pentaho/visual/base`.
+
+The default configuration module that you developed also needs to be advertised to the configuration system,
+by registering it with `pentaho/service` as a service of type `pentaho.config.spec.IRuleSet`.
+
+The result is the following `package.json` content:
+
+```json
+{ 
+  "name": "pentaho/visual/samples/bar",
+  "version": "1.0.0",
+  
+  "config": {
+    "pentaho/service": {
+      "pentaho/visual/samples/bar_1.0.0/model": "pentaho/visual/base",
+      "pentaho/visual/samples/bar_1.0.0/config": "pentaho.config.spec.IRuleSet"
+    }
+  },
+  
+  "dependencies": {
+    "d3": "^4.8.0"
+  }
+}
+```
+
+## 3. Create the OSGi Web Project
+
+The Pentaho platform is built on top of an OSGi container, 
+so developers must provide their code as an OSGi/Karaf artifact. 
+Additionally, any client-side dependencies must also be provided to the platform as OSGi bundles.
+
+The recommended way is to put the visualization bundle, its dependencies, 
+and corresponding feature definition together into a single KAR file.
+
+See [Create an OSGi Web Project for a Web Package and its Dependencies](../osgi-web-project) for instructions.
+
+## 4. Next Steps
+
+To learn how to deploy the visualization,
+continue reading at [Deploy the visualization](.#deploy-the-visualization).

--- a/docs/platform/visual/index.md
+++ b/docs/platform/visual/index.md
@@ -22,21 +22,6 @@ provides a unified way to visualize data across the Pentaho suite
 Essentially, it is a set of abstractions that enables safe, isolated operation between 
 applications, visualizations and business logic.
 
-A **visualization** is constituted by:
-
-- One [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}), 
-  which _identifies_ the visualization and 
-  _defines_ it in terms of its their data requirements, 
-  such as the visual degrees of freedom it has (e.g. _X position_, _color_ and _size_) and 
-  any major options that affect its rendering.
-
-- One [`View`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.View'}}) (at least), 
-  which implements the actual rendering using chosen technologies 
-  (e.g. [HTML](https://www.w3.org/TR/html/), [SVG](https://www.w3.org/TR/SVG/), [D3](https://d3js.org/)),
-  and handle user interaction, 
-  dispatching [actions]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.action'}}) and, 
-  for example, showing tooltips.
-
 The Visualization API is built on top of other Platform JavaScript APIs:
 
 - The [Data API]({{site.refDocsUrlPattern | replace: '$', 'pentaho.data'}}) 
@@ -59,18 +44,49 @@ read [Analyzer and the Visualization API](analyzer-viz-api).
 
 The following sections will guide you through the complete process of creating a custom visualization 
 for the Pentaho platform, 
-from [developing it](#create-a-visualization), 
-to [deploying it](#deploy-the-visualization) to Pentaho products and 
-to [configuring it](#configure-the-visualization).
+from [developing it](#creating-a-visualization), 
+to [deploying it](#deploying-the-visualization) to Pentaho products and 
+to [configuring it](#configuring-the-visualization).
  
-# Create a visualization
+# Creating a visualization
 
-Read the [Create a Custom Visualization](create) walk-through.
+Creating a visualization boils down to creating:
 
-# Deploy the visualization
+- One [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}) — 
+  which _identifies_ the visualization and 
+  _defines_ it in terms of its their data requirements, 
+  such as the visual degrees of freedom it has (e.g. _X position_, _color_ and _size_) and 
+  any major options that affect its rendering, — and
 
-See [OSGi Artifacts Deployment](../osgi-deployment) for quick instructions on 
-how to deploy the KAR file you just built (located at `assemblies/target`).
+- One [`View`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.View'}}) (at least) — 
+  which implements the actual rendering using chosen technologies 
+  (e.g. [HTML](https://www.w3.org/TR/html/), [SVG](https://www.w3.org/TR/SVG/), [D3](https://d3js.org/)),
+  and handle user interaction, 
+  dispatching [actions]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.action'}}) and, 
+  for example, showing tooltips.
+
+The [Create a Custom Visualization](create) walk-through shows you how to develop these and 
+how to create an OSGi artifact containing the visualization, 
+so that it can be deployed to a Pentaho product.
+
+{% include callout.html content="<h2>Fast-lane</h2>
+<p>If you prefer, you can skip the walk-through and get the final Pentaho Web Project, and build it.</p>
+<pre class='highlight'><code># Clone the repository.
+git clone https://github.com/pentaho/pentaho-engineering-samples
+
+# Go to the sample's directory.
+cd pentaho-engineering-samples
+cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-bundle
+
+# Build the Web Project
+mvn package
+</code></pre>" type="warning" %}
+
+# Deploying the visualization
+
+To deploy the visualization to a Pentaho product (Pentaho Server or PDI), 
+copy the KAR file you just built (located at `assemblies/target`) into its `karaf/deploy` folder.
+See [OSGi Artifacts Deployment](../osgi-deployment) if you need more information.
 
 If everything went well, you should now see your visualization being offered in Analyzer and/or PDI:
 
@@ -88,9 +104,9 @@ If everything went well, you should now see your visualization being offered in 
 
 <!-- TODO: Explain how to distribute it using marketplace? -->
 
-# Configure the visualization
+# Configuring the visualization
 
-Besides the default configuration you have included with the visualization,
-the visualization can be further configured by third-parties. 
+A visualization can be configured by third-parties using configuration rules in external configuration files.
+These configurations are merged with any default configuration that is included with the visualization.
 
 See [Configuring a Visualization](configuration) for more details.

--- a/docs/platform/visual/index.md
+++ b/docs/platform/visual/index.md
@@ -58,104 +58,19 @@ If you want to know more about the specifics of how Analyzer exposes the Visuali
 read [Analyzer and the Visualization API](analyzer-viz-api).
 
 The following sections will guide you through the complete process of creating a custom visualization 
-for the Pentaho platform, from developing the visualization itself to deploying it to Pentaho products.
+for the Pentaho platform, 
+from [developing it](#create-a-visualization), 
+to [deploying it](#deploy-the-visualization) to Pentaho products and 
+to [configuring it](#configure-the-visualization).
  
-1. [Create a visualization](#create-a-visualization)
-   1. [Develop the visualization itself](#develop-the-visualization-itself)
-   2. [Create the Pentaho Web Package](#create-the-pentaho-web-package)
-   3. [Create the OSGi Web Project](#create-the-osgi-web-project)
-2. [Build the OSGi Web Project](#build-the-osgi-web-project)
-3. [Deploy the OSGi Artifact](#deploy-the-osgi-artifact)
-4. [Configure the visualization](#configure-the-visualization)
-
 # Create a visualization
 
-## Fast-lane
+Read the [Create a Custom Visualization](create) walk-through.
 
-If you prefer to skip through the development of the visualization itself, 
-up until its bundling as an OSGi artifact,
-you can skip the following sub-sections and head on to 
-[Build the OSGi Web Project](#build-the-osgi-web-project).
-Before you go, though, you should clone the complete OSGi project:
-
-```shell
-# Clone the repository.
-git clone https://github.com/pentaho/pentaho-engineering-samples
-
-# Go to the sample's directory.
-cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-bundle
-```
-
-## Develop the visualization itself
-
-Read the [Bar/D3 sample](samples/bar-d3-sandbox) walk-through, 
-which guides you through the development of a custom visualization having a [D3](https://d3js.org/)-based view,
-under a controlled sandbox environment.
-
-## Create the Pentaho Web Package
-
-In the previous section you developed a custom visualization and tested it in a controlled sandbox environment.
-To use the visualization _anywhere_ in the Pentaho platform, 
-it must take the form of a [Pentaho Web Package](../web-package). 
-This essentially means that you need to create a `package.json` file that describes the contained resources.
-
-Apart from the mandatory `name` and `version` fields, and the D3 library dependency, 
-you must also advertise the existence of your visualization to the platform, 
-so that applications like Analyzer and PDI can offer it to users.
-This is done by registering 
-the visualization's [`Model`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}) module
-with [`pentaho/service`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}),
-as a service of type `pentaho/visual/base`.
-
-The default configuration module that you developed also needs to be advertised to the configuration system,
-by registering it with `pentaho/service` as a service of type `pentaho.config.spec.IRuleSet`.
-
-The result is the following `package.json` content:
-
-```json
-{ 
-  "name": "pentaho/visual/samples/bar",
-  "version": "1.0.0",
-  
-  "config": {
-    "pentaho/service": {
-      "pentaho/visual/samples/bar_1.0.0/model": "pentaho/visual/base",
-      "pentaho/visual/samples/bar_1.0.0/config": "pentaho.config.spec.IRuleSet"
-    }
-  },
-  
-  "dependencies": {
-    "d3": "^4.8.0"
-  }
-}
-```
-
-## Create the OSGi Web Project
-
-The Pentaho platform is built on top of an OSGi container, 
-so developers must provide their code as an OSGi/Karaf artifact. 
-Additionally, any client-side dependencies must also be provided to the platform as OSGi bundles.
-
-The recommended way is to put the visualization bundle, its dependencies, 
-and corresponding feature definition together into a single KAR file.
-
-See [Create an OSGi Web Project for a Web Package and its Dependencies](../osgi-web-project) for instructions.
-
-# Build the OSGi Web Project
-
-Now that you have an OSGi project containing the custom Bar/D3 visualization, 
-you need to build it. At the project root execute:
-
-```shell
-mvn clean package
-```
-
-If everything went well, the KAR artifact will be located at `assemblies/target`.
-
-# Deploy the OSGi Artifact
+# Deploy the visualization
 
 See [OSGi Artifacts Deployment](../osgi-deployment) for quick instructions on 
-how to deploy the KAR file you just built.
+how to deploy the KAR file you just built (located at `assemblies/target`).
 
 If everything went well, you should now see your visualization being offered in Analyzer and/or PDI:
 

--- a/docs/platform/visual/index.md
+++ b/docs/platform/visual/index.md
@@ -63,8 +63,8 @@ for the Pentaho platform, from developing the visualization itself to deploying 
 1. [Create a visualization](#create-a-visualization)
    1. [Develop the visualization itself](#develop-the-visualization-itself)
    2. [Create the Pentaho Web Package](#create-the-pentaho-web-package)
-   3. [Create the OSGi Project](#create-the-osgi-project)
-2. [Build the OSGi Project](#build-the-osgi-project)
+   3. [Create the OSGi Web Project](#create-the-osgi-web-project)
+2. [Build the OSGi Web Project](#build-the-osgi-web-project)
 3. [Deploy the OSGi Artifact](#deploy-the-osgi-artifact)
 4. [Configure the visualization](#configure-the-visualization)
 
@@ -75,7 +75,7 @@ for the Pentaho platform, from developing the visualization itself to deploying 
 If you prefer to skip through the development of the visualization itself, 
 up until its bundling as an OSGi artifact,
 you can skip the following sub-sections and head on to 
-[Build the OSGi Project](#build-the-osgi-project).
+[Build the OSGi Web Project](#build-the-osgi-web-project).
 Before you go, though, you should clone the complete OSGi project:
 
 ```shell
@@ -130,7 +130,7 @@ The result is the following `package.json` content:
 }
 ```
 
-## Create the OSGi Project
+## Create the OSGi Web Project
 
 The Pentaho platform is built on top of an OSGi container, 
 so developers must provide their code as an OSGi/Karaf artifact. 
@@ -139,9 +139,9 @@ Additionally, any client-side dependencies must also be provided to the platform
 The recommended way is to put the visualization bundle, its dependencies, 
 and corresponding feature definition together into a single KAR file.
 
-See [Create an OSGi project for a Web Package and its Dependencies](../osgi-web-project) for instructions.
+See [Create an OSGi Web Project for a Web Package and its Dependencies](../osgi-web-project) for instructions.
 
-## Build the OSGi Project
+# Build the OSGi Web Project
 
 Now that you have an OSGi project containing the custom Bar/D3 visualization, 
 you need to build it. At the project root execute:
@@ -152,9 +152,9 @@ mvn clean package
 
 If everything went well, the KAR artifact will be located at `assemblies/target`.
 
-## Deploy the OSGi Artifact
+# Deploy the OSGi Artifact
 
-See [OSGi/Karaf Artifacts Deployment](../osgi-deployment) for quick instructions on 
+See [OSGi Artifacts Deployment](../osgi-deployment) for quick instructions on 
 how to deploy the KAR file you just built.
 
 If everything went well, you should now see your visualization being offered in Analyzer and/or PDI:

--- a/docs/platform/visual/samples/bar-d3-sandbox/index.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/index.md
@@ -1,12 +1,12 @@
 ---
-title: Create a custom Bar chart visualization using D3
-description: Walks you through the creation of a simple Bar chart visualization that uses the D3 graphics library.
+title: Develop a custom Bar chart visualization using D3
+description: Walks you through the development of a simple Bar chart visualization that uses the D3 graphics library.
 parent-title: Visualization API
 parent-path: ../..
 layout: default
 ---
 
-This walk-through will guide you through the creation of a simple Bar chart visualization, 
+This walk-through will guide you through the development of a simple Bar chart visualization, 
 using the Pentaho Visualization API and the amazing [D3](https://d3js.org/) graphics library.
  
 The complete code of this sample is available at 

--- a/docs/platform/visual/samples/bar-d3-sandbox/index.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/index.md
@@ -1,6 +1,6 @@
 ---
-title: Develop a custom Bar chart visualization using D3
-description: Walks you through the development of a simple Bar chart visualization that uses the D3 graphics library.
+title: Bar/D3 Visualization in Sandbox
+description: Walks you through the development of a simple Bar chart visualization that uses the D3 graphics library, under a controlled sandbox environment.
 parent-title: Visualization API
 parent-path: ../..
 layout: default
@@ -20,7 +20,7 @@ The complete code of this sample is available at
 
 ## Steps
 
-The walk-through is divided in the following steps:
+This walk-through is divided in the following steps:
 
 1. [Preparing the environment](step1-environment-preparation)
 2. [Creating the model](step2-model-creation)

--- a/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
@@ -2,7 +2,7 @@
 title: Step 1 - Preparing the environment
 description: Walks you through setting up a basic sandbox for experimenting with visualizations.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
@@ -2,29 +2,30 @@
 title: Step 1 - Preparing the environment
 description: Walks you through setting up a basic sandbox for experimenting with visualizations.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
-## Choose your walk-through following mode
+## Fast-lane
 
-While reading, you can either build the sample step-by-step or follow along with the complete code.
-
-### a. Following with the complete code
+If you prefer, you can follow the walk-through step-by-step but skip writing the code itself. 
+Just clone the sample repository and install its dependencies:
 
 ```shell
-# Clone the repository.
+# Clone the sample repository.
 git clone https://github.com/pentaho/pentaho-engineering-samples
 
-# Go to the sample's directory.
-cd "Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-sandbox"
+# Go to the complete sample's directory.
+cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-sandbox
 
 # Install the dependencies.
 npm install
 # or: yarn install
 ```
 
-### b. Building it yourself
+You might want to go directly to [Visualize it](#visualize-it).
+
+## Setup the sandbox environment
 
 1. Create a folder and then initialize it:
    ```shell

--- a/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step1-environment-preparation.md
@@ -6,24 +6,24 @@ parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 
-## Fast-lane
+{% include callout.html content="<h2>Fast-lane</h2>
+<p>If you prefer, you can follow the walk-through step-by-step but skip writing the code itself. 
+   Just clone the sample repository and install its dependencies:</p>
 
-If you prefer, you can follow the walk-through step-by-step but skip writing the code itself. 
-Just clone the sample repository and install its dependencies:
-
-```shell
-# Clone the sample repository.
+<pre class='highlight'><code># Clone the sample repository.
 git clone https://github.com/pentaho/pentaho-engineering-samples
 
 # Go to the complete sample's directory.
+cd pentaho-engineering-samples
 cd Samples_for_Extending_Pentaho/javascript-apis/platform/pentaho/visual/samples/bar-d3-sandbox
 
 # Install the dependencies.
 npm install
 # or: yarn install
-```
+</code></pre>
 
-You might want to go directly to [Visualize it](#visualize-it).
+<p>Go directly to <a title='Visualize it' href='#visualize-it'>Visualize it</a>.</p>
+" type="warning" %}
 
 ## Setup the sandbox environment
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
@@ -2,7 +2,7 @@
 title: Step 2 - Creating the model
 description: Walks you through the creation of the Bar visualization model.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step2-model-creation.md
@@ -2,7 +2,7 @@
 title: Step 2 - Creating the model
 description: Walks you through the creation of the Bar visualization model.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
@@ -39,8 +39,8 @@ define([
     
     var BarModel = BaseModel.extend({
       type: {
-        id: "pentaho/visual/samples/bar",
-        sourceId: module.id,
+        id: module.id,
+        styleClass: "pentaho-visual-samples-bar",
         label: "D3 Bar Chart",
         defaultView: "./view-d3",
         props: [
@@ -76,9 +76,12 @@ define([
 
 Remarks:
   - The value of the AMD module is a factory function of Bar model classes.
-  - Defines a visualization (model) of id `pentaho/visual/samples/bar`.
+  - Defines a visualization (model) whose id is the file's AMD module identifier
+    (depending on how AMD is configured, it can be, for example: `pentaho/visual/samples/bar/model`).
   - Inherits directly from the base visualization model, 
     [pentaho/visual/base]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.Model'}}).
+  - Specifies the [styleClass]({{site.refDocsUrlPattern | replace: '$', 'pentaho.type.Type' | append: '#styleClass'}}),
+    which will later be useful to style the component using CSS.
   - Specifies the
     [default view]({{site.refDocsUrlPattern | replace: '$', 'pentaho.type.Type' | append: '#defaultView'}}) 
     to use with this model (which you'll create in a moment).

--- a/docs/platform/visual/samples/bar-d3-sandbox/step3-view-creation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step3-view-creation.md
@@ -2,7 +2,7 @@
 title: Step 3 - Creating the view
 description: Walks you through the creation of the Bar visualization view.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step3-view-creation.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step3-view-creation.md
@@ -2,7 +2,7 @@
 title: Step 3 - Creating the view
 description: Walks you through the creation of the Bar visualization view.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
@@ -46,7 +46,8 @@ define([
 ```
 
 Remarks:
-  - Defines a visualization view type of id `pentaho/visual/samples/bar/view-d3`.
+  - Defines a visualization view whose id is the file's AMD module identifier
+    (depending on how AMD is configured, it can be, for example: `pentaho/visual/samples/bar/view-d3`).
   - Inherits directly from the base visualization view, 
     [pentaho/visual/base/view]({{site.refDocsUrlPattern | replace: '$', 'pentaho.visual.base.View'}}).
   - The inherited 
@@ -88,14 +89,8 @@ Edit the `index.html` file and place the following code in it:
   <script>
     // Needed only in a sandbox environment.
     require.config({
-      packages: [
-        {
-          "name": "pentaho/visual/samples/bar",
-          "main": "model",
-          "location": "."
-        }
-      ],
       paths: {
+        "pentaho/visual/samples/bar": ".",
         "d3": "./node_modules/d3/build/d3"
       }
     });
@@ -106,7 +101,7 @@ Edit the `index.html` file and place the following code in it:
       "pentaho/type/Context",
       "pentaho/data/Table",
       "pentaho/visual/base/view",
-      "pentaho/visual/samples/bar",
+      "pentaho/visual/samples/bar/model",
       "json!./sales-by-product-family.json"
     ], function(Context, Table, baseViewFactory, barModelFactory, dataSpec) {
 
@@ -160,7 +155,7 @@ Remarks:
     This step is only needed in a sandbox environment. 
     When inside the Pentaho platform, these configurations are provided automatically,
     built from the web package information.
-  - The used visualization model is now `pentaho/visual/samples/bar`.
+  - The used visualization model is now `pentaho/visual/samples/bar/model`.
   - The model now contains visual role mappings for the `category` and `measure` visual roles.
   - The dimensions of the visualization were increased.
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step4-view-styling.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step4-view-styling.md
@@ -2,7 +2,7 @@
 title: Step 4 - Styling the view
 description: Walks you through the styling of the Bar visualization view.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step4-view-styling.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step4-view-styling.md
@@ -2,7 +2,7 @@
 title: Step 4 - Styling the view
 description: Walks you through the styling of the Bar visualization view.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
@@ -43,7 +43,7 @@ Create a folder named `css` and, in it, create a file named `view-d3.css`. Add t
 Remarks:
   - The CSS rules are scoped with the visualization model's
     CSS [style class]({{site.refDocsUrlPattern | replace: '$', 'pentaho.type.Type' | append: '#styleClass'}}), 
-    which, by default is derived from its id, `pentaho/visual/samples/bar`.
+    previously specified when defining the model.
 
 ## Loading the CSS file with the view
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step5-view-interactivity.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step5-view-interactivity.md
@@ -2,7 +2,7 @@
 title: Step 5 - Adding interactivity to the view
 description: Walks you through adding interactivity to the Bar visualization view.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step5-view-interactivity.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step5-view-interactivity.md
@@ -2,7 +2,7 @@
 title: Step 5 - Adding interactivity to the view
 description: Walks you through adding interactivity to the Bar visualization view.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step6-default-configuration.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step6-default-configuration.md
@@ -2,7 +2,7 @@
 title: Step 6 - Adding a default configuration
 description: Walks you through adding a default configuration to the visualization.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 

--- a/docs/platform/visual/samples/bar-d3-sandbox/step6-default-configuration.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/step6-default-configuration.md
@@ -2,7 +2,7 @@
 title: Step 6 - Adding a default configuration
 description: Walks you through adding a default configuration to the visualization.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
@@ -17,20 +17,26 @@ the developer of `V1` may package it a configuration module so that it better in
 out-of-the-box.
 
 If you do not have any knowledge about JavaScript configuration in the Pentaho Platform, 
-you might want to read [Configuring your Visualization](../configuration) before continuing.
+you might want to read 
+[Configuring a visualization](../../configuration) before continuing.
 
 ## Create the configuration module
 
 Now, create a configuration file, called `config.js`, and place the following content in it:
 
 ```js
-define(function() {
+define(["module"], function(module) {
+  
+  // Replace /config by /model.
+  // e.g. "pentaho/visual/samples/bar/model".
+  var vizId = module.id.replace(/(\w+)$/, "model");
+  
   return {
     rules: [
       {
         priority: -1,
         select: {
-          type: "pentaho/visual/samples/bar"
+          type: vizId
         },
         apply: {
           props: {
@@ -59,14 +65,8 @@ with the following:
   <script>
     // Needed only in a sandbox environment.
     require.config({
-      packages: [
-        {
-          "name": "pentaho/visual/samples/bar",
-          "main": "model",
-          "location": "."
-        }
-      ],
       paths: {
+        "pentaho/visual/samples/bar": ".",
         "d3": "./node_modules/d3/build/d3"
       },
       config: {
@@ -92,14 +92,15 @@ However, until then, the Bar visualization can be configured to contain this req
 being used by the PDI application. Add the following rule to the `config.js` file:
 
 ```js
-define(function() {
+define(["module"], function(module) {
+  // ...
   return {
     rules: [
       // ..,
       {
         priority: -1,
         select: {
-          type: "pentaho/visual/samples/bar",
+          type: vizId,
           application: "pentaho-det"
         },
         apply: {
@@ -129,14 +130,15 @@ parent attribute with the child attribute when drilling-down.
 Add the following rule to the `config.js` file:
 
 ```js
-define(function() {
+define(["module"], function(module) {
+  // ...
   return {
     rules: [
       // ..,
       {
         priority: -1,
         select: {
-          type: "pentaho/visual/samples/bar",
+          type: vizId,
           application: "pentaho-analyzer"
         },
         apply: {

--- a/docs/platform/visual/samples/bar-d3-sandbox/stepNext.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/stepNext.md
@@ -2,13 +2,13 @@
 title: Next Steps
 description: Concludes the walk-through by showing what else you can learn.
 parent-path: .
-parent-title: Create a custom Bar chart visualization using D3
+parent-title: Develop a custom Bar chart visualization using D3
 layout: default
 ---
 
 You've covered the basics of developing a visualization for the Pentaho Visualization API.
 Many features, such as color palettes, localization, theming and configuration, were purposely left out, 
-to keep things as accessible as possible.
+to keep things as simple as possible.
 
-To learn how to create a Pentaho Web Package for your visualization, and also how to bundle and deploy it,
-continue reading at [Visualization API](../..#packaging). 
+To learn how to create a Pentaho Web Package for your visualization,
+continue reading at [Create the Pentaho Web Package](../..#create-the-pentaho-web-package). 

--- a/docs/platform/visual/samples/bar-d3-sandbox/stepNext.md
+++ b/docs/platform/visual/samples/bar-d3-sandbox/stepNext.md
@@ -2,7 +2,7 @@
 title: Next Steps
 description: Concludes the walk-through by showing what else you can learn.
 parent-path: .
-parent-title: Develop a custom Bar chart visualization using D3
+parent-title: Bar/D3 Visualization in Sandbox
 layout: default
 ---
 
@@ -11,4 +11,4 @@ Many features, such as color palettes, localization, theming and configuration, 
 to keep things as simple as possible.
 
 To learn how to create a Pentaho Web Package for your visualization,
-continue reading at [Create the Pentaho Web Package](../..#create-the-pentaho-web-package). 
+continue reading at [Create the Pentaho Web Package](../../create#2-create-the-pentaho-web-package). 

--- a/docs/platform/web-package.md
+++ b/docs/platform/web-package.md
@@ -1,5 +1,5 @@
 ---
-title: Web Package
+title: Pentaho Web Package
 description: Describes how to package web client resources, including visualizations, into the Pentaho platform.
 parent-title: ""
 layout: default

--- a/docs/platform/web-package.md
+++ b/docs/platform/web-package.md
@@ -5,7 +5,7 @@ parent-title: ""
 layout: default
 ---
 
-The Pentaho Platform detects and manages OSGi bundles that are Web Packages, 
+The Pentaho Platform detects and manages [OSGi](https://www.osgi.org/) bundles that are **Pentaho Web Packages**, 
 collecting the information needed to build the AMD/RequireJS configuration and 
 to setup the mappings needed to serve the package resources through HTTP.
 
@@ -19,26 +19,44 @@ These are, for now, the relevant supported fields:
 
 **mandatory**
 
-The most important fields in `package.json` are the "name" and "version" fields. 
+The most important fields in `package.json` are the `name` and `version` fields. 
 Those are required, and the package must not install without them.
 - The name must be shorter than 214 characters;
 - The name can't start with a dot or an underscore;
 - The name should not have uppercase letters;
-- The name will end up being part of an URL; therefore, the name should avoid any non-URL-safe characters;
-- The version must be follow the the Semantic Versioning Specification (http://semver.org/).
+- The name will end up being part of an URL;
+  therefore, the name should avoid any non-URL-safe characters;
+  however, forward-slashes, `/`, are allowed; 
+- The version must follow the the Semantic Versioning Specification (http://semver.org/).
 
 The name and version together form an identifier that is assumed to be unique and 
 is used both as the main AMD/RequireJS module identifier (separated by an underscore, like `name_version`) and 
 as part of the HTTP location where the resources will be served from 
 (separated by a forward slash, like `/name/version`).
 
+Example:
+
+```json
+{
+  "name": "baz",
+  "version": "1.0.0"
+}
+```
+
 ## dependencies
 
 Dependencies are specified in a simple object that maps a package name to a version range.
 The version range is a string which has one or more space-separated descriptors, 
 as defined in https://github.com/npm/node-semver#ranges.
+
 ```json
-{ "name": "baz", "version": "1.0.0", "dependencies": { "bar": "~2.0" } }
+{
+  "name": "baz", 
+  "version": "1.0.0", 
+  "dependencies": { 
+    "bar": "~2.0" 
+  }
+}
 ```
 
 This information is used by the platform to find out the dependency tree, do the runtime dependency resolution, and 
@@ -66,7 +84,8 @@ In particular,
 this is used to configure the [`pentaho/service`]({{site.refDocsUrlPattern | replace: '$', 'pentaho.service'}}) plugin, 
 used as an inversion-of-control mechanism to inject the package resources into the system.
 
-For instance, to declare that the resource `"my-viz/model.js"` implements `"pentaho/visual/base"` you would need:
+For instance, to declare that the resource `"my-viz/model.js"` implements the service named `pentaho/visual/base`, 
+you would need:
 ```json
 { 
   "name": "baz",
@@ -79,25 +98,27 @@ For instance, to declare that the resource `"my-viz/model.js"` implements `"pent
 }
 ```
 
-Notice that you must use the complete final module identifier (`"baz_1.0.0"`) as the dependency name. 
+{% include callout.html content='<p>Notice that you must use the complete final module identifier 
+(<code>"baz_1.0.0"</code>) as the dependency name. 
 This is currently a limitation, as ideally you should be unaware of whatever naming scheme is chosen by the platform.
+</p>' type="warning" %}
 
 ## packages
 
-This field isn't part of the package.json spec. 
-It is based in [RequireJS's login modules from packages](http://requirejs.org/docs/api.html#packages) and 
-serves the same purpose.
+This field isn't part of the `package.json` spec.
+It is based in [RequireJS's Packages](http://requirejs.org/docs/api.html#packages) and serves the same purpose.
 
-Package configuration allows for CommonJS style path lookup rules, 
+Package configuration allows for CommonJS style path lookup rules,
 which are somewhat different from the default id-to-path lookup rules that are otherwise used by AMD loaders.
 
-It is an array of package configuration objects. Each configuration can either be:
-- String: The package’s module identifier prefix, which indicates the package name.
-- Object: a configuration object that can have the following properties:
+It is an array of package configurations. Each package configuration can either be:
+- String: The package’s module identifier.
+- Object: An object with the following properties:
   - name: String. The package’s module identifier.
   - location: String. _Optional_.
-  - main: String. _Optional_. 
-    Default value is "main". The module identifier to use inside the package for the "main module".
+  - main: String. _Optional_. The identifier of the sub-module that is used as the "main module", 
+    relative (appended) to the package module. Default value is "main".
 
-In the current implementation, each module identifier is relative (appended) to the package’s main module identifier, 
+In the current implementation, 
+each module identifier is relative (appended) to the Web Package’s main module identifier,
 unless if it starts with "/". This might change in the final release.

--- a/docs/platform/web-project.md
+++ b/docs/platform/web-project.md
@@ -1,5 +1,5 @@
 ---
-title: Create an OSGi Web Project for a Web Package and its Dependencies
+title: Create a Pentaho Web Project for a Web Package and its Dependencies
 description: Explains the core concepts and walks through the creation of a KAR file for deploying a web package and its dependencies in the Pentaho Platform.
 parent-title: ""
 layout: default


### PR DESCRIPTION
… Package”, “OSGi Web Project” and “OSGi Artifact Deployment”

* Changed the structure of the VizAPI page to feature a fast-lane to Build, Deploy and Configure.
* Updated Bar/D3 sample to not use packages, so that it better matched the ones used in Web Packages.
See also https://github.com/pentaho/pentaho-engineering-samples/pull/26.

@pentaho/millenniumfalcon please review.