### PR TITLE
[BACKLOG-16602] Fixed validation of nested accident types.

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/type/spec/IValueProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IValueProto.jsdoc
@@ -31,23 +31,3 @@
  *
  * @see pentaho.type.spec.IValueTypeProto#instance
  */
-
-/**
- * Determines if a value is **valid**.
- *
- * If you override this method,
- * be sure to call the base implementation,
- * and return any errors it reports.
- *
- * You can use the error utilities in {@link pentaho.type.Util} to
- * help in the implementation.
- *
- * @name validate
- * @memberOf pentaho.type.spec.IValueProto#
- * @method
- *
- * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
- *
- * @see pentaho.type.spec.IValueTypeProto#validateInstance
- * @see pentaho.type.Value#validate
- */

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
@@ -44,21 +44,3 @@
  *
  * @see pentaho.type.Type#isAccident
  */
-
-/**
- * Determines if a value of the type is **valid**.
- *
- * If you override this method,
- * be sure to call the base implementation,
- * and return any errors it reports.
- *
- * @name validateInstance
- * @memberOf pentaho.type.spec.IValueTypeProto#
- * @method
- *
- * @param {!pentaho.type.Value} value - The value to validate.
- *
- * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
- *
- * @see pentaho.type.Value.Type#validateInstance
- */

--- a/impl/client/src/main/javascript/web/pentaho/type/_type.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/_type.js
@@ -1412,11 +1412,21 @@ define([
        *
        * A type is considered a subtype of itself.
        *
-       * @param {?pentaho.type.Type} superType - The candidate super-type.
+       * @param {pentaho.type.Type} superType - The candidate super-type.
        * @return {boolean} `true` if this is a subtype of `superType` type; `false`, otherwise.
        */
       isSubtypeOf: function(superType) {
         return !!superType && (superType === this || O_isProtoOf.call(superType, this));
+      },
+
+      /**
+       * Returns the most specific type, between this and the given type.
+       *
+       * @param {!pentaho.type.Type} otherType - The other type.
+       * @return {!pentaho.type.Type} The most specific type.
+       */
+      mostSpecific: function(otherType) {
+        return this.isSubtypeOf(otherType) ? this : otherType;
       },
 
       // TODO: is conversion always successful? If so, should it be?

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -715,35 +715,6 @@ define([
       // endregion
       // endregion
 
-      // region validation
-      // @override
-      /**
-       * Determines if this complex value is a **valid instance** of its type.
-       *
-       * The default implementation
-       * validates each property's value against
-       * the property's [type]{@link pentaho.type.Property.Type#type}
-       * and collects and returns any reported errors.
-       * Override to complement with a type's specific validation logic.
-       *
-       * You can use the error utilities in {@link pentaho.type.Util} to
-       * help in the implementation.
-       *
-       * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
-       *
-       * @see pentaho.type.Value#isValid
-       */
-      validate: function() {
-        var errors = null;
-
-        this.type.each(function(pType) {
-          errors = typeUtil.combineErrors(errors, pType.validate(this));
-        }, this);
-
-        return errors;
-      },
-      // endregion
-
       // region serialization
       /** @inheritDoc */
       toSpecInContext: function(keyArgs) {
@@ -995,6 +966,37 @@ define([
           this._getProps().configure(propTypeSpec);
           return this;
         },
+
+        // region validation
+        // @override
+        /**
+         * Determines if the given complex value is a **valid instance** of this type.
+         *
+         * The default implementation
+         * validates each property's value against
+         * the property's [type]{@link pentaho.type.Property.Type#type}
+         * and collects and returns any reported errors.
+         * Override to complement with a type's specific validation logic.
+         *
+         * You can use the error utilities in {@link pentaho.type.Util} to
+         * help in the implementation.
+         *
+         * @param {!pentaho.type.Value} value - The value to validate.
+         *
+         * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
+         *
+         * @protected
+         */
+        _validate: function(value) {
+          var errors = null;
+
+          this.each(function(pType) {
+            errors = typeUtil.combineErrors(errors, pType.validateOwner(value));
+          });
+
+          return errors;
+        },
+        // endregion
 
         // region serialization
         /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/type/facets/discreteDomain.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/facets/discreteDomain.js
@@ -75,7 +75,7 @@ define([
         },
 
         /** @inheritDoc */
-        validateInstance: function(value) {
+        _validate: function(value) {
           return typeUtil.combineErrors(
               this.base(value),
               this.__validateDomain(value));

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -591,31 +591,6 @@ define([
       },
       // endregion
 
-      // region validation
-      /**
-       * Determines if this list value is a **valid instance** of its type.
-       *
-       * The default implementation validates each element against the
-       * list's [element type]{@link pentaho.type.List.Type#of}
-       * and collects and returns any reported errors.
-       * Override to complement with a type's specific validation logic.
-       *
-       * You can use the error utilities in {@link pentaho.type.Util} to
-       * help in the implementation.
-       *
-       * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
-       *
-       * @see pentaho.type.Value#isValid
-       */
-      validate: function() {
-        var elemType = this.type.of;
-
-        return this._projectedMock._elems.reduce(function(errors, elem) {
-          return typeUtil.combineErrors(errors, elemType.validateInstance(elem));
-        }, null);
-      },
-      // endregion
-
       // region serialization
       /** @inheritDoc */
       toSpecInContext: function(keyArgs) {
@@ -729,6 +704,33 @@ define([
           // Mark set locally even if it is the same...
           this._elemType = elemType;
 
+        },
+        // endregion
+
+        // region validation
+        /**
+         * Determines if the given list value is a **valid instance** of this type.
+         *
+         * The default implementation validates each element against the
+         * list's [element type]{@link pentaho.type.List.Type#of}
+         * and collects and returns any reported errors.
+         * Override to complement with a type's specific validation logic.
+         *
+         * You can use the error utilities in {@link pentaho.type.Util} to
+         * help in the implementation.
+         *
+         * @param {!pentaho.type.Value} value - The value to validate.
+         *
+         * @return {?Array.<!pentaho.type.ValidationError>} A non-empty array of errors or `null`.
+         *
+         * @protected
+         */
+        _validate: function(value) {
+          var elemType = this.of;
+
+          return value._projectedMock._elems.reduce(function(errors, elem) {
+            return typeUtil.combineErrors(errors, elemType.mostSpecific(elem.type)._validate(elem));
+          }, null);
         },
         // endregion
 

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -740,7 +740,7 @@ define([
          *
          * @see pentaho.type.Complex#validate
          */
-        validate: function(owner) {
+        validateOwner: function(owner) {
           var errors = null;
 
           if(this.isApplicableEval(owner)) {
@@ -750,10 +750,10 @@ define([
 
             var value = owner._getByType(this);
             if(value && !this.isBoundary) {
-              // Not null and surely of the type, so validateInstance can be called.
+              // Not null and surely of the type, so _validate can be called.
               // If a list, element validation is done before cardinality validation.
               // If a complex, its properties validation is done before local cardinality validation.
-              addErrors(this.type.validateInstance(value));
+              addErrors(this.type.mostSpecific(value.type)._validate(value));
             }
 
             var range = this.countRangeEval(owner);

--- a/impl/client/src/test/javascript/pentaho/type/complex.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.validation.spec.js
@@ -27,7 +27,7 @@ define([
   describe("pentaho.type.Complex", function() {
 
     describe("#validate()", function() {
-      it("should call each property's validate with the owner complex instance", function() {
+      it("should call each property's validateOwner with the owner complex instance", function() {
         var Derived = Complex.extend({
           type: {
             props: [
@@ -44,15 +44,15 @@ define([
         var yPropType = derived.type.get("y");
         var zPropType = derived.type.get("z");
 
-        spyOn(xPropType, "validate");
-        spyOn(yPropType, "validate");
-        spyOn(zPropType, "validate");
+        spyOn(xPropType, "validateOwner");
+        spyOn(yPropType, "validateOwner");
+        spyOn(zPropType, "validateOwner");
 
         derived.validate();
 
-        expect(xPropType.validate).toHaveBeenCalledWith(derived);
-        expect(yPropType.validate).toHaveBeenCalledWith(derived);
-        expect(zPropType.validate).toHaveBeenCalledWith(derived);
+        expect(xPropType.validateOwner).toHaveBeenCalledWith(derived);
+        expect(yPropType.validateOwner).toHaveBeenCalledWith(derived);
+        expect(zPropType.validateOwner).toHaveBeenCalledWith(derived);
       });
 
     });

--- a/impl/client/src/test/javascript/pentaho/type/list.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.validation.spec.js
@@ -27,22 +27,62 @@ define([
 
     var context = new Context();
     var List = context.get(listFactory);
-    var PentahoNumber = context.get(numberFactory);
-    var NumberList = List.extend({
-      type: {of: PentahoNumber}
-    });
 
     describe("#validate() -", function() {
-      it("should call validateInstance(.) of the list element type with each of its members", function() {
-        spyOn(PentahoNumber.type, "validateInstance");
+      it("should call _validate(.) of the list element type with each of its members", function() {
+        var PentahoNumber = context.get(numberFactory);
+        var NumberList = List.extend({
+          type: {of: PentahoNumber}
+        });
+
+        spyOn(PentahoNumber.type, "_validate");
 
         var list = new NumberList([1, 2, 3]);
 
         list.validate();
 
-        expect(PentahoNumber.type.validateInstance).toHaveBeenCalledWith(list.at(0));
-        expect(PentahoNumber.type.validateInstance).toHaveBeenCalledWith(list.at(1));
-        expect(PentahoNumber.type.validateInstance).toHaveBeenCalledWith(list.at(2));
+        expect(PentahoNumber.type._validate).toHaveBeenCalledWith(list.at(0));
+        expect(PentahoNumber.type._validate).toHaveBeenCalledWith(list.at(1));
+        expect(PentahoNumber.type._validate).toHaveBeenCalledWith(list.at(2));
+      });
+
+      it("should call _validate(.) of the list element accidental type with each of its members", function() {
+        var PentahoNumber = context.get(numberFactory);
+        var PentahoInteger = PentahoNumber.refine();
+
+        var IntegerList = List.extend({
+          type: {of: PentahoInteger}
+        });
+
+        spyOn(PentahoInteger.type, "_validate");
+
+        var list = new IntegerList([1, 2, 3]);
+
+        list.validate();
+
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(0));
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(1));
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(2));
+      });
+
+      it("should call _validate(.) of each of the list elements' type " +
+         "when the list element type is of a base type", function() {
+        var PentahoNumber = context.get(numberFactory);
+        var PentahoInteger = PentahoNumber.extend();
+
+        var NumberList = List.extend({
+          type: {of: PentahoNumber}
+        });
+
+        spyOn(PentahoInteger.type, "_validate");
+
+        var list = new NumberList([new PentahoInteger(1), new PentahoInteger(2), new PentahoInteger(3)]);
+
+        list.validate();
+
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(0));
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(1));
+        expect(PentahoInteger.type._validate).toHaveBeenCalledWith(list.at(2));
       });
     });
   });

--- a/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
@@ -24,6 +24,8 @@ define([
   /* global describe:false, it:false, expect:false, beforeEach:false, afterEach:false, spyOn:false, jasmine:false,
            JSON:false */
 
+  /* eslint max-nested-callbacks: 0 */
+
   var context = new Context();
   var Value = context.get("pentaho/type/value");
 
@@ -221,34 +223,8 @@ define([
       describe("#isAbstract", function() {
         // isAbstract is always local. Non-nullable. false by default.
 
-        serializationUtil.itFillSpecAttribute(Value, "isAbstract", true,  true);
+        serializationUtil.itFillSpecAttribute(Value, "isAbstract", true, true);
         serializationUtil.itFillSpecAttribute(Value, "isAbstract", false, false);
-      });
-
-      describe("#validateInstance", function() {
-
-        serializationUtil.itFillSpecMethodAttribute(Value, "validateInstance");
-
-        it("should not serialize when value is local and isJson: true", function() {
-          var spec = {};
-          var typeSpec = {validateInstance: function() {}};
-          var result = serializationUtil.fillSpec(Value, spec, typeSpec, {isJson: true});
-
-          expect(result).toBe(false);
-        });
-      });
-
-      describe("#instance.validate", function() {
-
-        serializationUtil.itFillSpecMethodAttribute(Value, "instance.validate");
-
-        it("should not serialize when value is local and isJson: true", function() {
-          var spec = {};
-          var typeSpec = {instance: {validate: function() {}}};
-          var result = serializationUtil.fillSpec(Value, spec, typeSpec, {isJson: true});
-
-          expect(result).toBe(false);
-        });
       });
     });
   });

--- a/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
@@ -144,15 +144,15 @@ define([
       });
 
       it("should return an error array when given a value not an instance " +
-         "of the type and not call the validateInstance method", function() {
+         "of the type and not call the _validate method", function() {
         var value = new Value();
 
         var errors = PentahoNumber.type.validate(value);
-        spyOn(PentahoNumber.type, "validateInstance").and.callThrough();
-        spyOn(Value.type, "validateInstance").and.callThrough();
+        spyOn(PentahoNumber.type, "_validate").and.callThrough();
+        spyOn(Value.type, "_validate").and.callThrough();
 
-        expect(PentahoNumber.type.validateInstance).not.toHaveBeenCalled();
-        expect(Value.type.validateInstance).not.toHaveBeenCalled();
+        expect(PentahoNumber.type._validate).not.toHaveBeenCalled();
+        expect(Value.type._validate).not.toHaveBeenCalled();
 
         expect(Array.isArray(errors)).toBe(true);
         expect(errors.length).toBe(1);
@@ -161,20 +161,19 @@ define([
           .toBe(bundle.format(bundle.structured.errors.value.notOfType, [PentahoNumber.type.label]));
       });
 
-      it("should call the validateInstance method with the value when it is an instance of the type",
-          function() {
-        spyOn(Value.type, "validateInstance").and.callThrough();
+      it("should call the _validate method with the value when it is an instance of the type", function() {
+        spyOn(Value.type, "_validate").and.callThrough();
 
         var value = new Value();
         Value.type.validate(value);
-        expect(Value.type.validateInstance.calls.count()).toBe(1);
-        expect(Value.type.validateInstance).toHaveBeenCalledWith(value);
+        expect(Value.type._validate.calls.count()).toBe(1);
+        expect(Value.type._validate).toHaveBeenCalledWith(value);
       });
 
-      it("should return an error array returned by the validateInstance method", function() {
+      it("should return an error array returned by the _validate method", function() {
         var value = new Value();
         var errors = [new ValidationError()];
-        spyOn(Value.type, "validateInstance").and.returnValue(errors);
+        spyOn(Value.type, "_validate").and.returnValue(errors);
         var result = Value.type.validate(value);
         expect(result).toBe(errors);
       });


### PR DESCRIPTION
* Moved validation functions to the Type prototype.
* Removed serialization of methods like `validate` (now `_validate`).
  These should be seen as `mixin` type matter, not to be serialized.

@pentaho/millenniumfalcon please review.

Merge with: https://github.com/pentaho/pentaho-det/pull/874