### PR TITLE
[BISERVER-13677]: Report with Post Processing Formula that references…

### DIFF
--- a/impl/client/src/main/javascript/web/util/formatting.js
+++ b/impl/client/src/main/javascript/web/util/formatting.js
@@ -113,7 +113,7 @@ define("common-ui/util/formatting", ['common-ui/util/timeutil', 'common-ui/util/
           } else if ('utc' === timezone) {
             return this.dateFormatters['utc'].format(date);
           } else {
-            var offset = ReportTimeUtil.getOffsetAsString(timezone);
+            var offset = ReportTimeUtil.getOffsetAsString(timezone, date);
             if (!this.dateFormatters[offset]) {
               this.dateFormatters[offset] = TextFormatter.createFormatter('date', "yyyy-MM-dd'T'HH:mm:ss.SSS'" + offset + "'");
             }
@@ -220,7 +220,7 @@ define("common-ui/util/formatting", ['common-ui/util/timeutil', 'common-ui/util/
     convertTimeStampToTimeZone: function(value, timezone) {
       this._initDateFormatters();
       // Lookup the offset in minutes
-      var offset = ReportTimeUtil.getOffset(timezone);
+      var offset = ReportTimeUtil.getOffset(timezone, date);
 
       var localDate = this.parseDateWithoutTimezoneInfo(value);
       var utcDate = this.dateFormatters['with-timezone'].parse(value);

--- a/impl/client/src/main/javascript/web/util/timeutil.js
+++ b/impl/client/src/main/javascript/web/util/timeutil.js
@@ -19,7 +19,7 @@
  * Timezone Utility to generate a timezone offset string from a given timezone.
  */
 
-define("common-ui/util/timeutil", [], function() {
+define("common-ui/util/timeutil", ['cdf/lib/moment-timezone'], function(momentTimezone) {
   return {
     offsets: {
       "ACT": 570,
@@ -631,12 +631,20 @@ define("common-ui/util/timeutil", [], function() {
     /**
      * Returns the timezone offset in minutes from UTC
      */
-    getOffset: function(timezone) {
-      return this.offsets[timezone] || 0;
+    getOffset: function(timezone, date) {
+	var zone = momentTimezone.tz.zone(timezone);
+	//there are possible cases when the certain timezone is absent in data of Moment Timezone
+	//in this case we are trying to use values from this.offsets without DST time
+	if(!zone){
+		return this.offsets[timezone] || 0;
+		}
+	//returns real offset in minutes with POSIX-style signs
+	//so should be reversed for backward compatibility because before this change this method exactly returned reversed offsets (please see values in this.offsets array)
+	return -1 * zone.parse(momentTimezone.utc(date));
     },
 
-    getOffsetAsString: function(timezone) {
-      return this.formatOffset(this.getOffset(timezone));
+    getOffsetAsString: function(timezone, date) {
+      return this.formatOffset(this.getOffset(timezone, date));
     },
 
     formatOffset: function(offsetMinutes) {


### PR DESCRIPTION
… another parameter goes into a loop and it never stops

timeutil.js knows nothing about Daylight Savings Time and returns incorrect time offset when DST is in effect.
Fixed by using moment-timezone JS with DST data.