### PR TITLE
[BACKLOG-17015] Update Javascript APIs' reference documentation

### DIFF
--- a/impl/client/pom.xml
+++ b/impl/client/pom.xml
@@ -22,7 +22,7 @@
     <pentaho-cdf-plugin.version>${project.version}</pentaho-cdf-plugin.version>
 
     <docjs.config.file>jsdoc-vizapi.json</docjs.config.file>
-    <docjs.config.github.branch>master</docjs.config.github.branch>
+    <docjs.config.github.branch>7.1-Doc</docjs.config.github.branch>
     <docjs.config.templateDirectory>${project.basedir}/src/doc/javascript/template</docjs.config.templateDirectory>
   </properties>
 

--- a/impl/client/src/doc/javascript/config/customPlugins/defineTags.js
+++ b/impl/client/src/doc/javascript/config/customPlugins/defineTags.js
@@ -18,7 +18,18 @@ exports.defineTags = function ( dictionary ) {
   // region New Tags
   /** Tag to add AMD module information to a class */
   createTagDefinition('amd', {
-    onTagged: function( doclet, tag ) { doclet.amd = tag; }
+    canHaveType: true,
+    canHaveName: true,
+
+    onTagged: function( doclet, tag ) {
+      const value = tag.value;
+
+      doclet.amd = {
+        text: tag.text,
+        type: firstTypeOf( value ),
+        module: value.name
+      };
+    }
   });
 
   /** Other tag for code examples in order to have different header */
@@ -47,7 +58,7 @@ exports.defineTags = function ( dictionary ) {
     onTagged: function( doclet, tag ) {
       let value = tag.value;
       if ( value.indexOf( "@link" ) < 0 ) {
-        value = firstWordOf(value);
+        value = firstWordOf( value );
       }
 
       doclet.augment( value );
@@ -107,4 +118,18 @@ function firstWordOf( string ) {
   } else {
     return '';
   }
+}
+
+/**
+ * Gets the first type a {@code tag}
+ *
+ * @param {object} tag
+ *
+ * @return {?string} the first type of a {@code tag} if any exist.
+ */
+function firstTypeOf( tag ) {
+  const FIRST_TYPE = 0;
+  const types = tag.type ? tag.type.names : [];
+
+  return types[ FIRST_TYPE ];
 }

--- a/impl/client/src/doc/javascript/template/vizApi/tmpl/amd.tmpl
+++ b/impl/client/src/doc/javascript/template/vizApi/tmpl/amd.tmpl
@@ -2,12 +2,14 @@
 var data = obj;
 var self = this;
 var paramName;
+var module;
 if(data.amd != null) {
   // hardcoded fix for "Dashboard.Blueprint", "Dashboard.Bootstrap" and "Dashboard.Clean"
   paramName = data.name.replace(/"?(Dashboard)\.(Blueprint|Bootstrap|Clean)"?/, "$1");
+  module =  data.amd.module;
 ?>
 	<p>
 		<strong>AMD Module</strong>
 	</p>
-	<pre function="syntax.javascript">require(["<?js= data.amd.value ?>"], function(<?js= paramName ?>) { /* code goes here */ });</pre>
+	<pre function="syntax.javascript">require(["<?js= module ?>"], function(<?js= paramName ?>) { /* code goes here */ });</pre>
 <?js } ?>

--- a/impl/client/src/doc/javascript/template/vizApi/tmpl/container.tmpl
+++ b/impl/client/src/doc/javascript/template/vizApi/tmpl/container.tmpl
@@ -112,24 +112,21 @@
 
     <?js 
       var classes = self.find({kind: 'class', memberof: doc.longname});
-      if (!isGlobalPage && classes && classes.length) {
-    ?>
+      if (!isGlobalPage && classes && classes.length) { ?>
         <h3>Classes</h3>
         <?js= self.partial('summary.tmpl', classes) ?>
     <?js } ?>
 
     <?js 
       var events = self.find({kind: 'event', memberof: doc.longname, scope: "static"});
-      if (!isGlobalPage && events && events.length) {
-    ?>
+      if (!isGlobalPage && events && events.length) { ?>
         <h3>Events</h3>
         <?js= self.partial('summary.tmpl', events) ?>
     <?js } ?>
 
     <?js 
       var interfaces = self.find({kind: 'interface', memberof: doc.longname});
-      if (!isGlobalPage && events && events.length) {
-    ?>
+      if (!isGlobalPage && interfaces && interfaces.length) { ?>
         <h3>Interfaces</h3>
         <?js= self.partial('summary.tmpl', interfaces) ?>
     <?js } ?>
@@ -137,7 +134,6 @@
     <?js var mixins = self.find({kind: 'mixin', memberof: doc.longname});
     if (!isGlobalPage && mixins && mixins.length) { ?>
         <h3>Mixins</h3>
-
         <dl><?js mixins.forEach(function(m) { ?>
             <dt><?js= self.linkto(m.longname, m.name) ?></dt>
         <?js }); ?></dl>

--- a/impl/client/src/main/doc-js/pentaho/IAmdLoaderPlugin.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/IAmdLoaderPlugin.jsdoc
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An AMD/RequireJS loader plugin module is a module which can be used to load other, _logical_ modules.
+ *
+ * To use this type of module as an AMD loader plugin module, request it with an `!` character appended
+ * to its module identifier. Any content after the `!` character denotes the logical module name.
+ *
+ * In the following example,
+ * the first dependency loads the the virtual module `foo.bar` using the `my/plugin-module` loader plugin module
+ * as an intermediary,
+ * while the second dependency loads the `my/plugin-module` itself.
+ * The latter is useful only if the loader plugin module exposes members beyond those of the loader plugin interface.
+ *
+ * ```js
+ * define([
+ *   "my/plugin-module!foo.bar",
+ *   "my/plugin-module"
+ * ], function(fooBar, pluginModule) {
+ *   // ...
+ * }
+ * ```
+ *
+ * AMD loader plugin modules are required to contain a [load]{@link IAmdLoaderPlugin#load} method.
+ *
+ * @name IAmdLoaderPlugin
+ * @interface
+ * @see http://requirejs.org/docs/plugins.html
+ */
+
+/**
+ * Loads a logical module given its name.
+ *
+ * @name load
+ * @memberOf IAmdLoaderPlugin#
+ * @method
+ *
+ * @param {string} name - The name of the logical module to load.
+ * @param {function} require - The contextual require function of the dependent module, if any,
+ *  or the global `require` function, if requested using it.
+ * @param {function} onLoad - Callback function to call with the resolved module, once it is resolved.
+ * @param {object} config - The full AMD/RequireJS config object.
+ */
+
+/**
+ * Normalizes the name of a logical module.
+ *
+ * Converts several names that refer to the same logical module to its canonical name,
+ * to ensure that the modules are recognized as being the same and are correctly cached.
+ *
+ * This is an optional method.
+ *
+ * @name normalize
+ * @memberOf IAmdLoaderPlugin#
+ * @method
+ *
+ * @param {string} name - The name of the logical module to load.
+ * @param {function} normalize - The default normalize function.
+ * @return {string} The normalized logical module
+ */

--- a/impl/client/src/main/doc-js/pentaho/i18n/IService.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/i18n/IService.jsdoc
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The interface of localization AMD/RequireJS loader plugins.
+ *
+ * This service allows loading a message bundle given its identifier as the AMD/RequireJS loader plugin parameter.
+ *
+ * Message bundle identifiers have the general form of AMD/RequireJS module identifiers.
+ * When relative, the full message bundle identifier is resolved relative to the requesting module's parent module.
+ *
+ * The following example loads the message bundle having the full identifier of `foo.bar`.
+ * ```js
+ * define(["pentaho/i18n!foo.bar"], function(msgBundle) { ... });
+ * ```
+ *
+ * The following example loads the message bundle having the relative identifier of `./i18n/bar`.
+ * Assuming the being defined module has the identifier `my/component`,
+ * the full identifier of the message bundle is `my/i18n/bar`.
+ * ```js
+ * define(["pentaho/i18n!./i18n/bar"], function(msgBundle) { ... });
+ * ```
+ *
+ * @name IService
+ * @memberOf pentaho.i18n
+ * @interface
+ * @extends IAmdLoaderPlugin
+ * @see pentaho.i18n.main
+ */

--- a/impl/client/src/main/doc-js/pentaho/i18n/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/i18n/_namespace.jsdoc
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `i18n` namespace contains the types of the **Pentaho Localization API**.
+ *
+ * ## Overview
+ *
+ * The **Pentaho Localization API** is constituted by an AMD/RequireJS loader plugin, {@link pentaho.i18n.IService},
+ * and a couple of helper types which allow you to load message bundles for use in JavaScript components.
+ *
+ * Message bundles are exposed as instances of {@link pentaho.util.MessageBundle}.
+ *
+ * The main localization service, and AMD/RequireJS loader plugin, is {@link pentaho.i18n.main}.
+ *
+ * @name pentaho.i18n
+ * @namespace
+ */

--- a/impl/client/src/main/doc-js/pentaho/service/ILocator.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/service/ILocator.jsdoc
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The interface of service locator AMD/RequireJS loader plugins.
+ *
+ * The service locator allows JavaScript components to declare dependency on other components in terms of the name of
+ * a _logical_ service.
+ * Other modules that provide such logical service should register as such.
+ * See [pentaho.service.locator]{@link pentaho.service.locator}.
+ *
+ * **AMD Plugin Usage**: `"pentaho/service!{logical-module-name}?meta&single&ids"`
+ *
+ * 1. `{logical-module-name}` — the name of a required logical module.
+ * 2. `single` — if present, the module resolves as a single value, the first declared dependency.
+ * 3. `meta` — if present, the module resolves as an array where each member is an object with two properties,
+ *    `moduleId` and `value`.
+ * 4. `ids` - if present, the module resolves as an array of the identifiers of the registered modules
+ *     and **does not load them**;
+ *     you can also use this module's {@link pentaho.service.ILocator#getRegisteredIds} method,
+ *     to be able to know the registered module ids synchronously.
+ *
+ * #### Logical service type
+ *
+ * There are no _a priori_ constraints on the type of value of a logical service.
+ * When a logical service has a certain value type, that should be described in its documentation.
+ * More often than not, the value type can be precisely defined as an interface or class.
+ *
+ * Currently, the plugin mechanism provides no assurances on the type of value of
+ * registered service provider modules.
+ * However, components requesting a logical module _should_ trust that the provided dependencies respect any
+ * documented contract.
+ *
+ * @name ILocator
+ * @memberOf pentaho.service
+ * @interface
+ * @extends IAmdLoaderPlugin
+ * @see pentaho.service.locator
+ */
+
+/**
+ * Gets the identifiers of modules registered as dependencies of a given logical module.
+ *
+ * @name getRegisteredIds
+ * @memberOf pentaho.service.ILocator#
+ * @method
+ * @param {string} name - The name of the logical module.
+ * @return {string[]} An array of identifiers, possibly empty.
+ */

--- a/impl/client/src/main/doc-js/pentaho/service/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/service/_namespace.jsdoc
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `service` namespace contains the types of the **Pentaho Service Locator API**.
+ *
+ * ## Overview
+ *
+ * The **Pentaho Service Locator API** is constituted by an AMD/RequireJS loader plugin, {@link pentaho.service.ILocator},
+ * which allows JavaScript components to depend on logical services.
+ * Other modules may declare to "implement" these services through AMD/RequireJS configuration.
+ *
+ * The main service locator service, and AMD/RequireJS loader plugin, is {@link pentaho.service.locator}.
+ *
+ * @name pentaho.service
+ * @namespace
+ */

--- a/impl/client/src/main/javascript/web/pentaho/i18n.js
+++ b/impl/client/src/main/javascript/web/pentaho/i18n.js
@@ -15,8 +15,14 @@
  */
 
 /**
- * RequireJS loader plugin for loading localized messages.
+ * The _main_ localization service of the JavaScript Pentaho platform.
+ *
+ * @name main
+ * @memberOf pentaho.i18n
+ * @type {pentaho.i18n.IService}
+ * @amd pentaho/i18n
  */
+
 define([
   "./context",
   "./util/MessageBundle",
@@ -25,7 +31,7 @@ define([
 
   "use strict";
 
-  return {
+  return /** @type pentaho.i18n.IService */ {
     load: function(bundlePath, localRequire, onLoad, config) {
 
       if(config.isBuild) {

--- a/impl/client/src/main/javascript/web/pentaho/type/_type.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/_type.js
@@ -887,7 +887,7 @@ define([
       /**
        * Gets the style classes of this and any base types.
        *
-       * Does **not** modify the returned array.
+       * The returned array should not be modified.
        *
        * @type {string[]}
        * @readonly

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
@@ -75,7 +75,7 @@ define([
     /**
      * Gets the list of contained primitive changes.
      *
-     * Do **NOT** modify the returned array in any way.
+     * The returned array should not be modified.
      *
      * @type {pentaho.type.change.PrimitiveChange[]}
      * @readOnly

--- a/impl/client/src/main/javascript/web/pentaho/type/simple.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/simple.js
@@ -405,7 +405,7 @@ define([
          *
          * When `null` is returned, it is considered that the conversion is not possible.
          * For informing on the actual reason why the conversion is not possible,
-         * throw an [UserError]{@link pentaho.lang.UserError} should be used instead.
+         * throw an [UserError]{@link pentaho.lang.UserError} instead.
          *
          * The default implementation is the identity function.
          *

--- a/impl/client/src/main/javascript/web/pentaho/visual/color/paletteRegistry.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/color/paletteRegistry.js
@@ -196,7 +196,7 @@ define([
       /**
        * Gets an array with all registered color palettes.
        *
-       * Do **not** modify the returned array.
+       * The returned array should not be modified.
        *
        * @return {Array.<pentaho.visual.color.IColorPalette>} An array of color palettes.
        */

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/mapping.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/mapping.js
@@ -615,7 +615,7 @@ define([
          * The root [visual.role.Mapping]{@link pentaho.visual.role.Mapping} has
          * a `levels` attribute which is list of all possible measurement levels.
          *
-         * Do **NOT** modify the returned list or its elements in any way.
+         * The returned list or its elements should not be modified.
          *
          * @type {pentaho.type.List.<pentaho.visual.role.MeasurementLevel>}
          *


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

Only added the commits related with the service/i18n documentation and small tweaks not related to 8.0
Excluded from the cherry-pick things like:
 - Point Event
 - Mixins
 - Refinements
 - The last cleanups from @dcleao that are also related with 8.0 code changes