### PR TITLE
[SP-3569][PIR-1351]-XSS vulnerability in DataSource name when creating new PIR

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/datasourceselect.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/datasourceselect.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  *
  */
-define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dijit/_WidgetsInTemplateMixin", "dojo/on", 'pentaho/common/SmallImageButton',
+define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dijit/_WidgetsInTemplateMixin", "dojo/on", "dojox/html/entities", 'pentaho/common/SmallImageButton',
   'pentaho/common/ListBox',
   'pentaho/common/Dialog',
   'pentaho/common/MessageBox', "dojo/_base/lang", 'dojo/text!pentaho/common/datasourceselect.html',
   'dojo/Stateful', 'dojo/has', 'dojo/_base/sniff'],
-  function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, on, SmallImageButton, ListBox, Dialog, MessageBox, lang, templateStr, Stateful, has) {
+  function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, on, entities, SmallImageButton, ListBox, Dialog, MessageBox, lang, templateStr, Stateful, has) {
     return declare("pentaho.common.datasourceselect", [Stateful, Dialog, _TemplatedMixin, _WidgetsInTemplateMixin],
 
       {
@@ -234,9 +234,11 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
               this.msgBox.setLocalizationLookupFunction(this.getLocaleString);
             }
 
-            this.msgBox.buttons = [this.getLocaleString('Ok'), this.getLocaleString('Cancel')];
-            this.msgBox.setTitle(this.getLocaleString('Warning'));
-            this.msgBox.setMessage(this.getLocaleString('DeleteDatasourceWarning'));
+
+            this.msgBox.buttons = [this.getLocaleString('Yes'), this.getLocaleString('No')];
+            this.msgBox.setTitle(this.getLocaleString('DeleteDatasourceWarningTitle'));
+            this.msgBox.setMessage(this.getLocaleString('DeleteDatasourceWarning', entities.encode(this.getSelectedModel().name)));
+
             this.msgBox.callbacks = [
               lang.hitch(this, this.deleteDatasource2),
               lang.hitch(this, function () {

--- a/impl/server/src/main/java/org/pentaho/common/ui/metadata/model/impl/Category.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/metadata/model/impl/Category.java
@@ -38,6 +38,9 @@ public class Category implements ICategory, Serializable {
    */
   @Override
   public String getId() {
+    if ( this.id != null ) {
+      return this.id.replaceAll( "<", "&lt;" ).replaceAll( ">", "&gt;" );
+    }
     return this.id;
   }
 
@@ -46,7 +49,11 @@ public class Category implements ICategory, Serializable {
    */
   @Override
   public String getName() {
-    return this.name;
+    if ( this.name != null ) {
+      return this.name.replaceAll( "<", "&lt;" ).replaceAll( ">", "&gt;" );
+    } else {
+      return this.name;
+    }
   }
 
   /**

--- a/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataService.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataService.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONException;
@@ -167,7 +167,7 @@ public class MetadataService extends PentahoBase {
       ModelInfo modelInfo = new ModelInfo();
       modelInfo.setDomainId( domain );
       modelInfo.setModelId( model.getId() );
-      modelInfo.setModelName( model.getName( locale ) );
+      modelInfo.setModelName( StringEscapeUtils.escapeHtml( model.getName( locale ) ) );
       if ( model.getDescription() != null ) {
         String modelDescription = model.getDescription( locale );
         modelInfo.setModelDescription( modelDescription );

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/model/impl/CategoryTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/model/impl/CategoryTest.java
@@ -1,0 +1,35 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.common.ui.metadata.model.impl;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+
+public class CategoryTest {
+  private static final String XSS_STRING = "<iMg SrC=x OnErRoR=alert(11113)>";
+  private Category category = new Category();
+
+  @Test
+  public void testGetIdAndName() {
+    category.setId( XSS_STRING );
+    category.setName( XSS_STRING );
+
+    Assert.assertFalse( category.getId().contains("<") );
+    Assert.assertFalse( category.getName().contains("<") );
+  }
+}

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataServiceTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.pentaho.common.ui.metadata.service;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -52,7 +54,11 @@ public class MetadataServiceTest {
 
   private static final String DOMAIN_NAME = "testDomain";
   private static final String MODEL_ID = "visibleModelId";
+  private static final String MODEL_NAME = " visibleModelName";
+  private static final String MODEL_ID_XSS = "zModelId_XSS";
   private static final String CTX = "testContext";
+  private static final String XSS_STRING = "<iMg SrC=x OnErRoR=alert(11113)>";
+
 
   private MetadataService metadataService;
 
@@ -72,9 +78,15 @@ public class MetadataServiceTest {
     visibleModel = mock( LogicalModel.class );
     doReturn( "testCtx0," + CTX ).when( visibleModel ).getProperty( "visible" );
     doReturn( MODEL_ID ).when( visibleModel ).getId();
-    doReturn( "visibleModelName" ).when( visibleModel ).getName( DEFAULT_LOCALE );
+    doReturn( MODEL_NAME ).when( visibleModel ).getName( DEFAULT_LOCALE );
     doReturn( new LocalizedString() ).when( visibleModel ).getDescription();
     doReturn( "visibleModelDescLocale" ).when( visibleModel ).getDescription( DEFAULT_LOCALE );
+    LogicalModel visibleModel2 = mock( LogicalModel.class );
+    doReturn( "testCtx0," + CTX ).when( visibleModel2 ).getProperty( "visible" );
+    doReturn( MODEL_ID_XSS ).when( visibleModel2 ).getId();
+    doReturn( XSS_STRING ).when( visibleModel2 ).getName( DEFAULT_LOCALE );
+    doReturn( new LocalizedString() ).when( visibleModel2 ).getDescription();
+    doReturn( "visibleModelDescLocale" ).when( visibleModel2 ).getDescription( DEFAULT_LOCALE );
 
     LogicalModel invisibleModel = mock( LogicalModel.class );
     doReturn( "testCtx0,testCtx1" ).when( invisibleModel ).getProperty( "visible" );
@@ -82,6 +94,7 @@ public class MetadataServiceTest {
     List<LogicalModel> listModels = new ArrayList<LogicalModel>( 2 );
     listModels.add( visibleModel );
     listModels.add( invisibleModel );
+    listModels.add( visibleModel2 );
 
     validDomain = mock( Domain.class );
     doReturn( listModels ).when( validDomain ).getLogicalModels();
@@ -114,7 +127,7 @@ public class MetadataServiceTest {
   public void testListBusinessModelsWithoutDomainName() throws Exception {
     ModelInfo[] result = metadataService.listBusinessModels( StringUtils.EMPTY, CTX );
     assertNotNull( result );
-    assertEquals( 1, result.length );
+    assertEquals( 2, result.length );
     assertEquals( DOMAIN_NAME, result[0].getDomainId() );
     assertEquals( visibleModel.getId(), result[0].getModelId() );
     assertEquals( visibleModel.getName( DEFAULT_LOCALE ), result[0].getModelName() );
@@ -125,7 +138,7 @@ public class MetadataServiceTest {
   public void testListBusinessModels() throws Exception {
     ModelInfo[] result = metadataService.listBusinessModels( DOMAIN_NAME, CTX );
     assertNotNull( result );
-    assertEquals( 1, result.length );
+    assertEquals( 2, result.length );
     assertEquals( DOMAIN_NAME, result[0].getDomainId() );
     assertEquals( visibleModel.getId(), result[0].getModelId() );
     assertEquals( visibleModel.getName( DEFAULT_LOCALE ), result[0].getModelName() );
@@ -136,7 +149,7 @@ public class MetadataServiceTest {
   public void testListBusinessModelsJson() throws IOException {
     String json = metadataService.listBusinessModelsJson( DOMAIN_NAME, CTX );
     assertEquals(
-        "[{\"class\":\"org.pentaho.common.ui.metadata.model.impl.ModelInfo\",\"domainId\":\"testDomain\",\"modelDescription\":\"visibleModelDescLocale\",\"modelId\":\"visibleModelId\",\"modelName\":\"visibleModelName\"}]",
+        "[{\"class\":\"org.pentaho.common.ui.metadata.model.impl.ModelInfo\",\"domainId\":\"testDomain\",\"modelDescription\":\"visibleModelDescLocale\",\"modelId\":\"visibleModelId\",\"modelName\":\" visibleModelName\"},{\"class\":\"org.pentaho.common.ui.metadata.model.impl.ModelInfo\",\"domainId\":\"testDomain\",\"modelDescription\":\"visibleModelDescLocale\",\"modelId\":\"zModelId_XSS\",\"modelName\":\"&lt;iMg SrC=x OnErRoR=alert(11113)&gt;\"}]",
         json );
   }
 
@@ -303,5 +316,14 @@ public class MetadataServiceTest {
 
     String result = metadataService.getQueryXmlFromJson( json );
     assertEquals( resultXml, result );
+  }
+
+  @Test
+  public void testListBusinessModelsXSS() throws Exception {
+    ModelInfo[] result = metadataService.listBusinessModels( DOMAIN_NAME, CTX );
+    assertNotNull( result );
+    assertEquals( 2, result.length );
+    assertFalse( XSS_STRING.equals( result[1].getModelName() ) );
+    assertFalse( result[1].getModelName().contains( "<" ) );
   }
 }


### PR DESCRIPTION
 - now name of datasource escaping
 - added unit test
 - fixing exception for case when add any field to report
 - fixing executing  malicious code when datasource deleting