### PR TITLE
[BACKLOG-16427] Refactor reserved names in the TypeAPI to clear the business namespace

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/config/spec/IRuleSelector.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/config/spec/IRuleSelector.jsdoc
@@ -46,7 +46,7 @@
  *
  * @name application
  * @memberOf pentaho.config.spec.IRuleSelector#
- * @type {?pentaho.type.spec.UContextPropFilter<string>}
+ * @type {pentaho.type.spec.UContextPropFilter<string>}
  */
 
 /**
@@ -54,7 +54,7 @@
  *
  * @name user
  * @memberOf pentaho.config.spec.IRuleSelector#
- * @type {?pentaho.type.spec.UContextPropFilter<string>}
+ * @type {pentaho.type.spec.UContextPropFilter<string>}
  */
 
 /**
@@ -62,7 +62,7 @@
  *
  * @name theme
  * @memberOf pentaho.config.spec.IRuleSelector#
- * @type {?pentaho.type.spec.UContextPropFilter<string>}
+ * @type {pentaho.type.spec.UContextPropFilter<string>}
  */
 
 /**
@@ -70,5 +70,5 @@
  *
  * @name locale
  * @memberOf pentaho.config.spec.IRuleSelector#
- * @type {?pentaho.type.spec.UContextPropFilter<string>}
+ * @type {pentaho.type.spec.UContextPropFilter<string>}
  */

--- a/impl/client/src/main/doc-js/pentaho/type/action/spec/IBaseProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/action/spec/IBaseProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of action type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.IBaseProto#
  * @type {pentaho.type.spec.IBaseTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/action/spec/IBaseTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/action/spec/IBaseTypeProto.jsdoc
@@ -29,7 +29,7 @@
  * @memberOf pentaho.type.action.spec.IBaseTypeProto#
  * @type {pentaho.type.action.spec.IBaseProto}
  *
- * @see pentaho.type.action.spec.IBaseProto#type
+ * @see pentaho.type.action.spec.IBaseProto#$type
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IComplexProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IComplexProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of complex type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.IComplexProto#
  * @type {pentaho.type.spec.IComplexTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IComplexTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IComplexTypeProto.jsdoc
@@ -29,7 +29,7 @@
  * @memberOf pentaho.type.spec.IComplexTypeProto#
  * @type {pentaho.type.spec.IComplexProto}
  *
- * @see pentaho.type.spec.IComplexProto#type
+ * @see pentaho.type.spec.IComplexProto#$type
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IInstanceProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IInstanceProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.IInstanceProto#
  * @type {pentaho.type.spec.ITypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IListProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IListProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of list type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.IListProto#
  * @type {pentaho.type.spec.IListTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IListTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IListTypeProto.jsdoc
@@ -29,7 +29,7 @@
  * @memberOf pentaho.type.spec.IListTypeProto#
  * @type {pentaho.type.spec.IListProto}
  *
- * @see pentaho.type.spec.IListProto#type
+ * @see pentaho.type.spec.IListProto#$type
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/ISimpleProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/ISimpleProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of simple type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.ISimpleProto#
  * @type {pentaho.type.spec.ISimpleTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/spec/ISimpleTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/ISimpleTypeProto.jsdoc
@@ -29,7 +29,7 @@
  * @memberOf pentaho.type.spec.ISimpleTypeProto#
  * @type {pentaho.type.spec.ISimpleProto}
  *
- * @see pentaho.type.spec.ISimpleProto#type
+ * @see pentaho.type.spec.ISimpleProto#$type
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/ITypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/ITypeProto.jsdoc
@@ -57,7 +57,7 @@
  * @memberOf pentaho.type.spec.ITypeProto#
  * @type {pentaho.type.spec.ITypeProto}
  *
- * @see pentaho.type.spec.IInstanceProto#type
+ * @see pentaho.type.spec.IInstanceProto#$type
  */
 
 /**

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IValueProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IValueProto.jsdoc
@@ -25,7 +25,7 @@
 /**
  * The extensible/configurable members of the prototype of value type classes.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.type.spec.IValueProto#
  * @type {pentaho.type.spec.IValueTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/IValueTypeProto.jsdoc
@@ -29,5 +29,5 @@
  * @memberOf pentaho.type.spec.IValueTypeProto#
  * @type {pentaho.type.spec.IValueProto}
  *
- * @see pentaho.type.spec.IValueProto#type
+ * @see pentaho.type.spec.IValueProto#$type
  */

--- a/impl/client/src/main/doc-js/pentaho/type/spec/UTypeReference.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/type/spec/UTypeReference.jsdoc
@@ -95,7 +95,7 @@
  *
  *     // Derive and return the derived type constructor
  *     return MyBaseType.extend({
- *        type: {
+ *        $type: {
  *          id: "my/derived/type"
  *          // ...
  *        }

--- a/impl/client/src/main/doc-js/pentaho/visual/action/spec/ISelectProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/action/spec/ISelectProto.jsdoc
@@ -26,7 +26,7 @@
 /**
  * The extensible/configurable members of the prototype of the selection action type class.
  *
- * @name type
+ * @name $type
  * @memberOf pentaho.visual.action.spec.ISelectProto#
  * @type {pentaho.visual.action.spec.ISelectTypeProto}
  *

--- a/impl/client/src/main/doc-js/pentaho/visual/action/spec/ISelectTypeProto.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/action/spec/ISelectTypeProto.jsdoc
@@ -29,7 +29,7 @@
  * @memberOf pentaho.visual.action.spec.ISelectTypeProto#
  * @type {pentaho.visual.action.spec.ISelectProto}
  *
- * @see pentaho.visual.action.spec.ISelectProto#type
+ * @see pentaho.visual.action.spec.ISelectProto#$type
  */
 
 /**

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/abstract.js
@@ -116,7 +116,7 @@ define([
 
     return BaseView.extend(/** @lends pentaho.visual.ccc.base.View# */{
 
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}
@@ -351,8 +351,8 @@ define([
         var mapping = this.model.get(roleName);
         if(mapping.attributes.count > 1) return true;
 
-        var MeasurementLevel = this.type.context.get(measurementLevelFactory);
-        var rolePropType = this.model.type.get(roleName);
+        var MeasurementLevel = this.$type.context.get(measurementLevelFactory);
+        var rolePropType = this.model.$type.get(roleName);
         var level = rolePropType.levelEffectiveOn(this.model);
         return !level || MeasurementLevel.type.isQualitative(level);
       },
@@ -597,7 +597,7 @@ define([
         // This is because, otherwise, we would not be able to specify valueType and isDiscrete differently
         // for different visual roles...
 
-        this.model.type.eachVisualRole(function(propType) {
+        this.model.$type.eachVisualRole(function(propType) {
           var roleName = propType.name;
           var mapping  = this.model.get(roleName);
 
@@ -1435,7 +1435,7 @@ define([
       _processExtensions: function() {
         var valid = null;
 
-        var extension = this.type.extensionEffective;
+        var extension = this.$type.extensionEffective;
         if(extension) {
           def.each(extension, function(v, p) {
             if(!def.hasOwn(extensionBlacklist, p)) {
@@ -1479,7 +1479,7 @@ define([
 
         // TODO: Currently, this is DET dependent...
 
-        var modelTypeApp = this.model.type.application;
+        var modelTypeApp = this.model.$type.application;
         var cellCountMax = +(modelTypeApp && modelTypeApp.optimalMaxDataSize);
         return cellCountMax > 0 ? cellCountMax : -1;
       },
@@ -1538,7 +1538,7 @@ define([
             operands.push(operand);
           }
         } else {
-          operands =selectingDatums.reduce(function(memo, datum) {
+          operands = selectingDatums.reduce(function(memo, datum) {
             if(!datum.isVirtual && !datum.isNull) {
               // When there are no attributes (e.g. bar chart with measures alone),
               // operand is null...
@@ -1559,8 +1559,8 @@ define([
         }
 
         if(operands.length) {
-          var SelectAction = this.type.context.get(selectActionFactory);
-          var Or = this.type.context.get("or");
+          var SelectAction = this.$type.context.get(selectActionFactory);
+          var Or = this.$type.context.get("or");
           this.act(new SelectAction({
             dataFilter: new Or({operands: operands}),
             position: srcEvent ? {x: srcEvent.clientX, y: srcEvent.clientY} : null
@@ -1587,10 +1587,10 @@ define([
       },
 
       _onDoubleClick: function(complex, srcEvent) {
-        var ExecuteAction = this.type.context.get(executeActionFactory);
+        var ExecuteAction = this.$type.context.get(executeActionFactory);
         var dataFilter = this._complexToFilter(complex);
         if(dataFilter != null) {
-          var Or = this.type.context.get("or");
+          var Or = this.$type.context.get("or");
           this.act(new ExecuteAction({
             dataFilter: new Or({operands: [dataFilter]}),
             position: srcEvent ? {x: srcEvent.clientX, y: srcEvent.clientY} : null
@@ -1613,7 +1613,7 @@ define([
 
         // Enforce that the returned filter is wrapped by an And
         if (filter != null && filter.kind !== "and") {
-          var And = this.type.context.get("and");
+          var And = this.$type.context.get("and");
           return new And({
             operands: [filter]
           });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/area.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/area.js
@@ -25,7 +25,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaAbstract.js
@@ -27,7 +27,7 @@ define([
     return BaseView.extend({
       _cccClass: "AreaChart",
 
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaStacked.js
@@ -28,7 +28,7 @@ define([
     return BaseView.extend({
       _cccClass: "StackedAreaChart",
 
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/axes/DiscreteAxis.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/axes/DiscreteAxis.js
@@ -52,7 +52,7 @@ define([
     complexToFilter: function(complex) {
       var filter = null;
 
-      var context = this.chart.type.context;
+      var context = this.chart.$type.context;
       var IsEqual;
 
       this.getSelectionMappingAttrInfos().each(function(maInfo) {

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/bar.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/bar.js
@@ -29,7 +29,7 @@ define([
     return BaseView.extend({
       _supportsTrends: true,
 
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barAbstract.js
@@ -28,7 +28,7 @@ define([
 
     return BaseView.extend({
 
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barHorizontal.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barLine.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barLine.js
@@ -28,7 +28,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalized.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalized.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedAbstract.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedHorizontal.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStacked.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStackedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStackedHorizontal.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/boxplot.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/boxplot.js
@@ -27,7 +27,7 @@ define([
     return BaseView.extend({
       _cccClass: "BoxplotChart",
 
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/bubble.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/bubble.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/cartesianAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/cartesianAbstract.js
@@ -28,7 +28,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}
@@ -130,7 +130,7 @@ define([
 
         var propName = "displayUnits" + (primary ? "" : "Secondary");
         var displayUnits = this.model.getv(propName);
-        var displayUnitsType = this.model.type.get(propName).valueType;
+        var displayUnitsType = this.model.$type.get(propName).valueType;
         var scaleFactor = displayUnitsType.scaleFactorOf(displayUnits);
 
         // Unfortunately the stored element value usually has no formatted value associated,

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/categoricalContinuousAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/categoricalContinuousAbstract.js
@@ -27,7 +27,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/donut.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/donut.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/heatGrid.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/heatGrid.js
@@ -27,7 +27,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
@@ -27,7 +27,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/metricPointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/metricPointAbstract.js
@@ -27,7 +27,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/pie.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/pie.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/pointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/pointAbstract.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/scatter.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/scatter.js
@@ -26,7 +26,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/sunburst.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/sunburst.js
@@ -30,7 +30,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend({
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}
@@ -158,7 +158,7 @@ define([
       },
 
       _configureDisplayUnits: function() {
-        var displayUnitsType = this.model.type.get("displayUnits").valueType;
+        var displayUnitsType = this.model.$type.get("displayUnits").valueType;
         var displayUnits = this.model.displayUnits;
         var scaleFactor = displayUnitsType.scaleFactorOf(displayUnits);
         if(scaleFactor > 1) {

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/treemap.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/treemap.js
@@ -27,7 +27,7 @@ define([
     return BaseView.extend({
       _cccClass: "TreemapChart",
 
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/waterfall.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/waterfall.js
@@ -27,7 +27,7 @@ define([
     return BaseView.extend({
       _cccClass: "WaterfallChart",
 
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/data/_ElementMock.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_ElementMock.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation. All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ define([
       this.table = dataTable;
       this.rowIdx = rowIdx;
 
-      this.type = {
+      this.$type = {
         has: function(property) {
           return dataTable.model.attributes.get(property) != null;
         }

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/and.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/and.js
@@ -87,7 +87,7 @@ define([
         return filter.Or;
       },
 
-      type: /** @lends pentaho.data.filter.And.Type# */{
+      $type: /** @lends pentaho.data.filter.And.Type# */{
         id: "pentaho/data/filter/and",
         alias: "and"
       }

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/false.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/false.js
@@ -80,7 +80,7 @@ define([
         return filter.True.instance;
       },
 
-      type: /** @lends pentaho.data.filter.False.Type# */{
+      $type: /** @lends pentaho.data.filter.False.Type# */{
         id: "pentaho/data/filter/false",
         alias: "false"
       }

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/not.js
@@ -129,7 +129,7 @@ define([
         return this.operand || new filter.Not({operand: this});
       },
 
-      type: /** @lends pentaho.data.filter.Not.Type# */{
+      $type: /** @lends pentaho.data.filter.Not.Type# */{
         id: "pentaho/data/filter/not",
         alias: "not",
         props: [

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/or.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/or.js
@@ -87,7 +87,7 @@ define([
         return filter.And;
       },
 
-      type: /** @lends pentaho.data.filter.Or.Type# */{
+      $type: /** @lends pentaho.data.filter.Or.Type# */{
         id: "pentaho/data/filter/or",
         alias: "or"
       }

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/tree.js
@@ -231,7 +231,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.data.filter.Tree.Type# */{
+      $type: /** @lends pentaho.data.filter.Tree.Type# */{
         id: "pentaho/data/filter/tree",
         isAbstract: true,
         props: [

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/true.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/true.js
@@ -80,7 +80,7 @@ define([
         return filter.False.instance;
       },
 
-      type: /** @lends pentaho.data.filter.True.Type# */{
+      $type: /** @lends pentaho.data.filter.True.Type# */{
         id: "pentaho/data/filter/true",
         alias: "true"
       }

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
@@ -135,7 +135,7 @@ define([
        */
       __buildContentKeyOuter: function() {
         var innerKey = this._buildContentKey();
-        return "(" + this.type.shortId + (innerKey ? (" " + innerKey) : "") + ")";
+        return "(" + this.$type.shortId + (innerKey ? (" " + innerKey) : "") + ")";
       },
 
       /**
@@ -423,7 +423,7 @@ define([
         return result;
       },
 
-      type: /** @lends pentaho.data.filter.Abstract.Type# */{
+      $type: /** @lends pentaho.data.filter.Abstract.Type# */{
         id: module.id,
 
         isAbstract: true

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/isEqual.js
@@ -80,7 +80,7 @@ define([
       /** @inheritDoc */
       _buildContentKey: function() {
         var v = this.get("value");
-        return (this.property || "") + " " + (v ? v.key : "");
+        return (this.property || "") + " " + (v ? v.$key : "");
       },
 
       type: /** @lends pentaho.data.filter.IsEqual.Type# */{

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/isEqual.js
@@ -83,7 +83,7 @@ define([
         return (this.property || "") + " " + (v ? v.$key : "");
       },
 
-      type: /** @lends pentaho.data.filter.IsEqual.Type# */{
+      $type: /** @lends pentaho.data.filter.IsEqual.Type# */{
         id: module.id,
         alias: "=",
         props: [

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/isIn.js
@@ -97,7 +97,7 @@ define([
         return (this.property || "") + " " + this.values.toArray(function(v) { return v.$key; }).join(" ");
       },
 
-      type: /** @lends pentaho.data.filter.IsIn.Type# */{
+      $type: /** @lends pentaho.data.filter.IsIn.Type# */{
         id: module.id,
         alias: "in",
         props: [

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/isIn.js
@@ -94,7 +94,7 @@ define([
 
       /** @inheritDoc */
       _buildContentKey: function() {
-        return (this.property || "") + " " + this.values.toArray(function(v) { return v.key; }).join(" ");
+        return (this.property || "") + " " + this.values.toArray(function(v) { return v.$key; }).join(" ");
       },
 
       type: /** @lends pentaho.data.filter.IsIn.Type# */{

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/property.js
@@ -94,10 +94,10 @@ define([
        */
       _contains: function(elem) {
         var prop = this.property;
-        return elem.type.has(prop) && this._operation(elem.getv(prop));
+        return elem.$type.has(prop) && this._operation(elem.getv(prop));
       },
 
-      type: /** @lends pentaho.data.filter.Property.Type# */{
+      $type: /** @lends pentaho.data.filter.Property.Type# */{
         id: module.id,
         isAbstract: true,
         props: [

--- a/impl/client/src/main/javascript/web/pentaho/type/Context.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/Context.js
@@ -327,7 +327,7 @@ define([
      *   var model = new VizChordModel({outerRadius: 200});
      *
      *   // Render the model using the default view
-     *   model.type.defaultViewClass.then(function(View) {
+     *   model.$type.defaultViewClass.then(function(View) {
      *     var view = new View(document.getElementById("container"), model);
      *
      *     // ...
@@ -467,7 +467,7 @@ define([
      *       var model = new VizChordModel({outerRadius: 200});
      *
      *       // Render the model using the default view
-     *       model.type.defaultViewClass.then(function(View) {
+     *       model.$type.defaultViewClass.then(function(View) {
      *         var view = new View(document.getElementById("container"), model);
      *
      *         // ...
@@ -637,8 +637,8 @@ define([
           });
 
         return Promise.all([this.getAsync(baseTypeId), instCtorsPromise])
-          .then(function(values) {
-            var baseType  = values[0].type;
+          .then(function(Values) {
+            var baseType  = Values[0].type;
             var InstCtors = Object.keys(me.__byTypeUid).map(function(typeUid) {
               return me.__byTypeUid[typeUid];
             });
@@ -1157,7 +1157,7 @@ define([
           var BaseInstCtor = this.__get(baseTypeSpec, null, /* sync: */true);
 
           // 2. Extend the base type
-          var InstCtor = BaseInstCtor.extend({type: typeSpec});
+          var InstCtor = BaseInstCtor.extend({$type: typeSpec});
 
           // 3. Register and configure the new type
           if(SpecificationContext.isIdTemporary(id)) {

--- a/impl/client/src/main/javascript/web/pentaho/type/PropertyTypeCollection.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/PropertyTypeCollection.js
@@ -170,7 +170,7 @@ define([
       // Replace with overridden property.
       var Existing = existing.instance.constructor;
       var Replacement = Existing.extend({
-        type: spec
+        $type: spec
       }, null, ka);
 
       return Replacement.type;
@@ -207,7 +207,7 @@ define([
       ka.isRoot = true;
 
       var BaseProp = basePropType.instance.constructor;
-      var Prop = BaseProp.extend({type: spec}, null, ka);
+      var Prop = BaseProp.extend({$type: spec}, null, ka);
 
       ka.index = -1;
       ka.isRoot = false;

--- a/impl/client/src/main/javascript/web/pentaho/type/action/base.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/action/base.js
@@ -77,7 +77,7 @@ define([
 
     return Element.extend(/** @lends pentaho.type.action.Base# */{
 
-      type: /** @lends pentaho.type.action.Base.Type# */{
+      $type: /** @lends pentaho.type.action.Base.Type# */{
         id: module.id,
         isAbstract: true,
 
@@ -361,7 +361,7 @@ define([
        * @throws {pentaho.lang.OperationInvalidError} When set and the action is not in an editable state.
        */
       get label() {
-        return this.__label || this.type.label;
+        return this.__label || this.$type.label;
       },
 
       set label(value) {
@@ -382,7 +382,7 @@ define([
        * @throws {pentaho.lang.OperationInvalidError} When set and the action is not in an editable state.
        */
       get description() {
-        return this.__description || this.type.description;
+        return this.__description || this.$type.description;
       },
 
       set description(value) {
@@ -901,7 +901,7 @@ define([
 
         this.__executor = executor || null;
 
-        if(this.type.isSync) {
+        if(this.$type.isSync) {
           this.__executeSyncAction();
         } else {
           this.__executeAsyncAction();
@@ -1080,7 +1080,7 @@ define([
 
         var promise = this._onPhaseDo();
 
-        var isSync = this.type.isSync;
+        var isSync = this.$type.isSync;
         if(isSync) {
           maybeDoDefault.call(this);
           return null;
@@ -1218,9 +1218,9 @@ define([
 
         var declaredType;
         var includeType = !!keyArgs.forceType ||
-              (!!(declaredType = keyArgs.declaredType) && this.type !== declaredType);
+              (!!(declaredType = keyArgs.declaredType) && this.$type !== declaredType);
 
-        if(includeType) spec._ = this.type.toRefInContext(keyArgs);
+        if(includeType) spec._ = this.$type.toRefInContext(keyArgs);
         if(this.label) spec.label = this.label;
         if(this.description) spec.description = this.description;
 

--- a/impl/client/src/main/javascript/web/pentaho/type/application.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/application.js
@@ -49,13 +49,13 @@ define([
      * @param {pentaho.type.spec.IApplication} [spec] An application specification.
      */
     var Application = Complex.extend(/** @lends pentaho.type.Application# */{
-      type: /** @lends pentaho.type.Application.Type# */{
+      $type: /** @lends pentaho.type.Application.Type# */{
         id: module.id,
         alias: "application"
       }
     })
     .implement({
-      type: bundle.structured.application
+      $type: bundle.structured.application
     });
 
     return Application;

--- a/impl/client/src/main/javascript/web/pentaho/type/boolean.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/boolean.js
@@ -43,13 +43,13 @@ define([
        * @readonly
        */
 
-      type: /** @lends pentaho.type.Boolean.Type# */{
+      $type: /** @lends pentaho.type.Boolean.Type# */{
         id: module.id,
         alias: "boolean",
         cast: Boolean
       }
     }).implement(/** @lends pentaho.type.Boolean# */{
-      type: bundle.structured["boolean"] // eslint-disable-line dot-notation
+      $type: bundle.structured["boolean"] // eslint-disable-line dot-notation
     });
 
     return PenBoolean;

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
@@ -87,7 +87,7 @@ define([
       var elem = this.element;
 
       target.__elems.splice(this.index, 0, elem);
-      target.__keys[elem.key] = elem;
+      target.__keys[elem.$key] = elem;
     }
   });
 });

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Add.js
@@ -73,13 +73,13 @@ define([
     /** @inheritDoc */
     _prepareRefs: function(txn, target) {
       var elem = this.element;
-      if(!target.isBoundary && elem.__addReference) txn.__ensureChangeRef(elem).addReference(target);
+      if(!target.$isBoundary && elem.__addReference) txn.__ensureChangeRef(elem).addReference(target);
     },
 
     /** @inheritDoc */
     _cancelRefs: function(txn, target) {
       var elem = this.element;
-      if(!target.isBoundary && elem.__addReference) txn.__ensureChangeRef(elem).removeReference(target);
+      if(!target.$isBoundary && elem.__addReference) txn.__ensureChangeRef(elem).removeReference(target);
     },
 
     /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
@@ -47,7 +47,7 @@ define([
     },
 
     _prepareRefs: function(txn, target) {
-      if(!target.isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.type.of.isComplex) {
         var i = -1;
         var elems = target.__elems;
         var L = elems.length;
@@ -61,7 +61,7 @@ define([
     },
 
     _cancelRefs: function(txn, target) {
-      if(!target.isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.type.of.isComplex) {
         var i = -1;
         var elems = target.__elems;
         var L = elems.length;

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Clear.js
@@ -47,7 +47,7 @@ define([
     },
 
     _prepareRefs: function(txn, target) {
-      if(!target.$isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.$type.of.isComplex) {
         var i = -1;
         var elems = target.__elems;
         var L = elems.length;
@@ -61,7 +61,7 @@ define([
     },
 
     _cancelRefs: function(txn, target) {
-      if(!target.$isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.$type.of.isComplex) {
         var i = -1;
         var elems = target.__elems;
         var L = elems.length;

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
@@ -115,7 +115,7 @@ define([
       // getChange("foo") -> PrimitiveChange or Changeset
       // Case I - Replace without changes within the new value (apart from ref changes)
       // Replace
-      //   (new) value : Value .changeset = null
+      //   (new) value : Value .$changeset = null
 
       // Lists, are never changed, and must always be copied.
       // The asymmetry comes from the fact that complex changesets cannot coexist with replaced values...
@@ -222,7 +222,7 @@ define([
       var valueIni = complex.__getByName(name);
 
       // Ambient value.
-      var cset = complex.changeset;
+      var cset = complex.$changeset;
       var change;
       var valueAmb = (cset && (change = O.getOwn(cset._changes, name))) ? change.value : valueIni;
 

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
@@ -136,7 +136,7 @@ define([
      * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
      */
     getChange: function(name) {
-      var pName = this.owner.type.get(name).name;
+      var pName = this.owner.$type.get(name).name;
       return O.getOwn(this._changes, pName) || null;
     },
 
@@ -150,7 +150,7 @@ define([
      * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
      */
     hasChange: function(name) {
-      var pName = this.owner.type.get(name).name;
+      var pName = this.owner.$type.get(name).name;
       return O.hasOwn(this._changes, pName);
     },
 
@@ -184,7 +184,7 @@ define([
      * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
      */
     getOld: function(name) {
-      var pName = this.owner.type.get(name).name;
+      var pName = this.owner.$type.get(name).name;
       return this.owner.__getByName(pName);
     },
 
@@ -212,7 +212,7 @@ define([
 
       // NOTE: For performance reasons, this function inlines code that would otherwise be available from.
       // For example: Container#usingChangeset(.) and TransactionScope.
-      var type = complex.type;
+      var type = complex.$type;
       var name = propType.name;
 
       // New value. Cast spec.

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
@@ -134,7 +134,7 @@ define([
 
     /** @inheritDoc */
     __setNestedChangeset: function(csetNested) {
-      this._changesByElemKey[csetNested.owner.key] = csetNested;
+      this._changesByElemKey[csetNested.owner.$key] = csetNested;
     },
 
     /**
@@ -277,7 +277,7 @@ define([
       var L = setElems.length;
       while(++i < L) {
         if((elem = setElems[i]) != null) {
-          key = elem.key;
+          key = elem.$key;
 
           var repeated = O.hasOwn(setKeys, key);
 
@@ -312,7 +312,7 @@ define([
       L = elems.length;
       while(++i < L) {
         elem = elems[i];
-        key = elem.key;
+        key = elem.$key;
 
         if(!O.hasOwn(setKeys, key)) {
           if(remove) {
@@ -354,7 +354,7 @@ define([
 
           this.__addChange(new Add(action.value, newIndex));
 
-          computed.splice(newIndex, 0, action.value.key);
+          computed.splice(newIndex, 0, action.value.$key);
         }
       }
 
@@ -365,7 +365,7 @@ define([
         L = setElems.length;
         while(++i < L) {
           if((elem = setElems[i]) != null) {
-            var currentIndex = computed.indexOf(elem.key);
+            var currentIndex = computed.indexOf(elem.$key);
             if(move) {
               if(currentIndex < baseIndex) {
                 --baseIndex;
@@ -384,8 +384,8 @@ define([
               lastDestinationIndex = currentIndex;
             }
 
-            if(update && setKeys[elem.key] === 2) {
-              existing = O.getOwn(keys, elem.key);
+            if(update && setKeys[elem.$key] === 2) {
+              existing = O.getOwn(keys, elem.$key);
 
               // This may create a new changeset, that gets hooked up into this.
               existing.configure(elem);
@@ -438,7 +438,7 @@ define([
       var L = removeElems.length;
       while(++i < L) {
         if((elem = removeElems[i])) {
-          key = elem.key;
+          key = elem.$key;
 
           if(!O.hasOwn(removeKeys, key) && O.hasOwn(keys, key)) {
             removeKeys[key] = 1;
@@ -534,7 +534,7 @@ define([
 
       var owner = this.owner;
       var elem = owner.__cast(elemSpec);
-      var existing = owner.get(elem.key);
+      var existing = owner.get(elem.$key);
       if(existing) {
         var indexOld = owner.indexOf(existing);
 

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
@@ -236,7 +236,7 @@ define([
       var list = this.__projectedMock; // calculate relative the last change
       var elems = list.__elems;
       var keys = list.__keys;
-      var elemType = this.owner.type.of;
+      var elemType = this.owner.$type.of;
       var existing;
       var elem;
       var key;
@@ -413,7 +413,7 @@ define([
       this._assertWritable();
 
       var list = this.__projectedMock; // calculate relative to the last change
-      var elemType = this.owner.type.of;
+      var elemType = this.owner.$type.of;
       var elems = list.__elems;
       var keys = list.__keys;
       var removeElems = Array.isArray(fragment)

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
@@ -70,7 +70,7 @@ define([
 
     /** @inheritDoc */
     _prepareRefs: function(txn, target) {
-      if(!target.$isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.$type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem.__addReference)
             txn.__ensureChangeRef(elem).removeReference(target);
@@ -80,7 +80,7 @@ define([
 
     /** @inheritDoc */
     _cancelRefs: function(txn, target) {
-      if(!target.$isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.$type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem.__addReference)
             txn.__ensureChangeRef(elem).addReference(target);

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
@@ -95,7 +95,7 @@ define([
       target.__elems.splice(this.index, elems.length);
 
       elems.forEach(function(elem) {
-        delete target.__keys[elem.key];
+        delete target.__keys[elem.$key];
       });
     }
   });

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Remove.js
@@ -70,7 +70,7 @@ define([
 
     /** @inheritDoc */
     _prepareRefs: function(txn, target) {
-      if(!target.isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem.__addReference)
             txn.__ensureChangeRef(elem).removeReference(target);
@@ -80,7 +80,7 @@ define([
 
     /** @inheritDoc */
     _cancelRefs: function(txn, target) {
-      if(!target.isBoundary && target.type.of.isComplex) {
+      if(!target.$isBoundary && target.type.of.isComplex) {
         this.elements.forEach(function(elem) {
           if(elem.__addReference)
             txn.__ensureChangeRef(elem).addReference(target);

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -192,7 +192,7 @@ define([
        * @type {string}
        * @readOnly
        */
-      get key() {
+      get $key() {
         return this.$uid;
       },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -72,7 +72,7 @@ define([
      *     var Complex = context.get(complexFactory);
      *
      *     return Complex.extend({
-     *       type: {
+     *       $type: {
      *         props: [
      *           {name: "name", valueType: "string", label: "Name"},
      *           {name: "categories", valueType: ["string"], label: "Categories"},
@@ -109,7 +109,7 @@ define([
         this._initContainer();
 
         // Create `Property` instances.
-        var propTypes = this.type.__getProps();
+        var propTypes = this.$type.__getProps();
         var i = propTypes.length;
         var readSpec = !spec ? undefined : (Array.isArray(spec) ? __readSpecByIndex : __readSpecByNameOrAlias);
         var values = {};
@@ -217,7 +217,7 @@ define([
        * name `name` is not defined.
        */
       get: function(name, sloppy) {
-        var pType = this.type.get(name, sloppy);
+        var pType = this.$type.get(name, sloppy);
         if(pType) return this.__getByType(pType);
       },
 
@@ -306,7 +306,7 @@ define([
        * @fires "rejected:change"
        */
       set: function(name, valueSpec) {
-        var propType = this.type.get(name);
+        var propType = this.$type.get(name);
 
         if(propType.isReadOnly) throw new TypeError("'" + name + "' is read-only");
 
@@ -326,8 +326,8 @@ define([
             // TODO: should copy only the properties of the LCA type?
 
             // Copy common properties, if it is a subtype of this one.
-            if(config.type.isSubtypeOf(this.type))
-              this.type.each(function(propType) {
+            if(config.$type.isSubtypeOf(this.$type))
+              this.$type.each(function(propType) {
                 this.set(propType, config.get(propType.name));
               }, this);
 
@@ -361,7 +361,7 @@ define([
        * name `name` is not defined.
        */
       countOf: function(name, sloppy) {
-        var pType = this.type.get(name, sloppy);
+        var pType = this.$type.get(name, sloppy);
         if(!pType) return 0;
 
         var value = this.__getByType(pType);
@@ -381,7 +381,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
       isApplicableOf: function(name) {
-        return this.type.get(name).isApplicableOn(this);
+        return this.$type.get(name).isApplicableOn(this);
       },
       // endregion
 
@@ -396,7 +396,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
       isEnabledOf: function(name) {
-        return this.type.get(name).isEnabledOn(this);
+        return this.$type.get(name).isEnabledOn(this);
       },
       // endregion
 
@@ -411,7 +411,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
       countRangeOf: function(name) {
-        return this.type.get(name).countRangeOn(this);
+        return this.$type.get(name).countRangeOn(this);
       },
       // endregion
 
@@ -429,7 +429,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
       isRequiredOf: function(name) {
-        return this.type.get(name).countRangeOn(this).min > 0;
+        return this.$type.get(name).countRangeOn(this).min > 0;
       },
       // endregion
 
@@ -444,7 +444,7 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
       domainOf: function(name) {
-        return this.type.get(name).domainOn(this);
+        return this.$type.get(name).domainOn(this);
       },
       // endregion
       // endregion
@@ -459,7 +459,7 @@ define([
         var noAlias = !!keyArgs.noAlias;
         var declaredType;
         var includeType = !!keyArgs.forceType ||
-              (!!(declaredType = keyArgs.declaredType) && this.type !== declaredType);
+              (!!(declaredType = keyArgs.declaredType) && this.$type !== declaredType);
 
         var useArray = !includeType && keyArgs.preferPropertyArray;
         var omitProps;
@@ -467,7 +467,7 @@ define([
           spec = [];
         } else {
           spec = {};
-          if(includeType) spec._ = this.type.toRefInContext(keyArgs);
+          if(includeType) spec._ = this.$type.toRefInContext(keyArgs);
           omitProps = keyArgs.omitProps;
 
           // Do not propagate to child values
@@ -475,7 +475,7 @@ define([
         }
 
         var includeDefaults = !!keyArgs.includeDefaults;
-        var type = this.type;
+        var type = this.$type;
 
         // reset
         keyArgs.forceType = false;
@@ -550,7 +550,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.type.Complex.Type# */{
+      $type: /** @lends pentaho.type.Complex.Type# */{
         id: module.id,
         alias: "complex",
 
@@ -788,7 +788,7 @@ define([
                *
                * // assert basePropType === O.lca(localPropType, otherPropType)
                *
-               * if(otherPropType.type.isSubtypeOf(localPropType.type))
+               * if(otherPropType.valueType.isSubtypeOf(localPropType.valueType))
                */
               if(fun.call(ctx, localPropType, i, this) === false)
                 return false;
@@ -810,7 +810,7 @@ define([
 
         // All properties are copied except lists, which are shallow cloned.
         // List properties are not affected by changesets.
-        var propTypes = this.type.__getProps();
+        var propTypes = this.$type.__getProps();
         var source = (this.__cset || this);
         var i = propTypes.length;
         var cloneValues = {};
@@ -836,7 +836,7 @@ define([
         return new ComplexChangeset(txn, this);
       },
 
-      type: bundle.structured.complex
+      $type: bundle.structured.complex
     });
 
     /**

--- a/impl/client/src/main/javascript/web/pentaho/type/complex.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/complex.js
@@ -207,8 +207,6 @@ define([
        *
        * @see pentaho.type.Complex#getv
        * @see pentaho.type.Complex#getf
-       * @see pentaho.type.Complex#at
-       * @see pentaho.type.Complex#first
        *
        * @param {string|!pentaho.type.Property.Type} [name] The property name or type object.
        * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
@@ -294,70 +292,6 @@ define([
         return v1 ? v1.toString() : "";
       },
 
-      // TODO: when called with more steps than the structure has, is throwing hard
-      /**
-       * Gets the value of a property/index/key path based on the current complex.
-       *
-       * When called with no arguments, or with an empty `steps` array argument,
-       * this complex value is returned.
-       *
-       * When a step, on a complex value, is not a defined property and `sloppy` is `true`,
-       * `undefined` is returned.
-       *
-       * Value `null` is returned when a step, in `steps`:
-       * 1. On a list value, is an element index that is out of range
-       * 2. On a list value, is an element key that is not present
-       * 3. On a complex value, a property has value `null`.
-       *
-       * This method supports two signatures.
-       * When the first argument is an array, it is the `steps` array,
-       * and the second argument is the optional `sloppy` argument:
-       * ```js
-       * var value;
-       *
-       * // Strict
-       * value = complex.path(["a", "b", 1]);
-       *
-       * // Sloppy
-       * value = complex.path(["a", "b", 1], true);
-       * ```
-       *
-       * Otherwise, the method behaves as if `sloppy` were `false`,
-       * and each argument is a step of the desired path:
-       * ```js
-       * var value;
-       *
-       * value = complex.path(); // -> null
-       *
-       * value = complex.path("a", "b", 1);
-       * ```
-       *
-       * @param {Array.<(string|number|!pentaho.type.Property.Type)>} steps - The property/index/key path steps.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {pentaho.type.Value|Nully} The requested value, or a {@link Nully} value.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a step, on a complex value,
-       * is not a defined property.
-       */
-      path: function(steps, sloppy) {
-        return Array.isArray(steps) ? this._path(steps, sloppy) : this._path(arguments, false);
-      },
-
-      _path: function(args, sloppy) {
-        var L = args.length;
-        var i = -1;
-        var v = this;
-        var step;
-
-        while(++i < L) {
-          if(!(v = (typeof (step = args[i]) === "number") ? v.at(step, sloppy) : v.get(step, sloppy)))
-            break;
-        }
-
-        return v;
-      },
-
       /**
        * Sets the value of a property.
        *
@@ -410,68 +344,6 @@ define([
       },
       // endregion
 
-      // region As Element
-      /**
-       * Gets the first element of the value of a property.
-       *
-       * This method returns the result of calling [Complex#at]{@link pentaho.type.Complex#at} with a `0` index.
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {pentaho.type.Element|Nully} An element or a {@link Nully} value.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-
-       * @see pentaho.type.Complex#firstv
-       * @see pentaho.type.Complex#firstf
-       */
-      first: function(name, sloppy) {
-        return this.at(name, 0, sloppy);
-      },
-
-      /**
-       * Gets the _primitive value_ of the first element of the value of a property.
-       *
-       * This method returns the result of calling [Complex#atv]{@link pentaho.type.Complex#atv} with a `0` index.
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {any|pentaho.type.Complex|Nully} The primitive value of the first element, or a {@link Nully} value.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-
-       * @see pentaho.type.Complex#first
-       * @see pentaho.type.Complex#firstf
-       */
-      firstv: function(name, sloppy) {
-        return this.atv(name, 0, sloppy);
-      },
-
-      /**
-       * Gets the _string representation_ of the first element of the value of a property.
-       *
-       * This method returns the result of calling [Complex#atf]{@link pentaho.type.Complex#atf} with a `0` index.
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {string} The string representation of the first element, or `""`.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-
-       * @see pentaho.type.Complex#first
-       * @see pentaho.type.Complex#firstv
-       */
-      firstf: function(name, sloppy) {
-        return this.atf(name, 0, sloppy);
-      },
-      // endregion
-
       // region As List
       /**
        * Gets the _number of values_ of a given property.
@@ -488,115 +360,12 @@ define([
        * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
        * name `name` is not defined.
        */
-      count: function(name, sloppy) {
+      countOf: function(name, sloppy) {
         var pType = this.type.get(name, sloppy);
         if(!pType) return 0;
 
         var value = this.__getByType(pType);
         return pType.isList ? value.count : (value ? 1 : 0);
-      },
-
-      /**
-       * Gets one `Element` of a property's value, given the property and the index of the element.
-       *
-       * If the specified property is not defined and `sloppy` is `true`, `undefined` is returned.
-       * If the specified index is out of range, `null` is returned.
-       *
-       * This method allows use of the same syntax for getting a single element from the value of a property,
-       * whether it is a list or an element property. If the property is an element property whose value
-       * is `null`, it is seen like a list property with no elements.
-       * If its value is not `null`, it is seen like a list property with one element.
-       * This behavior is consistent with that of the [count]{@link pentaho.type.Complex#count} property.
-       *
-       * @see pentaho.type.Property.Type#isList
-       * @see pentaho.type.Complex#path
-       * @see pentaho.type.Complex#atv
-       * @see pentaho.type.Complex#atf
-       * @see pentaho.type.Complex#count
-       * @see pentaho.type.Complex#first
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {number} index - The index of the desired element.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {pentaho.type.Element|Nully} A single `Element` value, or a {@link Nully} value.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-       */
-      at: function(name, index, sloppy) {
-        var pType = this.type.get(name, sloppy);
-
-        if(index == null) throw error.argRequired("index");
-
-        if(!pType) return undefined;
-
-        var value = this.__getByType(pType);
-
-        if(pType.isList) /* assert value */ return value.at(index || 0);
-
-        return value && !index ? value : null;
-      },
-
-      /**
-       * Gets the _primitive value_ of one element of the value of a property,
-       * given the property and the index of the element.
-       *
-       * This method reads the value of the property/index by calling [Complex#at]{@link pentaho.type.Complex#at}.
-       *
-       * When the latter does not return a {@link Nully} value,
-       * the result of the element's `valueOf()` method is returned.
-       *
-       * For a [Simple]{@link pentaho.type.Simple} type, this corresponds to returning
-       * its [value]{@link pentaho.type.Simple#value} attribute.
-       * For a [Complex]{@link pentaho.type.Complex} type, this corresponds to the value itself.
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {number} index - The index of the element.
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       *
-       * @return {any|pentaho.type.Complex|Nully} The primitive value of the requested element,
-       * or a {@link Nully} value.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-
-       * @see pentaho.type.Complex#at
-       * @see pentaho.type.Complex#atf
-       */
-      atv: function(name, index, sloppy) {
-        var v1 = this.at(name, index, sloppy); // undefined or nully
-        return v1 && v1.valueOf(); // .valueOf() should/must be non-nully
-      },
-
-      /**
-       * Gets the _string representation_ of one element of the value of a property,
-       * given the property and the index of the element.
-       *
-       * This method reads the value of the property/index by calling [Complex#at]{@link pentaho.type.Complex#at}.
-       *
-       * When the latter returns a {@link Nully} value, `""` is returned.
-       * Otherwise, the result of the element's `toString()` method is returned.
-       *
-       * For a [Simple]{@link pentaho.type.Simple} type, this corresponds to returning
-       * its [formatted]{@link pentaho.type.Simple#formatted} attribute, when it is not null.
-       * For a [Complex]{@link pentaho.type.Complex} type, this varies with the implementation.
-       *
-       * @param {string|!pentaho.type.Property.Type} name - The property name or type object.
-       * @param {number} index - The index of the value.
-       *
-       * @param {boolean} [sloppy=false] Indicates if an error is thrown if the specified property is not defined.
-       * @return {string} The string representation of the requested element, or `""`.
-       *
-       * @throws {pentaho.lang.ArgumentInvalidError} When `sloppy` is `false` and a property with
-       * name `name` is not defined.
-       *
-       * @see pentaho.type.Complex#at
-       * @see pentaho.type.Complex#atv
-       */
-      atf: function(name, index, sloppy) {
-        var v1 = this.at(name, index, sloppy);
-        return v1 ? v1.toString() : "";
       },
       // endregion
 
@@ -611,7 +380,7 @@ define([
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      isApplicable: function(name) {
+      isApplicableOf: function(name) {
         return this.type.get(name).isApplicableOn(this);
       },
       // endregion
@@ -626,7 +395,7 @@ define([
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      isEnabled: function(name) {
+      isEnabledOf: function(name) {
         return this.type.get(name).isEnabledOn(this);
       },
       // endregion
@@ -641,7 +410,7 @@ define([
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      countRange: function(name) {
+      countRangeOf: function(name) {
         return this.type.get(name).countRangeOn(this);
       },
       // endregion
@@ -651,7 +420,7 @@ define([
        * Gets a value that indicates if a given property is currently required.
        *
        * A property is currently required if
-       * its current {@link pentaho.type.Complex#countRange} minimum is at least 1.
+       * its current {@link pentaho.type.Complex#countRangeOf} minimum is at least 1.
        *
        * @param {string|pentaho.type.Property.Type} [name] The property name or type object.
        *
@@ -659,12 +428,12 @@ define([
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      isRequired: function(name) {
+      isRequiredOf: function(name) {
         return this.type.get(name).countRangeOn(this).min > 0;
       },
       // endregion
 
-      // region getPropDomain attribute
+      // region domainOf attribute
       /**
        * Gets the current list of valid values of a given property.
        *
@@ -674,7 +443,7 @@ define([
        *
        * @throws {pentaho.lang.ArgumentInvalidError} When a property with name `name` is not defined.
        */
-      getPropDomain: function(name) {
+      domainOf: function(name) {
         return this.type.get(name).domainOn(this);
       },
       // endregion

--- a/impl/client/src/main/javascript/web/pentaho/type/date.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/date.js
@@ -55,7 +55,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.type.Date.Type# */{
+      $type: /** @lends pentaho.type.Date.Type# */{
         id: module.id,
         alias: "date",
 
@@ -64,7 +64,7 @@ define([
         }
       }
     }).implement(/** @lends pentaho.type.Date# */{
-      type: bundle.structured["date"] // eslint-disable-line dot-notation
+      $type: bundle.structured["date"] // eslint-disable-line dot-notation
     });
 
     return PenDate;

--- a/impl/client/src/main/javascript/web/pentaho/type/element.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/element.js
@@ -165,7 +165,7 @@ define([
          */
         __intersect: function(elemsA, elemsB) {
           var elemsAByKey = {};
-          O.eachOwn(elemsA, function(elemA0) { elemsAByKey[elemA0.key] = elemA0; });
+          O.eachOwn(elemsA, function(elemA0) { elemsAByKey[elemA0.$key] = elemA0; });
 
           // Output order is that of `elemsB`.
           var isSimple = this.isSimple;
@@ -175,7 +175,7 @@ define([
           var countB = elemsB.length;
           while(++i < countB) {
             var elemB = elemsB[i];
-            var key = elemB.key;
+            var key = elemB.$key;
             var elemA = O.getOwn(elemsAByKey, key);
             if(elemA && !O.hasOwn(elemsCByKey, key)) {
               // The formatted value of elemB overrides that of elemA. Keep elemB if it has a formatted value.

--- a/impl/client/src/main/javascript/web/pentaho/type/element.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/element.js
@@ -65,7 +65,7 @@ define([
         return false;
       },
 
-      type: /** @lends pentaho.type.Element.Type# */{
+      $type: /** @lends pentaho.type.Element.Type# */{
 
         id: module.id,
         alias: "element",
@@ -189,7 +189,7 @@ define([
         }
       }
     }).implement({
-      type: bundle.structured.element
+      $type: bundle.structured.element
     });
 
     __elemType = Element.type;

--- a/impl/client/src/main/javascript/web/pentaho/type/function.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/function.js
@@ -84,7 +84,7 @@ define([
        * @type {string}
        * @readonly
        */
-      get key() {
+      get $key() {
         return this.__uid;
       },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/function.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/function.js
@@ -103,13 +103,13 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.type.Function.Type# */{
+      $type: /** @lends pentaho.type.Function.Type# */{
         id: module.id,
         alias: "function",
         cast: F.as
       }
     }).implement(/** @lends pentaho.type.Function# */{
-      type: bundle.structured["function"] // eslint-disable-line dot-notation
+      $type: bundle.structured["function"] // eslint-disable-line dot-notation
     });
 
     return PenFunction;

--- a/impl/client/src/main/javascript/web/pentaho/type/instance.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/instance.js
@@ -54,7 +54,7 @@ define([
      * [Foo.type]{@link pentaho.type.Instance.type}.
      *
      * Instances of the type `Foo` can also conveniently access the type's singleton object
-     * through the instance property [this.type]{@link pentaho.type.Instance#type}.
+     * through the instance property [this.$type]{@link pentaho.type.Instance#$type}.
      *
      * The instance and type classes of a type are closely bound and
      * must naturally reference each other.
@@ -75,12 +75,12 @@ define([
      *     constructor: function(label) {
      *       this.label = label;
      *     },
-     *     type: { // type specification
+     *     $type: { // type specification
      *       greeting: "Hello, ",
      *       veryLongString: "..."
      *     },
      *     saySomething: function() {
-     *       console.log(this.type.greeting + this.label + "!");
+     *       console.log(this.$type.greeting + this.label + "!");
      *     }
      *   });
      *
@@ -91,7 +91,7 @@ define([
      *   b.saySomething(); // "Hello, Bob!"
      *
      *   // All instances share the same _type_:
-     *   b.type.greeting ===  a.type.greeting // true
+     *   b.$type.greeting ===  a.$type.greeting // true
      * });
      *
      * @description Creates an instance of this type.
@@ -108,7 +108,7 @@ define([
       // Properties to ignore within extend
       extend_exclude: {_: 1},
 
-      // region type property
+      // region $type property
       __type: null, // Set on Type#_init
 
       /**
@@ -119,7 +119,7 @@ define([
        * @see pentaho.type.Instance.type
        * @see pentaho.type.Type#instance
        */
-      get type() {
+      get $type() {
         return this.__type;
       },
 
@@ -128,12 +128,12 @@ define([
       // Not documented on purpose, to avoid users trying to configure a type
       //  when they already have an instance of it, which is not supported...
       // However, this is the simplest and cleanest way to implement:
-      //   Instance.implement({type: {.}})
+      //   Instance.implement({$type: {.}})
       // to mean
       //   Type.implement({.}).instance.constructor
-      set type(config) {
+      set $type(config) {
         // Class.implement essentially just calls Class#extend.
-        if(config) this.type.extend(config);
+        if(config) this.__type.extend(config);
       }, // endregion
 
       // region serialization
@@ -215,13 +215,13 @@ define([
        * @readonly
        */
       get type() {
-        return this.prototype.type;
+        return this.prototype.$type;
       },
 
       // Supports Type class-level configuration only.
       // Not documented on purpose.
       // Allows writing;
-      //   Instance.implementStatic({type: .})
+      //   Instance.implementStatic({$type: .})
       // to mean:
       //   Type#implementStatic(.).instance.constructor
       set type(config) {
@@ -251,13 +251,13 @@ define([
        */
 
       /*
-       * Defaults `name` from `classSpec.type.sourceId` or `classSpec.type.id`, if any.
+       * Defaults `name` from `classSpec.$type.sourceId` or `classSpec.$type.id`, if any.
        *
        * @ignore
        */
       _extend: function(name, instSpec, classSpec, keyArgs) {
         var typeSpec;
-        if(name == null && (typeSpec = (instSpec && instSpec.type))) {
+        if(name == null && (typeSpec = (instSpec && instSpec.$type))) {
           name = typeSpec.sourceId || typeSpec.id || null;
           if(name) name = name.toString();
         }
@@ -281,11 +281,11 @@ define([
         var ka = keyArgs ? Object.create(keyArgs) : {};
         ka.instance = SubInstCtor.prototype;
 
-        this.Type.extend(typeName, instSpec && instSpec.type, classSpec && classSpec.type, ka);
+        this.Type.extend(typeName, instSpec && instSpec.$type, classSpec && classSpec.$type, ka);
 
-        // Don't process `instSpec.type` and `classSpec.type` twice, during construction.
+        // Don't process `instSpec.$type` and `classSpec.$type` twice, during construction.
         ka = keyArgs ? Object.create(keyArgs) : {};
-        (ka.exclude || (ka.exclude = {})).type = 1;
+        (ka.exclude || (ka.exclude = {})).$type = 1;
 
         this.base(SubInstCtor, instSpec, classSpec, ka);
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -111,7 +111,7 @@ define([
         var isBoundary = this.__isBoundary;
         var i = -1;
         var L = elemSpecs.length;
-        var elemType = this.type.of;
+        var elemType = this.$type.of;
         var elems = this.__elems;
         var keys  = this.__keys;
         var elem;
@@ -291,7 +291,7 @@ define([
        * Gets the element at a specified index, or `null`.
        *
        * @param {number} index - The desired index.
-       * @return {?pentaho.type.Element} The element value or `null`.
+       * @return {pentaho.type.Element} The element value or `null`.
        */
       at: function(index) {
         if(index == null) throw error.argRequired("index");
@@ -338,7 +338,7 @@ define([
        *
        * @param {string|any} key - The element's key.
        *
-       * @return {?pentaho.type.Element} The corresponding element or `null`.
+       * @return {pentaho.type.Element} The corresponding element or `null`.
        */
       get: function(key) {
         // jshint laxbreak:true
@@ -556,7 +556,7 @@ define([
        * @internal
        */
       __cast: function(valueSpec) {
-        return this.type.__elemType.to(valueSpec);
+        return this.$type.__elemType.to(valueSpec);
       },
 
       // region Core change methods
@@ -584,7 +584,7 @@ define([
         keyArgs = keyArgs ? Object.create(keyArgs) : {};
 
         // Capture now, before using it below for the elements.
-        var listType = this.type;
+        var listType = this.$type;
         var declaredType;
         var includeType = !!keyArgs.forceType || (!!(declaredType = keyArgs.declaredType) && listType !== declaredType);
 
@@ -614,7 +614,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.type.List.Type# */{
+      $type: /** @lends pentaho.type.List.Type# */{
 
         /** @inheritDoc */
         _postInit: function() {
@@ -764,7 +764,7 @@ define([
         this._cloneElementData(clone);
       },
 
-      type: bundle.structured.list
+      $type: bundle.structured.list
     });
 
     // override the documentation to specialize the argument types.

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -117,7 +117,7 @@ define([
         var elem;
         var key;
         while(++i < L) {
-          if((elem = elemType.to(elemSpecs[i])) != null && !O.hasOwn(keys, (key = elem.key))) {
+          if((elem = elemType.to(elemSpecs[i])) != null && !O.hasOwn(keys, (key = elem.$key))) {
             elems.push(elem);
             keys[key] = elem;
 
@@ -273,7 +273,7 @@ define([
        * @type {string}
        * @readonly
        */
-      get key() {
+      get $key() {
         return this.$uid;
       },
 
@@ -319,7 +319,7 @@ define([
        * @return {boolean} `true` if the element is present in the list; `false`, otherwise.
        */
       includes: function(elem) {
-        return elem != null && this.get(elem.key) === elem;
+        return elem != null && this.get(elem.$key) === elem;
       },
 
       /**
@@ -330,7 +330,7 @@ define([
        * @return {number} `true` if the element is present in the list; `false`, otherwise.
        */
       indexOf: function(elem) {
-        return elem && this.has(elem.key) ? this.__projectedMock.__elems.indexOf(elem) : -1;
+        return elem && this.has(elem.$key) ? this.__projectedMock.__elems.indexOf(elem) : -1;
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/type/list.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/list.js
@@ -126,7 +126,7 @@ define([
         }
       },
 
-      // region isReadOnly
+      // region $isReadOnly
       __isReadOnly: false,
 
       /**
@@ -135,14 +135,14 @@ define([
        * @type {boolean}
        * @readOnly
        */
-      get isReadOnly() {
+      get $isReadOnly() {
         return this.__isReadOnly;
       },
 
       /**
        * Asserts that the list can be changed, throwing an error if not.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        *
        * @private
        */
@@ -151,7 +151,7 @@ define([
       },
       // endregion
 
-      // region isBoundary
+      // region $isBoundary
       __isBoundary: false,
 
       /**
@@ -165,7 +165,7 @@ define([
        * @type {boolean}
        * @readOnly
        */
-      get isBoundary() {
+      get $isBoundary() {
         return this.__isBoundary;
       },
       // endregion
@@ -366,7 +366,7 @@ define([
        * When unspecified, new elements are appended to the list.
        * This argument is ignored when `noAdd` is `true`.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       set: function(fragment, keyArgs) {
 
@@ -387,7 +387,7 @@ define([
        *
        * @param {any|Array} fragment - Value or values to add.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       add: function(fragment) {
         this.__set(fragment, /* add: */true, /* update: */true, /* remove: */false, /* move: */false);
@@ -405,7 +405,7 @@ define([
        * @param {any|Array} fragment - Element or elements to add.
        * @param {number} index - The index at which to start inserting new elements.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       insert: function(fragment, index) {
         this.__set(fragment,
@@ -419,7 +419,7 @@ define([
        *
        * @param {any|Array} fragment - Element or elements to remove.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       remove: function(fragment) {
 
@@ -436,7 +436,7 @@ define([
        * @param {any} elemSpec - An element specification.
        * @param {number} indexNew - The new index of the element.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       move: function(elemSpec, indexNew) {
 
@@ -460,7 +460,7 @@ define([
        * @param {number} start - The index at which to start removing.
        * @param {number} [count=1] The number of elements to remove.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       removeAt: function(start, count) {
 
@@ -476,7 +476,7 @@ define([
        *
        * @param {function(pentaho.type.Element, pentaho.type.Element) : number} comparer - The comparer function.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       sort: function(comparer) {
 
@@ -490,7 +490,7 @@ define([
       /**
        * Removes all elements from the list.
        *
-       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#isReadOnly}.
+       * @throws {TypeError} When the list is [read-only]{@link pentaho.type.List#$isReadOnly}.
        */
       clear: function() {
 

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
@@ -204,8 +204,13 @@ define([
       return this.__cset;
     },
 
-    // TODO: Maybe remove
-    get hasChanges() {
+    /**
+     * Gets a value that indicates if this instance has any changes in the ambient transaction.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    get $hasChanges() {
       return !!this.__cset && this.__cset.hasChanges;
     },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
@@ -144,7 +144,7 @@ define([
      */
     get $references() {
       var cref;
-      var txn = this.type.context.transaction;
+      var txn = this.$type.context.transaction;
       return (txn && (cref = txn.__getChangeRef(this.__uid))) ? cref.projectedReferences : this.__refs;
     },
 
@@ -219,7 +219,7 @@ define([
       var cset = this.__cset;
       if(cset) return fun.call(this, cset);
 
-      var scope = this.type.context.enterChange();
+      var scope = this.$type.context.enterChange();
 
       return scope.using(function() {
 

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/Container.js
@@ -200,7 +200,7 @@ define([
      * @type {pentaho.type.changes.Changeset}
      * @readonly
      */
-    get changeset() {
+    get $changeset() {
       return this.__cset;
     },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
@@ -197,13 +197,13 @@ define([
           if(domain) {
             var domainByKey = {};
             domain.forEach(function(elem) {
-              domainByKey[elem.key] = elem;
+              domainByKey[elem.$key] = elem;
             });
 
             var propType = this;
 
             addValidator(function(owner, element) {
-              if(!O.hasOwn(domainByKey, element.key)) {
+              if(!O.hasOwn(domainByKey, element.$key)) {
                 return new ValidationError(
                     bundle.get("errors.discreteDomain.notInDomain", [element.toString(), propType.label]));
               }

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
@@ -61,7 +61,7 @@ define([
     var Instance = context.get("instance");
 
     return Instance.extend(/** @lends pentaho.type.mixins.DiscreteDomain# */{
-      type: /** @lends pentaho.type.mixins.DiscreteDomain.Type# */{
+      $type: /** @lends pentaho.type.mixins.DiscreteDomain.Type# */{
         id: module.id,
 
         dynamicAttributes: {

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/discreteDomain.js
@@ -135,7 +135,7 @@ define([
            * @type {undefined | Array.<pentaho.type.Element> |
            *        pentaho.type.PropertyDynamicAttribute.<Array.<pentaho.type.Element>>}
            *
-           * @see pentaho.type.Complex#getPropDomain
+           * @see pentaho.type.Complex#domainOf
            * @see pentaho.type.mixins.spec.IDiscreteDomainTypeProto#domain
            */
           "domain": {

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/enum.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/enum.js
@@ -117,7 +117,7 @@ define([
          */
         __validateDomain: function(value) {
           var domain = this.__domain;
-          return (!domain || domain.has(value.key))
+          return (!domain || domain.has(value.$key))
               ? null
               : new ValidationError(bundle.structured.errors.enum.notInDomain);
         },

--- a/impl/client/src/main/javascript/web/pentaho/type/mixins/enum.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/mixins/enum.js
@@ -68,7 +68,7 @@ define([
      *     var String = context.get("string");
      *
      *     return String.extend({
-     *       type: {
+     *       $type: {
      *         id: module.id,
      *         mixins: ["enum"],
      *         domain: [
@@ -86,7 +86,7 @@ define([
      */
     var Enum = Simple.extend(/** @lends pentaho.type.mixins.Enum# */{
 
-      type: /** @lends pentaho.type.mixins.Enum.Type# */{
+      $type: /** @lends pentaho.type.mixins.Enum.Type# */{
 
         id: module.id,
         alias: "enum",
@@ -128,7 +128,7 @@ define([
           this.base(spec, keyArgs);
 
           if(!keyArgs) keyArgs = {};
-          keyArgs.declaredType = this.type;
+          keyArgs.declaredType = this.$type;
           spec.domain = this.__domain.toSpecInContext(keyArgs);
 
           return true;
@@ -168,7 +168,7 @@ define([
           if(!this.__domain) {
             // List can only be configured (to allow for simple element's configuration of `formatted` field),
             // but is, for all other purposes, read-only.
-            var ListType = List.extend({type: {of: this}});
+            var ListType = List.extend({$type: {of: this}});
             this.__domain = new ListType(values, {isReadOnly: true});
             this.__domainPrimitive = this.__domain.toArray(function(v) { return v.value; });
 

--- a/impl/client/src/main/javascript/web/pentaho/type/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/model.js
@@ -69,7 +69,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.type.Model.Type# */{
+      $type: /** @lends pentaho.type.Model.Type# */{
         id: module.id,
         alias: "model",
 
@@ -96,7 +96,7 @@ define([
       }
     })
     .implement({
-      type: bundle.structured.model
+      $type: bundle.structured.model
     });
 
     return Model;

--- a/impl/client/src/main/javascript/web/pentaho/type/number.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/number.js
@@ -43,13 +43,13 @@ define([
        * @readonly
        */
 
-      type: /** @lends pentaho.type.Number.Type# */{
+      $type: /** @lends pentaho.type.Number.Type# */{
         id: module.id,
         alias: "number",
         cast: __toNumber
       }
     }).implement(/** @lends pentaho.type.Number# */{
-      type: bundle.structured["number"] // eslint-disable-line dot-notation
+      $type: bundle.structured["number"] // eslint-disable-line dot-notation
     });
 
     return PenNumber;

--- a/impl/client/src/main/javascript/web/pentaho/type/object.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/object.js
@@ -83,13 +83,13 @@ define([
        * @readonly
        */
 
-      type: /** @lends pentaho.type.Object.Type# */{
+      $type: /** @lends pentaho.type.Object.Type# */{
         id:   module.id,
         alias: "object",
         cast: Object
       }
     }).implement(/** @lends pentaho.type.Object# */{
-      type: bundle.structured["object"] // eslint-disable-line dot-notation
+      $type: bundle.structured["object"] // eslint-disable-line dot-notation
     });
 
     return PenObject;

--- a/impl/client/src/main/javascript/web/pentaho/type/object.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/object.js
@@ -72,7 +72,7 @@ define([
        * @type {string}
        * @readonly
        */
-      get key() {
+      get $key() {
         return this.__uid;
       },
 

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -649,7 +649,7 @@ define([
          * [declaring type]{@link pentaho.type.Property.Type#declaringType}.
          *
          * If the _value type_ is a [list]{@link pentaho.type.Value.Type#isList} type,
-         * then this property sets its lists as [boundary lists]{@link pentaho.type.List#isBoundary}.
+         * then this property sets its lists as [boundary lists]{@link pentaho.type.List#$isBoundary}.
          *
          * The validity of the object with a _boundary property_
          * is not affected by the validity of the property's value (or values).

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -1049,7 +1049,7 @@ define([
            * @throws {pentaho.lang.OperationInvalidError} When setting and the property already has
            * [descendant]{@link pentaho.type.Type#hasDescendants} properties.
            *
-           * @see pentaho.type.Complex#isRequired
+           * @see pentaho.type.Complex#isRequiredOf
            * @see pentaho.type.spec.IPropertyTypeProto#isRequired
            */
           isRequired: {
@@ -1135,7 +1135,7 @@ define([
            * @memberOf pentaho.type.Property.Type#
            * @type {undefined | number | pentaho.type.PropertyDynamicAttribute.<number>}
            *
-           * @see pentaho.type.Complex#countRange
+           * @see pentaho.type.Complex#countRangeOf
            *
            * @see pentaho.type.spec.IPropertyTypeProto#countMin
            */
@@ -1222,7 +1222,7 @@ define([
            * @memberOf pentaho.type.Property.Type#
            * @type {undefined | number | pentaho.type.PropertyDynamicAttribute.<number>}
            *
-           * @see pentaho.type.Complex#countRange
+           * @see pentaho.type.Complex#countRangeOf
            * @see pentaho.type.spec.IPropertyTypeProto#countMax
            */
           countMax: {
@@ -1301,7 +1301,7 @@ define([
            * @type {undefined | boolean | pentaho.type.PropertyDynamicAttribute.<boolean>}
            *
            * @see pentaho.type.Property.Type#isRequired
-           * @see pentaho.type.Complex#isApplicable
+           * @see pentaho.type.Complex#isApplicableOf
            * @see pentaho.type.spec.IPropertyTypeProto#isApplicable
            */
           isApplicable: {
@@ -1377,7 +1377,7 @@ define([
            * @memberOf pentaho.type.Property.Type#
            * @type {undefined | boolean | pentaho.type.PropertyDynamicAttribute.<boolean>}
            *
-           * @see pentaho.type.Complex#isEnabled
+           * @see pentaho.type.Complex#isEnabledOf
            * @see pentaho.type.spec.IPropertyTypeProto#isEnabled
            */
           isEnabled: {
@@ -1433,7 +1433,7 @@ define([
          *
          * @return {pentaho.IRange<number>} The evaluated element count range.
          *
-         * @see pentaho.type.Complex#countRange
+         * @see pentaho.type.Complex#countRangeOf
          */
         countRangeOn: function(owner) {
           var isRequired = this.isRequiredOn(owner);

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -82,7 +82,7 @@ define([
       // TODO: value, members?
       // TODO: p -> AnnotatableLinked.configure(this, config);
 
-      type: /** @lends pentaho.type.Property.Type# */{
+      $type: /** @lends pentaho.type.Property.Type# */{
         // Note: constructor/_init is only called on sub-classes of Property.Type,
         // and not on Property.Type itself.
 
@@ -959,7 +959,7 @@ define([
         // endregion
       }
     }, /** @lends pentaho.type.Property */{
-      type: /** @lends pentaho.type.Property.Type */{
+      $type: /** @lends pentaho.type.Property.Type */{
         /** @inheritDoc */
         _extend: function(name, instSpec, classSpec, keyArgs) {
 
@@ -972,7 +972,7 @@ define([
         }
       }
     }).implement({
-      type: /** @lends pentaho.type.Property.Type# */{
+      $type: /** @lends pentaho.type.Property.Type# */{
         dynamicAttributes: {
           /**
            * Evaluates the value of the `isRequired` attribute of a property of this type
@@ -1453,7 +1453,7 @@ define([
         }
       }
     }).implement({
-      type: /** @lends pentaho.type.Property.Type# */{
+      $type: /** @lends pentaho.type.Property.Type# */{
         // These are applied last so that mixins see any of the methods above as base implementations.
         mixins: [discreteDomainFactory]
       }

--- a/impl/client/src/main/javascript/web/pentaho/type/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/property.js
@@ -895,7 +895,7 @@ define([
             // Abstract Property classes don't have declaring type or `name`.
 
             // The default value type of abstract properties is value
-            if(valueTypeRef !== "value") spec.type = valueTypeRef;
+            if(valueTypeRef !== "value") spec.valueType = valueTypeRef;
 
             this._fillSpecInContext(spec, keyArgs);
           } else {
@@ -924,7 +924,7 @@ define([
 
             // The default value type of non-abstract properties is string
             if(valueTypeRef !== "string") {
-              spec.type = valueTypeRef;
+              spec.valueType = valueTypeRef;
               count++;
             }
 

--- a/impl/client/src/main/javascript/web/pentaho/type/simple.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/simple.js
@@ -110,7 +110,7 @@ define([
         // Value is immutable. Can only be set once.
 
         // Throws if nully.
-        _ = this.type.toValue(_);
+        _ = this.$type.toValue(_);
 
         if(this.__value == null) {
           // First set
@@ -295,7 +295,7 @@ define([
 
         var addFormatted = !keyArgs.omitFormatted && !!this.__formatted;
 
-        var type = this.type;
+        var type = this.$type;
 
         var declaredType = keyArgs.declaredType;
         var includeType = !!keyArgs.forceType;
@@ -364,7 +364,7 @@ define([
       },
       // endregion
 
-      type: /** pentaho.type.Simple.Type# */{
+      $type: /** pentaho.type.Simple.Type# */{
         id: module.id,
         alias: "simple",
         isAbstract: true,
@@ -542,7 +542,7 @@ define([
         // endregion
       }
     }).implement(/** @lends pentaho.type.Simple# */{
-      type: bundle.structured.simple
+      $type: bundle.structured.simple
     });
 
     // override the documentation to specialize the argument types.

--- a/impl/client/src/main/javascript/web/pentaho/type/simple.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/simple.js
@@ -196,7 +196,7 @@ define([
        * @type {string}
        * @readonly
        */
-      get key() {
+      get $key() {
         return this.__value.toString();
       },
 
@@ -205,7 +205,7 @@ define([
        *
        * The given value **must** be of the same concrete type (or the result is undefined).
        *
-       * If two values are equal, they must have an equal [key]{@link pentaho.type.Simple#key},
+       * If two values are equal, they must have an equal [key]{@link pentaho.type.Simple#$key},
        * [value]{@link pentaho.type.Simple#value}, [formatted value]{@link pentaho.type.Simple#formatted}.
        *
        * @param {!pentaho.type.Simple} other - A simple value to test for equality.

--- a/impl/client/src/main/javascript/web/pentaho/type/string.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/string.js
@@ -43,13 +43,13 @@ define([
        * @readonly
        */
 
-      type: {
+      $type: {
         id: module.id,
         alias: "string",
         cast: String
       }
     }).implement({
-      type: bundle.structured["string"] // eslint-disable-line dot-notation
+      $type: bundle.structured["string"] // eslint-disable-line dot-notation
     });
 
     return PenString;

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -83,7 +83,7 @@ define([
        * @see pentaho.type.Value#equals
        * @see pentaho.type.Value.Type#areEqual
        */
-      get key() {
+      get $key() {
         return this.toString();
       },
 
@@ -104,7 +104,7 @@ define([
        * @param {any} other - A value to test for equality.
        * @return {boolean} `true` if the given value is equal to this one; or, `false`, otherwise.
        *
-       * @see pentaho.type.Value#key
+       * @see pentaho.type.Value#$key
        * @see pentaho.type.Value.Type#areEqual
        * @final
        */
@@ -264,9 +264,9 @@ define([
          * Two values are considered equal if they represent the same real-world entity.
          *
          * If two values are considered equal,
-         * their value instances must have an equal [key]{@link pentaho.type.Value#key}.
+         * their value instances must have an equal [key]{@link pentaho.type.Value#$key}.
          * Conversely, if they are considered different,
-         * their value instances must have a different `key`.
+         * their value instances must have a different `$key`.
          *
          * If the values are identical as per JavaScript's `===` operator, `true` is returned.
          * If both values are {@link Nully}, `true` is returned.
@@ -278,7 +278,7 @@ define([
          *
          * @return {boolean} `true` if two values are considered equal; `false`, otherwise.
          *
-         * @see pentaho.type.Value#key
+         * @see pentaho.type.Value#$key
          * @see pentaho.type.Value.Type#_areEqual
          * @see pentaho.type.Value.Type#_isEqual
          */
@@ -324,7 +324,7 @@ define([
          * @see pentaho.type.Value.Type#areEqual
          */
         _isEqual: function(va, vb) {
-          return (va.constructor === vb.constructor) && (va.key === vb.key);
+          return (va.constructor === vb.constructor) && (va.$key === vb.$key);
         },
         // endregion
 

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -124,7 +124,7 @@ define([
        * @readonly
        * @final
        */
-      get isValid() {
+      get $isValid() {
         return !this.validate();
       },
 
@@ -135,7 +135,7 @@ define([
        *
        * @return {Array.<pentaho.type.ValidationError>} A non-empty array of errors or `null`.
        *
-       * @see pentaho.type.Value#isValid
+       * @see pentaho.type.Value#$isValid
        * @final
        */
       validate: function() {

--- a/impl/client/src/main/javascript/web/pentaho/type/value.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/value.js
@@ -109,7 +109,7 @@ define([
        * @final
        */
       equals: function(other) {
-        return this === other || (other != null && this.type._isEqual(this, other));
+        return this === other || (other != null && this.$type._isEqual(this, other));
       },
 
       // region validation
@@ -139,7 +139,7 @@ define([
        * @final
        */
       validate: function() {
-        return this.type.validate(this);
+        return this.$type.validate(this);
       },
 
       /**
@@ -247,7 +247,7 @@ define([
        * @type pentaho.type.Value.Type
        * @readonly
        */
-      type: /** @lends pentaho.type.Value.Type# */{
+      $type: /** @lends pentaho.type.Value.Type# */{
         id: module.id,
         alias: "value",
         isAbstract: true,
@@ -302,8 +302,8 @@ define([
          * @see pentaho.type.Value.Type#areEqual
          */
         _areEqual: function(va, vb) {
-          return (va instanceof Value) ? va.type._isEqual(va, vb) :
-                 (vb instanceof Value) ? vb.type._isEqual(vb, va) :
+          return (va instanceof Value) ? va.$type._isEqual(va, vb) :
+                 (vb instanceof Value) ? vb.$type._isEqual(vb, va) :
                  false;
         },
 
@@ -372,7 +372,7 @@ define([
           if(!this.is(value))
             return [new ValidationError(bundle.format(bundle.structured.errors.value.notOfType, [this.label]))];
 
-          return value.type._validate(value);
+          return value.$type._validate(value);
         },
 
         /**
@@ -380,7 +380,7 @@ define([
          * that **is an instance of this type**,
          * is also a **valid instance** of this type.
          *
-         * Thus, `this === value.type` must be true.
+         * Thus, `this === value.$type` must be true.
          *
          * The default implementation does nothing and considers the instance valid.
          * Override to implement a type's specific validation logic.
@@ -398,7 +398,7 @@ define([
          */
         _validate: function(value) {
 
-          // assert this === value.type
+          // assert this === value.$type
 
           return null;
         },
@@ -427,7 +427,7 @@ define([
     }, /* classDesc: */{}, /* keyArgs: */{
       isRoot: true
     }).implement({
-      type: bundle.structured.value
+      $type: bundle.structured.value
     });
 
     // override the documentation to specialize the argument types.

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/base.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/base.js
@@ -39,7 +39,7 @@ define([
     var __ActionBase = context.get(baseActionFactory);
 
     return __ActionBase.extend(/** @lends pentaho.visual.action.Base# */{
-      type: /** @lends pentaho.visual.action.Base.Type# */{
+      $type: /** @lends pentaho.visual.action.Base.Type# */{
         id: module.id,
         isAbstract: true
       },

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/data.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/data.js
@@ -41,7 +41,7 @@ define([
     var ActionBase = context.get(baseActionFactory);
 
     return ActionBase.extend(/** @lends pentaho.visual.action.Data# */{
-      type: /** @lends pentaho.visual.action.Data.Type# */{
+      $type: /** @lends pentaho.visual.action.Data.Type# */{
         id: module.id,
         isAbstract: true
       },

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/execute.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/execute.js
@@ -50,7 +50,7 @@ define([
      * when calling [on]{@link pentaho.lang,IEventSource#on} of action targets.
      */
     return DataAction.extend(/** @lends  pentaho.visual.action.Execute# */{
-      type: {
+      $type: {
         id: module.id,
         alias: "execute"
       }

--- a/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/action/select.js
@@ -43,7 +43,7 @@ define([
     var DataAction = context.get(dataActionFactory);
 
     return DataAction.extend(/** @lends pentaho.visual.action.Select# */{
-      type: /** @lends pentaho.visual.action.Select.Type# */{
+      $type: /** @lends pentaho.visual.action.Select.Type# */{
         id: module.id,
         alias: "select",
 
@@ -155,7 +155,7 @@ define([
       get selectionMode() {
 
         var fun = this.__selectionMode;
-        return fun ? fun.valueOf() : this.type.defaultSelectionMode;
+        return fun ? fun.valueOf() : this.$type.defaultSelectionMode;
       },
 
       set selectionMode(value) {

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/application.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/application.js
@@ -50,12 +50,12 @@ define([
      * @param {pentaho.visual.base.spec.IApplication} [spec] A visual application specification.
      */
     var VisualApplication = Application.extend(/** @lends pentaho.visual.base.Application# */{
-      type: /** @lends pentaho.visual.base.Application.Type# */{
+      $type: /** @lends pentaho.visual.base.Application.Type# */{
         id: module.id
       }
     })
     .implement({
-      type: bundle.structured.application.type
+      $type: bundle.structured.application.type
     });
 
     return VisualApplication;

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/model.js
@@ -74,7 +74,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.visual.base.Model.Type# */{
+      $type: /** @lends pentaho.visual.base.Model.Type# */{
         sourceId: module.id,
         id: module.id.replace(/.\w+$/, ""),
         defaultView: "./view",
@@ -148,7 +148,7 @@ define([
         }
       }
     })
-    .implement({type: bundle.structured.type});
+    .implement({$type: bundle.structured.type});
 
     return VisualModel;
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
@@ -868,7 +868,7 @@ define([
 
       // region Actions
       __emitActionPhase: function(action, phase, isFinal) {
-        var eventType = action.type.id;
+        var eventType = action.$type.id;
 
         // TODO: emitGenericAsync when action is async.
 
@@ -1008,7 +1008,7 @@ define([
       },
       // endregion
 
-      type: /** @lends pentaho.visual.base.View.Type# */{
+      $type: /** @lends pentaho.visual.base.View.Type# */{
         id: module.id,
         isAbstract: true,
         props: [
@@ -1272,8 +1272,6 @@ define([
 
         if(!modelType) return Promise.reject(error.argRequired("modelType"));
 
-        var context = this.type.context;
-
         return context
             .getAsync(modelType)
             .then(function(Model) {
@@ -1486,7 +1484,7 @@ define([
        */
       // endregion
     })
-    .implement({type: bundle.structured.type});
+    .implement({$type: bundle.structured.type});
 
     return View;
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/abstract.js
@@ -38,7 +38,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
 
         isAbstract: true,
@@ -156,6 +156,6 @@ define([
 
     })
     /* eslint dot-notation:0 */
-    .implement({type: bundle.structured["abstract"]});
+    .implement({$type: bundle.structured["abstract"]});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/areaStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/areaStacked.js
@@ -26,13 +26,13 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_area",
         category: "areachart",
         defaultView: "pentaho/ccc/visual/areaStacked"
       }
     })
-    .implement({type: bundle.structured.areaStacked});
+    .implement({$type: bundle.structured.areaStacked});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/bar.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/bar.js
@@ -28,7 +28,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [trendedFactory],
 
@@ -52,6 +52,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.bar});
+    .implement({$type: bundle.structured.bar});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barAbstract.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [multiChartedFactory],
         isAbstract: true,
@@ -39,6 +39,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.barAbstract});
+    .implement({$type: bundle.structured.barAbstract});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barHorizontal.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_horzbar",
         category: "horzbarchart",
@@ -50,6 +50,6 @@ define([
       }
 
     })
-    .implement({type: bundle.structured.barHorizontal});
+    .implement({$type: bundle.structured.barHorizontal});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barLine.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barLine.js
@@ -32,7 +32,7 @@ define([
 
     return BaseModel.extend({
 
-      type: {
+      $type: {
         id: module.id,
         mixins: [interpolatedFactory],
 
@@ -89,7 +89,7 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.barLine});
+    .implement({$type: bundle.structured.barLine});
   };
 
   function __requiredOneMeasure() {

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalized.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalized.js
@@ -26,7 +26,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_barnormalized",
         category: "barchart",
@@ -34,6 +34,6 @@ define([
         defaultView: "pentaho/ccc/visual/barNormalized"
       }
     })
-    .implement({type: bundle.structured.barNormalized});
+    .implement({$type: bundle.structured.barNormalized});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalizedAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalizedAbstract.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
 
@@ -47,6 +47,6 @@ define([
       }
 
     })
-    .implement({type: bundle.structured.barNormalizedAbstract});
+    .implement({$type: bundle.structured.barNormalizedAbstract});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalizedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barNormalizedHorizontal.js
@@ -26,7 +26,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_horzbarnormalized",
         category: "horzbarchart",
@@ -34,6 +34,6 @@ define([
         defaultView: "pentaho/ccc/visual/barNormalizedHorizontal"
       }
     })
-    .implement({type: bundle.structured.barNormalizedHorizontal});
+    .implement({$type: bundle.structured.barNormalizedHorizontal});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barStacked.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_barstacked",
         category: "barchart",
@@ -49,6 +49,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.barStacked});
+    .implement({$type: bundle.structured.barStacked});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/barStackedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/barStackedHorizontal.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         v2Id: "ccc_horzbarstacked",
         category: "horzbarchart",
@@ -49,6 +49,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.barStackedHorizontal});
+    .implement({$type: bundle.structured.barStackedHorizontal});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/bubble.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/bubble.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [scaleSizeContinuousFactory],
 
@@ -46,6 +46,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.bubble});
+    .implement({$type: bundle.structured.bubble});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/cartesianAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/cartesianAbstract.js
@@ -27,7 +27,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
 
@@ -56,6 +56,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.cartesianAbstract});
+    .implement({$type: bundle.structured.cartesianAbstract});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/categoricalContinuousAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/categoricalContinuousAbstract.js
@@ -26,7 +26,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
 
@@ -53,6 +53,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.categoricalContinuousAbstract});
+    .implement({$type: bundle.structured.categoricalContinuousAbstract});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/donut.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/donut.js
@@ -26,11 +26,11 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         defaultView: "pentaho/ccc/visual/donut"
       }
     })
-    .implement({type: bundle.structured.donut});
+    .implement({$type: bundle.structured.donut});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/heatGrid.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/heatGrid.js
@@ -31,7 +31,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [scaleColorContinuousFactory, scaleSizeContinuousFactory],
 
@@ -86,7 +86,7 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.heatGrid});
+    .implement({$type: bundle.structured.heatGrid});
   };
 
   function requiredOneMeasure() {

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/line.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/line.js
@@ -29,7 +29,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [trendedFactory],
 
@@ -52,6 +52,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.line});
+    .implement({$type: bundle.structured.line});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/metricPointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/metricPointAbstract.js
@@ -33,7 +33,7 @@ define([
     var MeasurementLevel = context.get(measurementLevelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         // TODO: scaleColor... should only be applicable when color is continuous
@@ -106,6 +106,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.metricDot});
+    .implement({$type: bundle.structured.metricDot});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/interpolated.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/interpolated.js
@@ -29,7 +29,7 @@ define([
     var BaseModel = context.get(modelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         props: [
@@ -42,6 +42,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.interpolation});
+    .implement({$type: bundle.structured.interpolation});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/multiCharted.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/multiCharted.js
@@ -33,7 +33,7 @@ define([
     var BaseModel = context.get(modelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         props: [
@@ -58,6 +58,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.settingsMultiChart});
+    .implement({$type: bundle.structured.settingsMultiChart});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleColorContinuous.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleColorContinuous.js
@@ -32,7 +32,7 @@ define([
     var MeasurementLevel = context.get(measurementLevelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         props: [
@@ -60,12 +60,12 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.scaleColorContinuous});
+    .implement({$type: bundle.structured.scaleColorContinuous});
 
     function __hasQuantitativeAttributesColor() {
       if(!this.color.isMapped) return false;
 
-      var rolePropType = this.type.get("color");
+      var rolePropType = this.$type.get("color");
       var level = rolePropType.levelEffectiveOn(this);
 
       return MeasurementLevel.type.isQuantitative(level);

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleSizeContinuous.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleSizeContinuous.js
@@ -35,7 +35,7 @@ define([
           {
             name: "sizeByNegativesMode",
             valueType: sizeByNegativesModeFactory,
-            isApplicable: function() { return this.count("size") > 0; },
+            isApplicable: function() { return this.countOf("size") > 0; },
             isRequired: true,
             defaultValue: "negLowest"
           }

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleSizeContinuous.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/scaleSizeContinuous.js
@@ -28,7 +28,7 @@ define([
     var BaseModel = context.get(modelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         props: [
@@ -42,6 +42,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.scaleSizeContinuous});
+    .implement({$type: bundle.structured.scaleSizeContinuous});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/trended.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/mixins/trended.js
@@ -30,7 +30,7 @@ define([
     var BaseModel = context.get(modelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         props: [
@@ -55,7 +55,7 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.trend});
+    .implement({$type: bundle.structured.trend});
   };
 
   function __isApplicableTrend() {

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/pie.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/pie.js
@@ -28,7 +28,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [multiChartedFactory],
 
@@ -66,6 +66,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.pie});
+    .implement({$type: bundle.structured.pie});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/pointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/pointAbstract.js
@@ -29,7 +29,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         isAbstract: true,
         mixins: [interpolatedFactory, multiChartedFactory],
@@ -76,6 +76,6 @@ define([
       }
 
     })
-    .implement({type: bundle.structured.pointAbstract});
+    .implement({$type: bundle.structured.pointAbstract});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/scatter.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/scatter.js
@@ -26,11 +26,11 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         defaultView: "pentaho/ccc/visual/scatter"
       }
     })
-    .implement({type: bundle.structured.scatter});
+    .implement({$type: bundle.structured.scatter});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/sunburst.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/sunburst.js
@@ -31,7 +31,7 @@ define([
     var BaseModel = context.get(baseModelFactory);
 
     return BaseModel.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: [multiChartedFactory],
         v2Id: "ccc_sunburst",
@@ -88,7 +88,7 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.sunburst});
+    .implement({$type: bundle.structured.sunburst});
   };
 
   function __isSizeMapped() {

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/backgroundFill.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/backgroundFill.js
@@ -26,12 +26,12 @@ define([
 
     return PentahoString.extend({
 
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["none", "solid", "gradient"]
       }
     })
-    .implement({type: bundle.structured.backgroundFill});
+    .implement({$type: bundle.structured.backgroundFill});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/color.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/color.js
@@ -22,7 +22,7 @@ define(["module"], function(module) {
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id
       }
     });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/colorSet.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/colorSet.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["ryg", "ryb", "blue", "gray"]
       }
     })
-    .implement({type: bundle.structured.colorSet});
+    .implement({$type: bundle.structured.colorSet});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/displayUnits.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/displayUnits.js
@@ -25,7 +25,7 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["units_0", "units_2", "units_3", "units_4", "units_5", "units_6"],
@@ -47,6 +47,6 @@ define([
         }
       }
     })
-    .implement({type: bundle.structured.displayUnits});
+    .implement({$type: bundle.structured.displayUnits});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/emptyCellMode.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/emptyCellMode.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["gap", "linear", "zero"]
       }
     })
-    .implement({type: bundle.structured.emptyCellMode});
+    .implement({$type: bundle.structured.emptyCellMode});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/fontStyle.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/fontStyle.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["plain", "bold", "italic"]
       }
     })
-    .implement({type: bundle.structured.fontStyle});
+    .implement({$type: bundle.structured.fontStyle});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/labelsOption.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/labelsOption.js
@@ -25,7 +25,7 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: [
@@ -38,6 +38,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.labelsOption});
+    .implement({$type: bundle.structured.labelsOption});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/lineWidth.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/lineWidth.js
@@ -25,12 +25,12 @@ define([
     var PentahoNumber = context.get("number");
 
     return PentahoNumber.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: [1, 2, 3, 4, 5, 6, 7, 8]
       }
     })
-    .implement({type: bundle.structured.lineWidth});
+    .implement({$type: bundle.structured.lineWidth});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/maxChartsPerRow.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/maxChartsPerRow.js
@@ -25,12 +25,12 @@ define([
     var PentahoNumber = context.get("number");
 
     return PentahoNumber.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: [1, 2, 3, 4, 5]
       }
     })
-    .implement({type: bundle.structured.maxChartsPerRow});
+    .implement({$type: bundle.structured.maxChartsPerRow});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/multiChartOverflow.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/multiChartOverflow.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["grow", "fit", "clip"]
       }
     })
-    .implement({type: bundle.structured.multiChartOverflow});
+    .implement({$type: bundle.structured.multiChartOverflow});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/multiChartRangeScope.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/multiChartRangeScope.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["global", "cell"]
       }
     })
-    .implement({type: bundle.structured.multiChartRangeScope});
+    .implement({$type: bundle.structured.multiChartRangeScope});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/pattern.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/pattern.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["gradient", "3_color", "5_color"]
       }
     })
-    .implement({type: bundle.structured.pattern});
+    .implement({$type: bundle.structured.pattern});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/shape.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/shape.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["none", "circle", "cross", "diamond", "square", "triangle"]
       }
     })
-    .implement({type: bundle.structured.shape});
+    .implement({$type: bundle.structured.shape});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/sides.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/sides.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["top", "right", "bottom", "left"]
       }
     })
-    .implement({type: bundle.structured.sides});
+    .implement({$type: bundle.structured.sides});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/sizeByNegativesMode.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/sizeByNegativesMode.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["negLowest", "useAbs"]
       }
     })
-    .implement({type: bundle.structured.sizeByNegativesMode});
+    .implement({$type: bundle.structured.sizeByNegativesMode});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/sliceOrder.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/sliceOrder.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type:  {
+      $type:  {
         id: module.id,
         mixins: ["enum"],
         domain: ["bySizeDescending", "bySizeAscending", "none"]
       }
     })
-    .implement({type: bundle.structured.sliceOrder});
+    .implement({$type: bundle.structured.sliceOrder});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/types/trendType.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/types/trendType.js
@@ -25,12 +25,12 @@ define([
     var PentahoString = context.get("string");
 
     return PentahoString.extend({
-      type:  {
+      $type:  {
         id: module.id,
         mixins: ["enum"],
         domain: ["none", "linear"]
       }
     })
-    .implement({type: bundle.structured.trendType});
+    .implement({$type: bundle.structured.trendType});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/aggregation.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/aggregation.js
@@ -44,12 +44,12 @@ define([
      * * `mode` - Mode (applicable to any type)
      */
     return PentahoString.extend({
-      type: {
+      $type: {
         id: module.id,
         mixins: ["enum"],
         domain: ["sum", "avg", "min", "max", "first", "last"]
       }
     })
-    .implement({type: bundle.structured.aggregation});
+    .implement({$type: bundle.structured.aggregation});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/level.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/level.js
@@ -88,7 +88,7 @@ define([
 
     var Level = PentahoString.extend({
 
-      type: /** @lends pentaho.visual.role.MeasurementLevel.Type# */{
+      $type: /** @lends pentaho.visual.role.MeasurementLevel.Type# */{
 
         id: module.id,
         mixins: ["enum"],
@@ -147,7 +147,7 @@ define([
         }
       }
     })
-    .implement({type: bundle.structured.level});
+    .implement({$type: bundle.structured.level});
 
     return Level;
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/mapping.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/mapping.js
@@ -81,7 +81,7 @@ define([
         return this.attributes.count > 0;
       },
 
-      type: /** @lends pentaho.visual.role.Mapping.Type# */{
+      $type: /** @lends pentaho.visual.role.Mapping.Type# */{
         id: module.id,
 
         props: [
@@ -114,7 +114,7 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.mapping});
+    .implement({$type: bundle.structured.mapping});
 
     return VisualRoleMapping;
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/mappingAttribute.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/mappingAttribute.js
@@ -137,7 +137,7 @@ define([
        */
       get keyQualitative() {
         var name = this.get("name");
-        return name ? name.key : "";
+        return name ? name.$key : "";
       },
 
       /**
@@ -153,7 +153,7 @@ define([
        */
       get keyQuantitative() {
         var aggregation = this.get("aggregation");
-        return this.keyQualitative + "|" + (aggregation ? aggregation.key : "");
+        return this.keyQualitative + "|" + (aggregation ? aggregation.$key : "");
       },
 
       type: {

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/mappingAttribute.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/mappingAttribute.js
@@ -156,7 +156,7 @@ define([
         return this.keyQualitative + "|" + (aggregation ? aggregation.$key : "");
       },
 
-      type: {
+      $type: {
         id: module.id,
 
         props: [
@@ -200,6 +200,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.mappingAttribute});
+    .implement({$type: bundle.structured.mappingAttribute});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/property.js
@@ -790,7 +790,7 @@ define([
           if(level) {
             // Fixed level.
             // Must be one of the role's levels.
-            if(!allRoleLevels.has(level.key)) {
+            if(!allRoleLevels.has(level.$key)) {
               addErrors(new ValidationError(bundle.format(
                 bundle.structured.errors.property.levelIsNotOneOfRoleLevels,
                 {

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/property.js
@@ -71,7 +71,7 @@ define([
      */
     var VisualRoleProperty = __Property.extend(/** @lends pentaho.visual.role.Property# */{
 
-      type: /** @lends pentaho.visual.role.Property.Type# */{
+      $type: /** @lends pentaho.visual.role.Property.Type# */{
 
         id: module.id,
 
@@ -456,7 +456,7 @@ define([
         // endregion
       }
     }).implement({
-      type: /** @lends pentaho.visual.role.Property.Type# */{
+      $type: /** @lends pentaho.visual.role.Property.Type# */{
         /**
          * Determines the level of measurement on which this visual role will effectively be operating,
          * on the given visualization model, according to the mapping's current state.
@@ -739,7 +739,7 @@ define([
             if(count < range.min) {
               addErrors(new ValidationError(
                   bundleTypes.get("errors.property.countOutOfRange", [
-                    this.label + " " + mapping.type.get("attributes").label,
+                    this.label + " " + mapping.$type.get("attributes").label,
                     count,
                     range.min,
                     range.max
@@ -748,7 +748,7 @@ define([
             } else if(count > range.max) {
               addErrors(new ValidationError(
                   bundleTypes.get("errors.property.countOutOfRange", [
-                    this.label + " " + mapping.type.get("attributes").label,
+                    this.label + " " + mapping.$type.get("attributes").label,
                     count,
                     range.min,
                     range.max
@@ -967,7 +967,7 @@ define([
         // endregion
       }
     })
-    .implement({type: bundle.structured.property});
+    .implement({$type: bundle.structured.property});
 
     return VisualRoleProperty;
   };

--- a/impl/client/src/main/javascript/web/pentaho/visual/samples/calc/model.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/samples/calc/model.js
@@ -35,7 +35,7 @@ define([
      * @amd {pentaho.type.Factory<pentaho.visual.samples.calc.Model>} pentaho/visual/samples/calc
      */
     return BaseModel.extend({
-      type: {
+      $type: {
         sourceId: module.id,
         id: module.id.replace(/.\w+$/, ""),
         v2Id: "sample_calc",
@@ -68,6 +68,6 @@ define([
         ]
       }
     })
-    .implement({type: bundle.structured.type});
+    .implement({$type: bundle.structured.type});
   };
 });

--- a/impl/client/src/main/javascript/web/pentaho/visual/samples/calc/view.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/samples/calc/view.js
@@ -39,7 +39,7 @@ define([
     var BaseView = context.get(baseViewFactory);
 
     return BaseView.extend(/** @lends pentaho.visual.samples.calc.View# */{
-      type: {
+      $type: {
         id: module.id,
         props: {
           model: {valueType: modelFactory}

--- a/impl/client/src/test/config/javascript/require.config.js
+++ b/impl/client/src/test/config/javascript/require.config.js
@@ -95,7 +95,7 @@
   requireTypeInfo["pentaho/visual/base/view"] = {
     base: "complex",
     props: {
-      model: {type: "pentaho/visual/base"}
+      model: {valueType: "pentaho/visual/base"}
     }
   };
 

--- a/impl/client/src/test/javascript/pentaho/data/Table.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/Table.spec.js
@@ -358,7 +358,7 @@ define([
           var filter = new CustomFilter();
 
           spyOn(filter, "_contains").and.callFake(function(elem) {
-            return elem.type.has("sales") && elem.getv("sales") === 12000;
+            return elem.$type.has("sales") && elem.getv("sales") === 12000;
           });
 
           var view = data.filter(filter);

--- a/impl/client/src/test/javascript/pentaho/data/filter/and.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/and.spec.js
@@ -37,7 +37,7 @@ define([
     var CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/false.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/false.spec.js
@@ -32,7 +32,7 @@ define([
     var Complex = context.get(complexFactory);
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/isEqual.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/isEqual.spec.js
@@ -30,7 +30,7 @@ define([
     var Complex = context.get(complexFactory);
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/isIn.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/isIn.spec.js
@@ -30,7 +30,7 @@ define([
     var Complex = context.get(complexFactory);
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/not.spec.js
@@ -34,7 +34,7 @@ define([
     var CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/or.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/or.spec.js
@@ -37,7 +37,7 @@ define([
     var CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/data/filter/true.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/true.spec.js
@@ -32,7 +32,7 @@ define([
     var Complex = context.get(complexFactory);
 
     var ProductSummary = Complex.extend({
-      type: {
+      $type: {
         props: [
           {name: "name", valueType: "string", label: "Name"},
           {name: "sales", valueType: "number", label: "Sales"},

--- a/impl/client/src/test/javascript/pentaho/type/Context.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/Context.spec.js
@@ -330,7 +330,7 @@ define([
             localRequire.define(mid, [], function() {
               return function(context) {
                 var Simple = context.get("pentaho/type/simple");
-                return Simple.extend({type: {id: mid}});
+                return Simple.extend({$type: {id: mid}});
               };
             });
 
@@ -356,7 +356,7 @@ define([
               return function(context) {
                 var Simple = context.get("pentaho/type/simple");
                 return Simple.extend({
-                  type: {
+                  $type: {
                     id: mid
                   }
                 });
@@ -392,7 +392,7 @@ define([
               return function(context) {
                 var Simple = context.get("pentaho/type/simple");
                 return Simple.extend({
-                  type: {
+                  $type: {
                     id: mid,
                     alias: "XYZ"
                   }
@@ -481,7 +481,7 @@ define([
             var context = new Context();
             var Value = context.get("pentaho/type/value");
             var Value2 = Value.extend({
-              type: {
+              $type: {
                 id: "tests/foo/bar"
               }
             });
@@ -527,7 +527,7 @@ define([
 
             var Value = context.get("pentaho/type/value");
             var Value2 = Value.extend({
-              type: {
+              $type: {
                 id: "tests/foo/bar"
               }
             });
@@ -568,7 +568,7 @@ define([
 
             var Value = context.get("pentaho/type/value");
             var Value2 = Value.extend({
-              type: {
+              $type: {
                 id: "tests/foo/bar"
               }
             });
@@ -1034,7 +1034,7 @@ define([
           function defineTempModule(mid) {
             localRequire.define(mid, [], function() {
               return function(context) {
-                return context.get("pentaho/type/simple").extend({type: {id: mid}});
+                return context.get("pentaho/type/simple").extend({$type: {id: mid}});
               };
             });
           }
@@ -1042,7 +1042,7 @@ define([
           function defineTempMixin(mid) {
             localRequire.define(mid, [], function() {
               return function(context) {
-                return context.get("pentaho/type/value").extend({type: {id: mid}});
+                return context.get("pentaho/type/value").extend({$type: {id: mid}});
               };
             });
           }
@@ -1050,7 +1050,7 @@ define([
           function defineTempProp(mid) {
             localRequire.define(mid, [], function() {
               return function(context) {
-                return context.get("pentaho/type/property").extend({type: {id: mid}});
+                return context.get("pentaho/type/property").extend({$type: {id: mid}});
               };
             });
           }
@@ -1465,7 +1465,7 @@ define([
 
         localRequire.define("exp/baseWithNoRegistrations", ["pentaho/type/simple"], function(simpleFactory) {
           return function(context) {
-            return context.get(simpleFactory).extend({type: {id: "exp/baseWithNoRegistrations"}});
+            return context.get(simpleFactory).extend({$type: {id: "exp/baseWithNoRegistrations"}});
           };
         });
 
@@ -1473,13 +1473,13 @@ define([
 
         localRequire.define("exp/thing", ["pentaho/type/simple"], function(simpleFactory) {
           return function(context) {
-            return context.get(simpleFactory).extend({type: {id: "exp/thing"}});
+            return context.get(simpleFactory).extend({$type: {id: "exp/thing"}});
           };
         });
 
         localRequire.define("exp/foo", ["exp/thing"], function(thingFactory) {
           return function(context) {
-            return context.get(thingFactory).extend({type: {id: "exp/foo"}});
+            return context.get(thingFactory).extend({$type: {id: "exp/foo"}});
           };
         });
 
@@ -1487,7 +1487,7 @@ define([
 
         localRequire.define("exp/bar", ["exp/thing"], function(thingFactory) {
           return function(context) {
-            return context.get(thingFactory).extend({type: {id: "exp/bar", isBrowsable: false}});
+            return context.get(thingFactory).extend({$type: {id: "exp/bar", isBrowsable: false}});
           };
         });
 
@@ -1495,7 +1495,7 @@ define([
 
         localRequire.define("exp/dude", ["pentaho/type/simple"], function(simpleFactory) {
           return function(context) {
-            return context.get(simpleFactory).extend({type: {id: "exp/dude"}});
+            return context.get(simpleFactory).extend({$type: {id: "exp/dude"}});
           };
         });
 
@@ -1503,7 +1503,7 @@ define([
 
         localRequire.define("exp/prop", ["pentaho/type/property"], function(propFactory) {
           return function(context) {
-            return context.get(propFactory).extend({type: {id: "exp/prop"}});
+            return context.get(propFactory).extend({$type: {id: "exp/prop"}});
           };
         });
 
@@ -1698,7 +1698,7 @@ define([
 
           var simpleType = context.get("pentaho/type/simple").type;
 
-          var ExpBar = context.get(simpleType).extend({type: {id: "exp/bar", isBrowsable: false}});
+          var ExpBar = context.get(simpleType).extend({$type: {id: "exp/bar", isBrowsable: false}});
 
           // register
           context.get(ExpBar);
@@ -1716,7 +1716,7 @@ define([
 
           var simpleType = context.get("pentaho/type/simple").type;
 
-          var ExpBar = context.get(simpleType).extend({type: {id: "exp/bar", isBrowsable: false}});
+          var ExpBar = context.get(simpleType).extend({$type: {id: "exp/bar", isBrowsable: false}});
 
           // register
           context.get(ExpBar);
@@ -1734,7 +1734,7 @@ define([
 
           var Simple = context.get("pentaho/type/simple");
 
-          var ExpBar = Simple.extend({type: {id: "exp/bar", isBrowsable: false}});
+          var ExpBar = Simple.extend({$type: {id: "exp/bar", isBrowsable: false}});
 
           // register
           context.get(ExpBar);
@@ -1749,19 +1749,19 @@ define([
 
         localRequire.define("exp/thing", ["pentaho/type/simple"], function(simpleFactory) {
           return function(context) {
-            return context.get(simpleFactory).extend({type: {id: "exp/thing"}});
+            return context.get(simpleFactory).extend({$type: {id: "exp/thing"}});
           };
         });
 
         localRequire.define("exp/foo", ["exp/thing"], function(thingFactory) {
           return function(context) {
-            return context.get(thingFactory).extend({type: {id: "exp/foo"}});
+            return context.get(thingFactory).extend({$type: {id: "exp/foo"}});
           };
         });
 
         localRequire.define("exp/bar", ["exp/thing"], function(simpleFactory) {
           return function(context) {
-            return context.get(simpleFactory).extend({type: {id: "exp/bar"}});
+            return context.get(simpleFactory).extend({$type: {id: "exp/bar"}});
           };
         });
 

--- a/impl/client/src/test/javascript/pentaho/type/PropertyTypeCollection.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/PropertyTypeCollection.spec.js
@@ -30,7 +30,7 @@ define([
   var Complex = context.get("complex");
   var PostalCode = PentahoString.extend();
   var Derived = Complex.extend({
-    type: {
+    $type: {
       props: ["foo", "guru"]
     }
   });
@@ -260,7 +260,7 @@ define([
 
     describe("property inheritance", function() {
       var MoreDerived = Derived.extend({
-        type: {
+        $type: {
           label: "MoreDerived",
           props: ["bar"]
         }

--- a/impl/client/src/test/javascript/pentaho/type/SpecificationContext.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/SpecificationContext.spec.js
@@ -41,7 +41,7 @@ define([
 
       it("should return the id of a type that has an id", function() {
         var id = "foo";
-        var Derived = Instance.extend({type: {id: id}});
+        var Derived = Instance.extend({$type: {id: id}});
         var context = new SpecificationContext();
 
         var result = context.getIdOf(Derived.type);
@@ -144,7 +144,7 @@ define([
 
       it("should add a type that has an id and return its id", function() {
         var id = "foo";
-        var Derived = Instance.extend({type: {id: id}});
+        var Derived = Instance.extend({$type: {id: id}});
         var context = new SpecificationContext();
 
         var result = context.add(Derived.type);
@@ -154,7 +154,7 @@ define([
 
       it("should accept adding a type that has an id multiple times, always returning its id", function() {
         var id = "foo";
-        var Derived = Instance.extend({type: {id: id}});
+        var Derived = Instance.extend({$type: {id: id}});
         var context = new SpecificationContext();
 
         var result1 = context.add(Derived.type);
@@ -207,7 +207,7 @@ define([
 
       it("should return the id returned by get, for the same named type", function() {
         var id = "foo";
-        var Derived = Instance.extend({type: {id: id}});
+        var Derived = Instance.extend({$type: {id: id}});
         var context = new SpecificationContext();
 
         var result1 = context.add(Derived.type);

--- a/impl/client/src/test/javascript/pentaho/type/_type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/_type.serialization.spec.js
@@ -37,7 +37,7 @@ define([
       var derivedType;
 
       beforeEach(function() {
-        derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
+        derivedType = Instance.extend({$type: {id: "pentaho/type/test"}}).type;
       });
 
       it("should call #toSpecInContext", function() {
@@ -137,7 +137,7 @@ define([
       });
 
       it("should return a specification object having the id of the type, if an alias is defined", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
 
         var scope = new SpecificationScope();
 
@@ -150,7 +150,7 @@ define([
       });
 
       it("should return a specification object having the alias of the type, if it is defined", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
 
         var scope = new SpecificationScope();
 
@@ -163,7 +163,7 @@ define([
       });
 
       it("should return a specification object having the id of the type, if no alias is defined", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test"}}).type;
 
         var scope = new SpecificationScope();
 
@@ -279,7 +279,7 @@ define([
 
               return Value.extend({
                 testMethodAInst: function() {},
-                type: {
+                $type: {
                   id: "tests/mixins/A",
                   testMethodA: function() {}
                 }
@@ -295,7 +295,7 @@ define([
 
               return Value.extend({
                 testMethodBInst: function() {},
-                type: {
+                $type: {
                   id: "tests/mixins/B",
                   testMethodB: function() {}
                 }
@@ -316,14 +316,14 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue1 = Value.extend({
-              type: {
+              $type: {
                 id: "tests/types/foo1",
                 mixins: [mixinFactoryA]
               }
             });
 
             var DerivedValue2 = DerivedValue1.extend({
-              type: {
+              $type: {
                 id: "tests/types/foo2",
                 mixins: [mixinFactoryB]
               }
@@ -346,7 +346,7 @@ define([
     describe("#toRef(keyArgs)", function() {
 
       it("should return the #id of the type when it has an id and no alias", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test"}}).type;
 
         var typeRef = derivedType.toRef();
 
@@ -354,7 +354,7 @@ define([
       });
 
       it("should return the #alias of the type when it has an id and an alias", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test", alias: "test"}}).type;
 
         var typeRef = derivedType.toRef();
 
@@ -445,7 +445,7 @@ define([
     describe("#toRefInContext(keyArgs)", function() {
 
       it("should return the #id of the type when it has an id and no alias", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test"}}).type;
 
         var scope = new SpecificationScope();
 
@@ -457,7 +457,7 @@ define([
       });
 
       it("should return the #alias of the type when it has an id and an alias", function() {
-        var derivedType = Instance.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+        var derivedType = Instance.extend({$type: {id: "pentaho/type/test", alias: "test"}}).type;
 
         var scope = new SpecificationScope();
 
@@ -503,7 +503,7 @@ define([
       var derivedType;
 
       beforeEach(function() {
-        derivedType = Instance.extend({type: {id: "pentaho/type/test"}}).type;
+        derivedType = Instance.extend({$type: {id: "pentaho/type/test"}}).type;
       });
 
       it("should call #toSpec({isJson: true})", function() {

--- a/impl/client/src/test/javascript/pentaho/type/_type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/_type.spec.js
@@ -35,7 +35,7 @@ define([
 
     describe("construction", function() {
       it("should allow specifying static type members", function() {
-        var Derived = Instance.extend({}, {type: {foo: "bar"}});
+        var Derived = Instance.extend({}, {$type: {foo: "bar"}});
 
         expect(Derived.Type.foo).toBe("bar");
       });
@@ -69,7 +69,7 @@ define([
 
         it("should inherit `label`", function() {
           function expectIt(derivedSpec) {
-            var Derived = Instance.extend({type: derivedSpec});
+            var Derived = Instance.extend({$type: derivedSpec});
             expect(Derived.type.label).toBe(Instance.type.label);
           }
 
@@ -80,8 +80,8 @@ define([
         });
 
         it("subclasses should preserve the default value", function() {
-          var FirstDerivative  = Instance.extend({type: {label: "Foo"}});
-          var SecondDerivative = FirstDerivative.extend({type: {label: "Bar"}});
+          var FirstDerivative  = Instance.extend({$type: {label: "Foo"}});
+          var SecondDerivative = FirstDerivative.extend({$type: {label: "Bar"}});
           SecondDerivative.type.label = undefined;
           // The default value is still there (did not delete)
           expect(SecondDerivative.type.label).toBe("Foo");
@@ -91,7 +91,7 @@ define([
       describe("when `label` is truthy", function() {
         // Can change the label
         it("should respect the `label`", function() {
-          var Derived = Instance.extend({type: {label: "Foo"}});
+          var Derived = Instance.extend({$type: {label: "Foo"}});
           expect(Derived.type.label).toBe("Foo");
         });
       });
@@ -102,7 +102,7 @@ define([
       describe("when `id` is falsy -", function() {
         it("should have `null` as a default `id`", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
             expect(Derived.type.id).toBe(null);
           }
 
@@ -115,7 +115,7 @@ define([
           function expectIt(spec) {
             spec.sourceId = "foo";
 
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
             expect(Derived.type.id).toBe("foo");
           }
 
@@ -128,7 +128,7 @@ define([
       describe("when `id` is truthy -", function() {
         it("should respect it", function() {
           var Derived = Instance.extend({
-            type: {id: "foo/bar"}
+            $type: {id: "foo/bar"}
           });
 
           expect(Derived.type.id).toBe("foo/bar");
@@ -136,7 +136,7 @@ define([
 
         it("should convert it to a string", function() {
           var Derived = Instance.extend({
-            type: {id: {toString: function() { return "foo/bar"; }}}
+            $type: {id: {toString: function() { return "foo/bar"; }}}
           });
 
           expect(Derived.type.id).toBe("foo/bar");
@@ -144,7 +144,7 @@ define([
 
         it("should ignore it, if it is a temporary id", function() {
           var Derived = Instance.extend({
-            type: {id: SpecificationContext.idTemporaryPrefix + "id"}
+            $type: {id: SpecificationContext.idTemporaryPrefix + "id"}
           });
 
           expect(Derived.type.id).toBe(null);
@@ -157,7 +157,7 @@ define([
           function expectIt(spec) {
             spec.id = "foo";
 
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
             expect(Derived.type.sourceId).toBe("foo");
           }
 
@@ -170,7 +170,7 @@ define([
       describe("when `sourceId` is truthy -", function() {
         it("should respect it", function() {
           var Derived = Instance.extend({
-            type: {sourceId: "foo/bar"}
+            $type: {sourceId: "foo/bar"}
           });
 
           expect(Derived.type.sourceId).toBe("foo/bar");
@@ -178,7 +178,7 @@ define([
 
         it("should convert it to a string", function() {
           var Derived = Instance.extend({
-            type: {sourceId: {toString: function() { return "foo/bar"; }}}
+            $type: {sourceId: {toString: function() { return "foo/bar"; }}}
           });
 
           expect(Derived.type.sourceId).toBe("foo/bar");
@@ -188,7 +188,7 @@ define([
       describe("when both `id` and `sourceId` are truthy and different -", function() {
         it("should respect both", function() {
           var Derived = Instance.extend({
-            type: {id: "bar/foo", sourceId: "foo/bar"}
+            $type: {id: "bar/foo", sourceId: "foo/bar"}
           });
 
           expect(Derived.type.id).toBe("bar/foo");
@@ -202,7 +202,7 @@ define([
 
       it("should leave absolute ids intact", function() {
 
-        var Derived = Instance.extend({type: {sourceId: "fake/id"}});
+        var Derived = Instance.extend({$type: {sourceId: "fake/id"}});
 
         expect(Derived.type.buildSourceRelativeId("/foo")).toBe("/foo");
         expect(Derived.type.buildSourceRelativeId("foo:")).toBe("foo:");
@@ -213,7 +213,7 @@ define([
 
       it("should convert relative ids to absolute", function() {
 
-        var Derived = Instance.extend({type: {sourceId: "fake/id"}});
+        var Derived = Instance.extend({$type: {sourceId: "fake/id"}});
 
         expect(Derived.type.buildSourceRelativeId("./foo/bar")).toBe("fake/./foo/bar");
         expect(Derived.type.buildSourceRelativeId("./bar")).toBe("fake/./bar");
@@ -228,7 +228,7 @@ define([
 
         // ---
 
-        Derived = Instance.extend({type: {sourceId: "id"}});
+        Derived = Instance.extend({$type: {sourceId: "id"}});
 
         expect(Derived.type.buildSourceRelativeId("../bar")).toBe("../bar");
       });
@@ -238,13 +238,13 @@ define([
 
       it("cannot be assigned to an anonymous type", function() {
         expect(function() {
-          var Derived = Instance.extend({type: {label: "Foo", alias: "bar"}});
+          var Derived = Instance.extend({$type: {label: "Foo", alias: "bar"}});
         }).toThrow(errorMatch.argInvalid("alias", "Anonymous types cannot have an alias"));
       });
 
       it("is read only", function() {
         expect(function() {
-          var Derived = Instance.extend({type: {label: "Foo", id: "type/bar", alias: "bar"}});
+          var Derived = Instance.extend({$type: {label: "Foo", id: "type/bar", alias: "bar"}});
           Derived.type.alias = "mux";
         }).toThrowError(TypeError);
       });
@@ -259,12 +259,12 @@ define([
       });
 
       it("should be equal to #id when no alias is defined", function() {
-        var Derived = Instance.extend({type: {id: "my/foo"}});
+        var Derived = Instance.extend({$type: {id: "my/foo"}});
         expect(Derived.type.shortId).toBe(Derived.type.id);
       });
 
       it("should be equal to #alias when the alias is defined", function() {
-        var Derived = Instance.extend({type: {id: "my/foo", alias: "foo"}});
+        var Derived = Instance.extend({$type: {id: "my/foo", alias: "foo"}});
         expect(Derived.type.shortId).toBe(Derived.type.alias);
       });
 
@@ -272,20 +272,20 @@ define([
 
     describe("#defaultView -", function() {
       it("should default to `null`", function() {
-        var Derived = Instance.extend({type: {id: "fake/id"}});
+        var Derived = Instance.extend({$type: {id: "fake/id"}});
 
         expect(Derived.type.defaultView).toBe(null);
       });
 
       it("should store relative ids as relative ids", function() {
 
-        var Derived = Instance.extend({type: {id: "fake/id", defaultView: "./foo/bar"}});
+        var Derived = Instance.extend({$type: {id: "fake/id", defaultView: "./foo/bar"}});
 
         expect(Derived.type.defaultView).toBe("./foo/bar");
       });
 
       it("should inherit the base type's defaultView, when unspecified", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
@@ -295,52 +295,52 @@ define([
       });
 
       it("should inherit the base type's defaultView, when spec is undefined", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
-        var B = A.extend({type: {defaultView: undefined}});
+        var B = A.extend({$type: {defaultView: undefined}});
 
         expect(B.type.defaultView).toBe("foo");
       });
 
       it("should respect a null spec value", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
-        var B = A.extend({type: {defaultView: null}});
+        var B = A.extend({$type: {defaultView: null}});
 
         expect(B.type.defaultView).toBe(null);
       });
 
       it("should convert an empty string value to null", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
-        var B = A.extend({type: {defaultView: ""}});
+        var B = A.extend({$type: {defaultView: ""}});
 
         expect(B.type.defaultView).toBe(null);
       });
 
       it("should respect a specified non-empty string", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
-        var B = A.extend({type: {defaultView: "bar"}});
+        var B = A.extend({$type: {defaultView: "bar"}});
 
         expect(B.type.defaultView).toBe("bar");
       });
 
       // coverage
       it("should allow setting to the same string value", function() {
-        var A = Instance.extend({type: {defaultView: "foo"}});
+        var A = Instance.extend({$type: {defaultView: "foo"}});
 
         expect(A.type.defaultView).toBe("foo");
 
-        var B = A.extend({type: {defaultView: "bar"}});
+        var B = A.extend({$type: {defaultView: "bar"}});
 
         B.type.defaultView = "bar";
 
@@ -350,7 +350,7 @@ define([
       it("should inherit a base function", function() {
         var FA = function() {
         };
-        var A  = Instance.extend({type: {defaultView: FA}});
+        var A  = Instance.extend({$type: {defaultView: FA}});
 
         expect(A.type.defaultView).toBe(FA);
 
@@ -362,13 +362,13 @@ define([
       it("should respect a specified function", function() {
         var FA = function() {
         };
-        var A  = Instance.extend({type: {defaultView: FA}});
+        var A  = Instance.extend({$type: {defaultView: FA}});
 
         expect(A.type.defaultView).toBe(FA);
 
         var FB = function() {
         };
-        var B  = A.extend({type: {defaultView: FB}});
+        var B  = A.extend({$type: {defaultView: FB}});
 
         expect(B.type.defaultView).toBe(FB);
       });
@@ -377,13 +377,13 @@ define([
       it("should allow setting to the same function", function() {
         var FA = function() {
         };
-        var A  = Instance.extend({type: {defaultView: FA}});
+        var A  = Instance.extend({$type: {defaultView: FA}});
 
         expect(A.type.defaultView).toBe(FA);
 
         var FB = function() {
         };
-        var B  = A.extend({type: {defaultView: FB}});
+        var B  = A.extend({$type: {defaultView: FB}});
 
         B.type.defaultView = FB;
 
@@ -398,7 +398,7 @@ define([
 
       it("should throw when defaultView is not a string, nully or a function", function() {
         expect(function() {
-          Instance.extend({type: {defaultView: {}}});
+          Instance.extend({$type: {defaultView: {}}});
         }).toThrow(errorMatch.argInvalidType("defaultView", ["nully", "string", "function"], "object"));
       });
     }); // end #defaultView
@@ -427,7 +427,7 @@ define([
         var View = function() {
         };
 
-        var A = Instance.extend({type: {defaultView: View}});
+        var A = Instance.extend({$type: {defaultView: View}});
         var p = A.type.defaultViewClass;
 
         expect(p instanceof Promise).toBe(true);
@@ -446,7 +446,7 @@ define([
           return View;
         });
 
-        var A = Instance.extend({type: {defaultView: "foo/bar"}});
+        var A = Instance.extend({$type: {defaultView: "foo/bar"}});
 
         var p = A.type.defaultViewClass;
 
@@ -468,7 +468,7 @@ define([
           return View;
         });
 
-        var A = Instance.extend({type: {sourceId: "foo/bar", defaultView: "./barView"}});
+        var A = Instance.extend({$type: {sourceId: "foo/bar", defaultView: "./barView"}});
 
         var p = A.type.defaultViewClass;
 
@@ -489,7 +489,7 @@ define([
           return View;
         });
 
-        var A = Instance.extend({type: {defaultView: "foo/bar"}});
+        var A = Instance.extend({$type: {defaultView: "foo/bar"}});
 
         var B = A.extend();
 
@@ -516,9 +516,9 @@ define([
           return View;
         });
 
-        var A = Instance.extend({type: {sourceId: "foo/bar", defaultView: "./barView"}});
+        var A = Instance.extend({$type: {sourceId: "foo/bar", defaultView: "./barView"}});
 
-        var B = A.extend({type: {sourceId: "gugu/dada"}});
+        var B = A.extend({$type: {sourceId: "gugu/dada"}});
 
         var pb = B.type.defaultViewClass;
 
@@ -542,7 +542,7 @@ define([
           return View;
         });
 
-        var A = Instance.extend({type: {defaultView: "foo/bar"}});
+        var A = Instance.extend({$type: {defaultView: "foo/bar"}});
 
         var pa = A.type.defaultViewClass;
 
@@ -567,7 +567,7 @@ define([
           return ViewDude;
         });
 
-        var A = Instance.extend({type: {defaultView: "foo/bar"}});
+        var A = Instance.extend({$type: {defaultView: "foo/bar"}});
 
         var pa = A.type.defaultViewClass;
 
@@ -598,10 +598,10 @@ define([
 
     describe("#isAbstract", function() {
       it("should respect a specified abstract spec value", function() {
-        var Derived = Instance.extend({type: {isAbstract: true}});
+        var Derived = Instance.extend({$type: {isAbstract: true}});
         expect(Derived.type.isAbstract).toBe(true);
 
-        Derived = Instance.extend({type: {isAbstract: false}});
+        Derived = Instance.extend({$type: {isAbstract: false}});
         expect(Derived.type.isAbstract).toBe(false);
       });
 
@@ -609,8 +609,8 @@ define([
         var Derived = Instance.extend();
         expect(Derived.type.isAbstract).toBe(false);
 
-        var Abstract = Instance.extend({type: {isAbstract: true}});
-        var Concrete = Instance.extend({type: {isAbstract: false}});
+        var Abstract = Instance.extend({$type: {isAbstract: true}});
+        var Concrete = Instance.extend({$type: {isAbstract: false}});
 
         var DerivedAbstract = Abstract.extend();
         var DerivedConcrete = Concrete.extend();
@@ -630,7 +630,7 @@ define([
       describe("when not specified -", function() {
         it("should inherit the base application attribute", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.application).toEqual({});
           }
@@ -643,15 +643,15 @@ define([
       describe("when specified -", function() {
         it("should clone the spec if there is no previous application attribute defined", function() {
           var spec = {foo: "bar"};
-          var Derived = Instance.extend({type: {application: spec}});
+          var Derived = Instance.extend({$type: {application: spec}});
 
           expect(Derived.type.application).not.toBe(spec);
           expect(Derived.type.application.foo).toBe(spec.foo);
         });
 
         it("should merge the spec if there is a previous application attribute defined", function() {
-          var Derived1 = Instance.extend({type: {application: {foo: "foo"}}});
-          var Derived2 = Instance.extend({type: {application: {foo: "bar", bar: "foo"}}});
+          var Derived1 = Instance.extend({$type: {application: {foo: "foo"}}});
+          var Derived2 = Instance.extend({$type: {application: {foo: "bar", bar: "foo"}}});
           expect(Derived1.type.application.foo).toBe("foo");
           expect(Derived2.type.application.foo).toBe("bar");
           expect(Derived2.type.application.bar).toBe("foo");
@@ -675,7 +675,7 @@ define([
       describe("when not specified -", function() {
         it("should inherit the base description", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.description).toBe(Instance.type.description);
           }
@@ -688,7 +688,7 @@ define([
       describe("when specified as `null` or an empty string -", function() {
         it("should set the description to `null`", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.description).toBe(null);
           }
@@ -700,7 +700,7 @@ define([
 
       describe("when specified as a non-empty string -", function() {
         it("should respect it", function() {
-          var Derived = Instance.extend({type: {description: "Foo"}});
+          var Derived = Instance.extend({$type: {description: "Foo"}});
 
           expect(Derived.type.description).toBe("Foo");
         });
@@ -718,7 +718,7 @@ define([
 
         it("should inherit the base category", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.category).toBe(Instance.type.category);
           }
@@ -731,7 +731,7 @@ define([
       describe("when specified as `null` or an empty string -", function() {
         it("should set the category to `null`", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.category).toBe(null);
           }
@@ -743,7 +743,7 @@ define([
 
       describe("when specified as a non-empty string", function() {
         it("should respect it", function() {
-          var Derived = Instance.extend({type: {category: "Foo"}});
+          var Derived = Instance.extend({$type: {category: "Foo"}});
 
           expect(Derived.type.category).toBe("Foo");
         });
@@ -760,7 +760,7 @@ define([
       describe("when not specified", function() {
         it("should inherit the base helpUrl", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.helpUrl).toBe(Instance.type.helpUrl);
           }
@@ -773,7 +773,7 @@ define([
       describe("when specified as `null` or an empty string -", function() {
         it("should set the helpUrl to `null`", function() {
           function expectIt(spec) {
-            var Derived = Instance.extend({type: spec});
+            var Derived = Instance.extend({$type: spec});
 
             expect(Derived.type.helpUrl).toBe(null);
           }
@@ -785,7 +785,7 @@ define([
 
       describe("when specified as a non-empty string -", function() {
         it("should respect it", function() {
-          var Derived = Instance.extend({type: {helpUrl: "Foo"}});
+          var Derived = Instance.extend({$type: {helpUrl: "Foo"}});
 
           expect(Derived.type.helpUrl).toBe("Foo");
         });
@@ -821,7 +821,7 @@ define([
 
       it("should default to the id of the type, in snake case, when the type is not anonymous", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar"
           }
         });
@@ -837,7 +837,7 @@ define([
 
       it("should respect a specified styleClass upon extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: "foo-bar-gugu"
           }
@@ -848,7 +848,7 @@ define([
 
       it("should respect a specified styleClass equal to `null` upon extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: null
           }
@@ -859,7 +859,7 @@ define([
 
       it("should convert a specified styleClass equal to `''` to `null` upon extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: ""
           }
@@ -870,7 +870,7 @@ define([
 
       it("should default to the id of the type if specified as `undefined` upon extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: undefined
           }
@@ -881,7 +881,7 @@ define([
 
       it("should clear the value when set to '' after extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: "abc"
           }
@@ -894,7 +894,7 @@ define([
 
       it("should clear the value when set to `null` after extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: "abc"
           }
@@ -907,7 +907,7 @@ define([
 
       it("should default the value when set to `undefined` after extension", function() {
         var Derived = Instance.extend({
-          type: {
+          $type: {
             id: "foo/bar",
             styleClass: "abc"
           }
@@ -934,9 +934,9 @@ define([
         Instance = context.get("instance");
 
         Instance.type.styleClass = null;
-        DerivedLevel1 = Instance.extend({type: {styleClass: null}});
-        DerivedLevel2 = DerivedLevel1.extend({type: {styleClass: null}});
-        DerivedLevel3 = DerivedLevel2.extend({type: {styleClass: null}});
+        DerivedLevel1 = Instance.extend({$type: {styleClass: null}});
+        DerivedLevel2 = DerivedLevel1.extend({$type: {styleClass: null}});
+        DerivedLevel3 = DerivedLevel2.extend({$type: {styleClass: null}});
       });
 
       it("should return empty array when no styleClass are defined", function() {
@@ -984,19 +984,19 @@ define([
 
       it("can be set on a derived class", function() {
         [true, false].forEach(function(bool) {
-          var Derived = Instance.extend({type: {"isAdvanced": bool}});
+          var Derived = Instance.extend({$type: {"isAdvanced": bool}});
           expect(Derived.type.isAdvanced).toBe(bool);
 
           var inst = new Derived();
-          expect(inst.type.isAdvanced).toBe(bool);
+          expect(inst.$type.isAdvanced).toBe(bool);
         });
       });
 
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [true, false].forEach(function(bool) {
           [null, undefined].forEach(function(value) {
-            var FirstDerivative  = Instance.extend({type: {"isAdvanced": bool}});
-            var SecondDerivative = FirstDerivative.extend({type: {"isAdvanced": !bool}});
+            var FirstDerivative  = Instance.extend({$type: {"isAdvanced": bool}});
+            var SecondDerivative = FirstDerivative.extend({$type: {"isAdvanced": !bool}});
 
             SecondDerivative.type.isAdvanced = value;
             expect(SecondDerivative.type.isAdvanced).toBe(FirstDerivative.type.isAdvanced);
@@ -1014,19 +1014,19 @@ define([
 
       it("can be set on a derived class", function() {
         [true, false].forEach(function(bool) {
-          var Derived = Instance.extend({type: {"isBrowsable": bool}});
+          var Derived = Instance.extend({$type: {"isBrowsable": bool}});
           expect(Derived.type.isBrowsable).toBe(bool);
 
           var inst = new Derived();
-          expect(inst.type.isBrowsable).toBe(bool);
+          expect(inst.$type.isBrowsable).toBe(bool);
         });
       });
 
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [true, false].forEach(function(bool) {
           [null, undefined].forEach(function(value) {
-            var FirstDerivative  = Instance.extend({type: {"isBrowsable": bool}});
-            var SecondDerivative = FirstDerivative.extend({type: {"isBrowsable": !bool}});
+            var FirstDerivative  = Instance.extend({$type: {"isBrowsable": bool}});
+            var SecondDerivative = FirstDerivative.extend({$type: {"isBrowsable": !bool}});
 
             SecondDerivative.type.isBrowsable = value;
             expect(SecondDerivative.type.isBrowsable).toBe(FirstDerivative.type.isBrowsable);
@@ -1044,11 +1044,11 @@ define([
 
       it("can be set on a derived class", function() {
         [1].forEach(function(someValue) {
-          var Derived = Instance.extend({type: {"ordinal": someValue}});
+          var Derived = Instance.extend({$type: {"ordinal": someValue}});
           expect(Derived.type.ordinal).toBe(someValue);
 
           var inst = new Derived();
-          expect(inst.type.ordinal).toBe(someValue);
+          expect(inst.$type.ordinal).toBe(someValue);
         });
       });
 
@@ -1066,20 +1066,20 @@ define([
           var candidate = candidateAndFinal[0];
           var final     = candidateAndFinal[1];
 
-          var FirstDerivative  = Instance.extend({type: {"ordinal": 42}});
-          var SecondDerivative = FirstDerivative.extend({type: {"ordinal": candidate}});
+          var FirstDerivative  = Instance.extend({$type: {"ordinal": 42}});
+          var SecondDerivative = FirstDerivative.extend({$type: {"ordinal": candidate}});
           expect(SecondDerivative.type.ordinal).toBe(final);
 
           var inst = new SecondDerivative();
-          expect(inst.type.ordinal).toBe(final);
+          expect(inst.$type.ordinal).toBe(final);
         });
       });
 
       it("can be unset by passing a nully, thus delegating to the ancestor class", function() {
         [1, 20].forEach(function(someValue) {
           [null, undefined].forEach(function(resetValue) {
-            var FirstDerivative  = Instance.extend({type: {"ordinal": 42}});
-            var SecondDerivative = FirstDerivative.extend({type: {"ordinal": someValue}});
+            var FirstDerivative  = Instance.extend({$type: {"ordinal": 42}});
+            var SecondDerivative = FirstDerivative.extend({$type: {"ordinal": someValue}});
 
             SecondDerivative.type.ordinal = resetValue;
             expect(SecondDerivative.type.ordinal).toBe(FirstDerivative.type.ordinal);
@@ -1095,16 +1095,16 @@ define([
           expect(Derived.type.isRoot).toBe(isRoot);
 
           var inst = new Derived();
-          expect(inst.type.isRoot).toBe(isRoot);
+          expect(inst.$type.isRoot).toBe(isRoot);
         });
       });
     }); // #isRoot
 
     describe("#ancestor -", function() {
       it("returns the immediate ancestor", function() {
-        var FirstDerivative  = Instance.extend({type: {"firstDerivative": true}});
-        var FirstSibling     = Instance.extend({type: {"firstSibling": true}});
-        var SecondDerivative = FirstDerivative.extend({type: {"secondDerivative": true}});
+        var FirstDerivative  = Instance.extend({$type: {"firstDerivative": true}});
+        var FirstSibling     = Instance.extend({$type: {"firstSibling": true}});
+        var SecondDerivative = FirstDerivative.extend({$type: {"secondDerivative": true}});
 
         expect(FirstDerivative.type.ancestor).toBe(Instance.type);
 
@@ -1249,7 +1249,7 @@ define([
       });
 
       it("should throw if given a type annotated value of an abstract type", function() {
-        var MyAbstract = context.get("pentaho/type/complex").extend({type: {isAbstract: true}});
+        var MyAbstract = context.get("pentaho/type/complex").extend({$type: {isAbstract: true}});
 
         expect(function() {
           Instance.type.create({_: MyAbstract});
@@ -1257,7 +1257,7 @@ define([
       });
 
       it("should throw if given a value and called on an abstract type", function() {
-        var MyAbstract = context.get("pentaho/type/complex").extend({type: {isAbstract: true}});
+        var MyAbstract = context.get("pentaho/type/complex").extend({$type: {isAbstract: true}});
 
         expect(function() {
           MyAbstract.type.create({});
@@ -1403,7 +1403,7 @@ define([
       });
 
       it("should throw if given a type annotated value of an abstract type", function() {
-        var MyAbstract = context.get("pentaho/type/complex").extend({type: {isAbstract: true}});
+        var MyAbstract = context.get("pentaho/type/complex").extend({$type: {isAbstract: true}});
 
         return expectToRejectWith(
             function() { return Instance.type.createAsync({_: MyAbstract}); },
@@ -1421,7 +1421,7 @@ define([
               var Complex = context.get("pentaho/type/complex");
 
               return Complex.extend({
-                type: {
+                $type: {
                   id: "test/foo/a",
                   props: {
                     a: {valueType: "string"}
@@ -1437,7 +1437,7 @@ define([
               var Complex = context.get("pentaho/type/complex");
 
               return Complex.extend({
-                type: {
+                $type: {
                   id: "test/foo/b",
                   props: {
                     b: {valueType: "string"}
@@ -1453,7 +1453,7 @@ define([
               var TestFooB = context.get("test/foo/b");
 
               return TestFooB.extend({
-                type: {
+                $type: {
                   id: "test/foo/c",
                   props: {
                     c: {valueType: "string"}
@@ -1582,7 +1582,7 @@ define([
 
             return Value.extend({
               testMethodAInst: function() {},
-              type: {
+              $type: {
                 id: "tests/mixins/A",
                 testMethodA: function() {}
               }
@@ -1598,7 +1598,7 @@ define([
 
             return Value.extend({
               testMethodBInst: function() {},
-              type: {
+              $type: {
                 id: "tests/mixins/B",
                 testMethodB: function() {}
               }
@@ -1613,7 +1613,7 @@ define([
             var Value = context.get(valueFactory);
 
             return Value.extend({
-              type: {
+              $type: {
                 id: "tests/mixins/C",
                 _init: function(spec, ka) {
                   this.base(spec, ka);
@@ -1654,7 +1654,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: ["tests/mixins/A"]
               }
             });
@@ -1682,7 +1682,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: "tests/mixins/A"
               }
             });
@@ -1710,7 +1710,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: [mixinFactoryA]
               }
             });
@@ -1739,7 +1739,7 @@ define([
             var MixinA = context.get(mixinFactoryA);
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: [MixinA]
               }
             });
@@ -1765,7 +1765,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: ["tests/mixins/A"]
               }
             });
@@ -1786,7 +1786,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 id: "tests/type/target",
                 mixins: ["tests/mixins/A"]
               }
@@ -1808,13 +1808,13 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue1 = Value.extend({
-              type: {
+              $type: {
                 mixins: ["tests/mixins/A"]
               }
             });
 
             var DerivedValue2 = DerivedValue1.extend({
-              type: {
+              $type: {
                 mixins: ["tests/mixins/B"]
               }
             });
@@ -1861,7 +1861,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: ["tests/mixins/A", "tests/mixins/A", "tests/mixins/B"]
               }
             });
@@ -1890,7 +1890,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: null
               }
             });
@@ -1900,7 +1900,7 @@ define([
             // ---
 
             DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: undefined
               }
             });
@@ -1910,7 +1910,7 @@ define([
             // ---
 
             DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: [mixinFactoryA]
               }
             });
@@ -1938,7 +1938,7 @@ define([
             var Value = context.get("pentaho/type/value");
 
             var DerivedValue = Value.extend({
-              type: {
+              $type: {
                 mixins: [mixinFactoryC]
               }
             });

--- a/impl/client/src/test/javascript/pentaho/type/changes/Add.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Add.spec.js
@@ -64,7 +64,7 @@ define([
       it("should add an element and be visible as an ambient value", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -79,7 +79,7 @@ define([
       it("should add an element and be visible if txn is committed", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -98,7 +98,7 @@ define([
       it("should add an element and cancel it if txn is rejected", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -116,7 +116,7 @@ define([
       it("should add an element and not be there as an ambient value if changes are cleared", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -134,7 +134,7 @@ define([
       it("should add an element and not be there if changes are cleared and the txn committed", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -154,7 +154,7 @@ define([
       it("should add an element and, if removed again, it should stop being there as an ambient value", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -169,7 +169,7 @@ define([
       it("should add an element and, if removed again, it should stop being there when committed", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 
@@ -188,7 +188,7 @@ define([
       it("should add an element and, if removed again, it should stop being there when txn is rejected", function() {
 
         var list = new NumberList();
-        var elem = list.type.of.to(0);
+        var elem = list.$type.of.to(0);
 
         // ---
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/Add.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Add.spec.js
@@ -124,7 +124,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 
@@ -142,7 +142,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         scope.accept();
 
@@ -257,7 +257,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
         });
       });
 
@@ -348,7 +348,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           // ---
 
@@ -372,7 +372,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           scope.accept();
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/Changeset.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Changeset.spec.js
@@ -45,7 +45,7 @@ define([
 
       beforeEach(function() {
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "foo", defaultValue: "bar"}
             ]

--- a/impl/client/src/test/javascript/pentaho/type/changes/Clear.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Clear.spec.js
@@ -146,7 +146,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 
@@ -163,7 +163,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         scope.accept();
 
@@ -297,7 +297,7 @@ define([
 
             // ---
 
-            list.changeset.clearChanges();
+            list.$changeset.clearChanges();
           });
         });
 
@@ -320,7 +320,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
         });
       });
 
@@ -427,7 +427,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           // ---
 
@@ -449,7 +449,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           scope.accept();
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
@@ -40,11 +40,11 @@ define([
       PentahoNumber = context.get(numberFactory);
 
       NumberList = List.extend({
-        type: {of: PentahoNumber}
+        $type: {of: PentahoNumber}
       });
 
       Derived = Complex.extend({
-        type: {
+        $type: {
           props: [
             {name: "foo", valueType: "number"},
             {name: "bar", valueType: "number"},
@@ -200,7 +200,7 @@ define([
         });
 
         it("should add a new property to the ComplexChangeset", function() {
-          var Derived = Complex.extend({type: {props: ["foo"]}});
+          var Derived = Complex.extend({$type: {props: ["foo"]}});
 
           var derived = new Derived({foo: "a"});
 
@@ -217,7 +217,7 @@ define([
         });
 
         it("should update a Replace change, when it already exists in the changeset", function() {
-          var Derived = Complex.extend({type: {props: ["foo"]}});
+          var Derived = Complex.extend({$type: {props: ["foo"]}});
 
           var derived = new Derived({foo: "a"});
 
@@ -240,7 +240,7 @@ define([
         });
 
         it("should not create a change, when the value is the same", function() {
-          var Derived = Complex.extend({type: {props: ["foo"]}});
+          var Derived = Complex.extend({$type: {props: ["foo"]}});
 
           var derived = new Derived({foo: "a"});
 
@@ -259,7 +259,7 @@ define([
 
           var txnScope = context.enterChange();
 
-          var Derived = Complex.extend({type: {props: ["foo"]}});
+          var Derived = Complex.extend({$type: {props: ["foo"]}});
           var derived = new Derived({foo: "bar"});
 
           var changeset = new ComplexChangeset(txnScope.transaction, derived);

--- a/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
@@ -75,8 +75,8 @@ define([
         owner.foo = 10;
         owner.myList.add(3);
 
-        listChangeset = myList.changeset;
-        changeset = owner.changeset;
+        listChangeset = myList.$changeset;
+        changeset = owner.$changeset;
       });
 
       afterEach(function() {
@@ -211,7 +211,7 @@ define([
           derived.set("foo", "b");
 
           expect(derived.hasChanges).toBe(true);
-          expect(derived.changeset.hasChange("foo")).toBe(true);
+          expect(derived.$changeset.hasChange("foo")).toBe(true);
 
           txnScope.dispose();
         });
@@ -225,13 +225,13 @@ define([
 
           derived.set("foo", "b");
 
-          var change0 = derived.changeset.getChange("foo");
+          var change0 = derived.$changeset.getChange("foo");
 
           expect(change0.value.valueOf()).toBe("b");
 
           derived.set("foo", "c");
 
-          var change1 = derived.changeset.getChange("foo");
+          var change1 = derived.$changeset.getChange("foo");
 
           expect(change0).toBe(change1);
           expect(change1.value.valueOf()).toBe("c");

--- a/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/ComplexChangeset.spec.js
@@ -206,11 +206,11 @@ define([
 
           var txnScope = context.enterChange();
 
-          expect(derived.hasChanges).toBe(false);
+          expect(derived.$hasChanges).toBe(false);
 
           derived.set("foo", "b");
 
-          expect(derived.hasChanges).toBe(true);
+          expect(derived.$hasChanges).toBe(true);
           expect(derived.$changeset.hasChange("foo")).toBe(true);
 
           txnScope.dispose();
@@ -246,11 +246,11 @@ define([
 
           var txnScope = context.enterChange();
 
-          expect(derived.hasChanges).toBe(false);
+          expect(derived.$hasChanges).toBe(false);
 
           derived.set("foo", "a");
 
-          expect(derived.hasChanges).toBe(false);
+          expect(derived.$hasChanges).toBe(false);
 
           txnScope.dispose();
         });

--- a/impl/client/src/test/javascript/pentaho/type/changes/ListChangeset.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/ListChangeset.spec.js
@@ -47,7 +47,7 @@ define([
       PentahoNumber = context.get(numberFactory);
 
       NumberList = List.extend({
-        type: {of: PentahoNumber}
+        $type: {of: PentahoNumber}
       });
 
       scope = context.enterChange();

--- a/impl/client/src/test/javascript/pentaho/type/changes/Move.Spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Move.Spec.js
@@ -166,7 +166,7 @@ define([
         // ---
 
         list.move(/*elemSpec:*/3, /*indexNew:*/0);
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 
@@ -188,7 +188,7 @@ define([
         // ---
 
         list.move(/*elemSpec:*/3, /*indexNew:*/0);
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/Remove.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Remove.spec.js
@@ -145,7 +145,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 
@@ -164,7 +164,7 @@ define([
 
         // ---
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         scope.accept();
 
@@ -283,7 +283,7 @@ define([
 
             // ---
 
-            list.changeset.clearChanges();
+            list.$changeset.clearChanges();
           });
         });
 
@@ -308,7 +308,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
         });
       });
 
@@ -395,7 +395,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           // ---
 
@@ -413,7 +413,7 @@ define([
 
           // ---
 
-          list.changeset.clearChanges();
+          list.$changeset.clearChanges();
 
           scope.accept();
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/Replace.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Replace.spec.js
@@ -80,11 +80,11 @@ define([
 
         derived.x = "1";
 
-        var change1 = derived.changeset.getChange("x");
+        var change1 = derived.$changeset.getChange("x");
 
         derived.x = "2";
 
-        var change2 = derived.changeset.getChange("x");
+        var change2 = derived.$changeset.getChange("x");
 
         // ---
 
@@ -153,7 +153,7 @@ define([
 
         // ---
 
-        derived.changeset.clearChanges();
+        derived.$changeset.clearChanges();
 
         // ---
 
@@ -171,7 +171,7 @@ define([
 
         // ---
 
-        derived.changeset.clearChanges();
+        derived.$changeset.clearChanges();
         scope.accept();
 
         // ---
@@ -227,7 +227,7 @@ define([
 
           // ---
 
-          owner.changeset.clearChanges();
+          owner.$changeset.clearChanges();
         });
       });
 
@@ -324,7 +324,7 @@ define([
 
           // ---
 
-          owner.changeset.clearChanges();
+          owner.$changeset.clearChanges();
 
           // ---
 
@@ -344,7 +344,7 @@ define([
 
           // ---
 
-          owner.changeset.clearChanges();
+          owner.$changeset.clearChanges();
 
           scope.accept();
 
@@ -514,7 +514,7 @@ define([
 
           // ---
 
-          owner.changeset.clearChanges();
+          owner.$changeset.clearChanges();
 
           // ---
 
@@ -538,7 +538,7 @@ define([
 
           // ---
 
-          owner.changeset.clearChanges();
+          owner.$changeset.clearChanges();
           scope.accept();
 
           // ---

--- a/impl/client/src/test/javascript/pentaho/type/changes/Sort.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Sort.spec.js
@@ -141,7 +141,7 @@ define([
 
         list.sort(fun.compare);
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 
@@ -157,7 +157,7 @@ define([
 
         list.sort(fun.compare);
 
-        list.changeset.clearChanges();
+        list.$changeset.clearChanges();
 
         // ---
 

--- a/impl/client/src/test/javascript/pentaho/type/changes/Transaction.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/changes/Transaction.spec.js
@@ -117,7 +117,7 @@ define([
         var scope = txn.enter();
         var container = new Derived();
         container.x = "foo";
-        container.changeset.clearChanges();
+        container.$changeset.clearChanges();
 
         var cset = txn.getChangeset(container.$uid);
 
@@ -166,7 +166,7 @@ define([
         var container = new Derived();
         var cset = new Changeset(txn, container);
 
-        expect(container.changeset).toBe(null);
+        expect(container.$changeset).toBe(null);
       });
 
       it("should add the changeset and sync the container's changeset if txn is current", function() {
@@ -176,7 +176,7 @@ define([
         var container = new Derived();
         var cset = new Changeset(txn, container);
 
-        expect(container.changeset).toBe(cset);
+        expect(container.$changeset).toBe(cset);
 
         scope.exit();
       });
@@ -303,9 +303,9 @@ define([
 
         txn.__eachChangeset(fun);
 
-        expect(fun).toHaveBeenCalledWith(inst1.changeset);
-        expect(fun).toHaveBeenCalledWith(inst2.changeset);
-        expect(fun).toHaveBeenCalledWith(inst3.changeset);
+        expect(fun).toHaveBeenCalledWith(inst1.$changeset);
+        expect(fun).toHaveBeenCalledWith(inst2.$changeset);
+        expect(fun).toHaveBeenCalledWith(inst3.$changeset);
       });
 
       it("should call fun with the transaction as JS context", function() {
@@ -449,9 +449,9 @@ define([
 
         scope.exit();
 
-        expect(inst1.changeset).toBe(null);
-        expect(inst2.changeset).toBe(null);
-        expect(inst3.changeset).toBe(null);
+        expect(inst1.$changeset).toBe(null);
+        expect(inst2.$changeset).toBe(null);
+        expect(inst3.$changeset).toBe(null);
 
         scope = txn.enter();
 
@@ -463,9 +463,9 @@ define([
         expect(cset2).not.toBe(null);
         expect(cset3).not.toBe(null);
 
-        expect(inst1.changeset).toBe(cset1);
-        expect(inst2.changeset).toBe(cset2);
-        expect(inst3.changeset).toBe(cset3);
+        expect(inst1.$changeset).toBe(cset1);
+        expect(inst2.$changeset).toBe(cset2);
+        expect(inst3.$changeset).toBe(cset3);
 
         scope.exit();
       });
@@ -485,15 +485,15 @@ define([
         var cset2 = txn.getChangeset(inst2.$uid);
         var cset3 = txn.getChangeset(inst3.$uid);
 
-        expect(inst1.changeset).toBe(cset1);
-        expect(inst2.changeset).toBe(cset2);
-        expect(inst3.changeset).toBe(cset3);
+        expect(inst1.$changeset).toBe(cset1);
+        expect(inst2.$changeset).toBe(cset2);
+        expect(inst3.$changeset).toBe(cset3);
 
         scope.exit();
 
-        expect(inst1.changeset).toBe(null);
-        expect(inst2.changeset).toBe(null);
-        expect(inst3.changeset).toBe(null);
+        expect(inst1.$changeset).toBe(null);
+        expect(inst2.$changeset).toBe(null);
+        expect(inst3.$changeset).toBe(null);
       });
     });
   });

--- a/impl/client/src/test/javascript/pentaho/type/complex.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.Type.serialization.spec.js
@@ -44,7 +44,7 @@ define([
       });
 
       it("should not create a props array when there are no local properties to serialize", function() {
-        var Derived = Complex.extend({type: {props: ["foo"]}});
+        var Derived = Complex.extend({$type: {props: ["foo"]}});
 
         var spec = {};
         serializationUtil.fillSpec(Derived, spec, {});
@@ -63,7 +63,7 @@ define([
 
       it("should call propertyType#toSpecInContext when the property is root", function() {
 
-        var derivedType = Complex.extend({type: {props: ["foo"]}}).type;
+        var derivedType = Complex.extend({$type: {props: ["foo"]}}).type;
         var fooPropType = derivedType.get("foo");
 
         spyOn(fooPropType, "toSpecInContext").and.returnValue({});
@@ -79,8 +79,8 @@ define([
 
       it("should call propertyType#toSpecInContext when the property is overridden", function() {
 
-        var Derived = Complex.extend({type: {props: ["foo"]}});
-        var Derived2 = Derived.extend({type: {props: [{name: "foo", label: "Bar"}]}});
+        var Derived = Complex.extend({$type: {props: ["foo"]}});
+        var Derived2 = Derived.extend({$type: {props: [{name: "foo", label: "Bar"}]}});
 
         var fooPropType = Derived2.type.get("foo");
 
@@ -97,7 +97,7 @@ define([
 
       it("should not call propertyType#toSpecInContext when the property is inherited", function() {
 
-        var Derived = Complex.extend({type: {props: ["foo"]}});
+        var Derived = Complex.extend({$type: {props: ["foo"]}});
         var Derived2 = Derived.extend();
 
         var fooPropType = Derived2.type.get("foo");
@@ -119,7 +119,7 @@ define([
           bar: {}
         };
 
-        var derivedType = Complex.extend({type: {props: ["foo"]}}).type;
+        var derivedType = Complex.extend({$type: {props: ["foo"]}}).type;
         var fooPropType = derivedType.get("foo");
 
         spyOn(fooPropType, "toSpecInContext").and.returnValue({});
@@ -137,7 +137,7 @@ define([
       });
 
       it("should call propertyType#toSpecInContext and push its result to spec.props", function() {
-        var derivedType = Complex.extend({type: {props: ["foo"]}}).type;
+        var derivedType = Complex.extend({$type: {props: ["foo"]}}).type;
         var fooPropType = derivedType.get("foo");
 
         var propTypeSpec = {};

--- a/impl/client/src/test/javascript/pentaho/type/complex.Type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.Type.spec.js
@@ -57,7 +57,7 @@ define([
             expect(Derived.type.count).toBe(0);
 
             Derived = Complex.extend({
-              type: {
+              $type: {
                 props: []
               }
             });
@@ -67,7 +67,7 @@ define([
 
           it("#each should never call the mapping function", function() {
             var Derived = Complex.extend({
-              type: {
+              $type: {
                 props: []
               }
             });
@@ -82,7 +82,7 @@ define([
 
           it("should inherit the base class' properties", function() {
             var A = Complex.extend({
-              type: {
+              $type: {
                 props: ["fooBar", "guru"]
               }
             });
@@ -99,7 +99,7 @@ define([
 
         describe("when specified with a single 'string' entry", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: ["fooBar"]
             }
           });
@@ -139,7 +139,7 @@ define([
 
         describe("when specified with two entries", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: ["fooBar", "guru"]
             }
           });
@@ -172,14 +172,14 @@ define([
 
         describe("when specified with with an entry that overrides a base type property", function() {
           var A = Complex.extend({
-            type: {
+            $type: {
               label: "A",
               props: ["fooBar", "guru"]
             }
           });
 
           var B = A.extend({
-            type: {
+            $type: {
               label: "B",
               props: [{name: "guru", label: "HELLO"}]
             }
@@ -206,14 +206,14 @@ define([
 
         describe("when specified with with an entry that is not a base type property", function() {
           var A = Complex.extend({
-            type: {
+            $type: {
               label: "A",
               props: ["fooBar", "guru"]
             }
           });
 
           var B = A.extend({
-            type: {
+            $type: {
               label: "B",
               props: [{name: "guru", label: "HELLO"}, {name: "babah"}]
             }
@@ -232,7 +232,7 @@ define([
         describe("when specified with with a dictionary", function() {
           it("should define the defined properties", function() {
             var A = Complex.extend({
-              type: {
+              $type: {
                 label: "A",
                 props: {"fooBar": {}, "guru": {}}
               }
@@ -252,7 +252,7 @@ define([
 
           it("should ignore undefined properties", function() {
             var A = Complex.extend({
-              type: {
+              $type: {
                 label: "A",
                 props: {"fooBar": {}, "guru": {}, "dada": null, "babah": undefined}
               }
@@ -268,7 +268,7 @@ define([
           it("should throw if a property specifies a name different from the key", function() {
             expect(function() {
               Complex.extend({
-                type: {
+                $type: {
                   label: "A",
                   props: {"fooBar": {name: "babah"}}
                 }
@@ -282,14 +282,14 @@ define([
     describe(".implement(...)", function() {
       it("should be possible to configure existing properties with a dictionary", function() {
         var A = Complex.extend({
-          type: {
+          $type: {
             label: "A",
             props: ["x", "y"]
           }
         });
 
         A.implement({
-          type: {
+          $type: {
             props: {
               "x": {label: "labelX"},
               "y": {label: "labelY"}
@@ -315,11 +315,11 @@ define([
     });
 
     describe("#has(name)", function() {
-      var Derived = Complex.extend({type: {
+      var Derived = Complex.extend({$type: {
         props: ["foo", "bar"]
       }});
 
-      var DerivedB = Derived.extend({type: {
+      var DerivedB = Derived.extend({$type: {
         props: [{name: "bar", label: "HELLO"}]
       }});
 
@@ -343,7 +343,7 @@ define([
 
       it("should return false when given the type object of a property from a different complex type", function() {
         var OtherDerived = Complex.extend({
-          type: {
+          $type: {
             props: ["fooBar"]
           }
         });
@@ -364,7 +364,7 @@ define([
 
     describe("#at(index[, sloppy])", function() {
 
-      var Derived = Complex.extend({type: {
+      var Derived = Complex.extend({$type: {
         props: ["foo", "bar"]
       }});
 
@@ -407,7 +407,7 @@ define([
     });
 
     describe("#get(name[, sloppy])", function() {
-      var Derived = Complex.extend({type: {
+      var Derived = Complex.extend({$type: {
         props: ["foo", "bar"]
       }});
 
@@ -468,7 +468,7 @@ define([
 
       describe("when given a property type object from a different complex type", function() {
         var OtherDerived = Complex.extend({
-          type: {
+          $type: {
             props: ["fooBar"]
           }
         });
@@ -483,7 +483,7 @@ define([
 
     describe("#count", function() {
       it("should return the number of properties of a type with properties", function() {
-        var Derived = Complex.extend({type: {
+        var Derived = Complex.extend({$type: {
           props: ["foo", "bar"]
         }});
         expect(Derived.type.count).toBe(2);
@@ -498,7 +498,7 @@ define([
     describe("#add", function() {
       it("should add new properties", function() {
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: []
           }
         });
@@ -520,7 +520,7 @@ define([
       it("should call f once for each property of the type", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -539,7 +539,7 @@ define([
       it("should call f once for each property of the type passing the index as second argument", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -558,7 +558,7 @@ define([
       it("should call f once for each property of the type passing this as the third argument", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -577,7 +577,7 @@ define([
       it("should call f on the given x", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -595,7 +595,7 @@ define([
       it("should return this", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -612,7 +612,7 @@ define([
       it("should stop iteration if f returns false", function() {
 
         var SampleType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -630,7 +630,7 @@ define([
       it("should call f for inherited properties", function() {
 
         var RootType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -639,7 +639,7 @@ define([
         });
 
         var SampleType = RootType.extend({
-          type: {
+          $type: {
             props: [
               {name: "c", valueType: "string"},
               {name: "d", valueType: "string"}
@@ -663,7 +663,7 @@ define([
       it("should call f once for each corresponding property of the common base type", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -686,7 +686,7 @@ define([
          "passing the index as second argument", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -709,7 +709,7 @@ define([
           "passing this as third argument", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -731,7 +731,7 @@ define([
       it("should call f on the given x", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -752,7 +752,7 @@ define([
       it("should return this", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -774,7 +774,7 @@ define([
         var BaseType = Complex.extend();
 
         var SubTypeA = BaseType.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -782,7 +782,7 @@ define([
         });
 
         var SubTypeB = BaseType.extend({
-          type: {
+          $type: {
             props: [
               {name: "b", valueType: "string"}
             ]
@@ -799,7 +799,7 @@ define([
       it("should stop iteration if f returns false", function() {
 
         var BaseType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -820,7 +820,7 @@ define([
       it("should call f for inherited properties", function() {
 
         var RootType = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"},
               {name: "b", valueType: "string"}
@@ -829,7 +829,7 @@ define([
         });
 
         var BaseType = RootType.extend({
-          type: {
+          $type: {
             props: [
               {name: "c", valueType: "string"},
               {name: "d", valueType: "string"}
@@ -855,7 +855,7 @@ define([
         var BaseType = Complex.extend();
 
         var SubTypeA = BaseType.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]
@@ -863,7 +863,7 @@ define([
         });
 
         var SubTypeB = BaseType.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: "string"}
             ]

--- a/impl/client/src/test/javascript/pentaho/type/complex.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.serialization.spec.js
@@ -28,7 +28,7 @@ define([
     var Complex = context.get("pentaho/type/complex");
 
     var TestLevel1 = Complex.extend("TestLevel1", {
-      type: {
+      $type: {
         label: "TestLevel1",
         props: [
           "type"
@@ -37,7 +37,7 @@ define([
     });
 
     var TestLevel2 = TestLevel1.extend("TestLevel2", {
-      type: {
+      $type: {
         label: "TestLevel2",
         props: [
           "name"
@@ -46,7 +46,7 @@ define([
     });
 
     var Derived = Complex.extend({
-      type: {
+      $type: {
         label: "Derived",
         props: [
           {name: "quantity", valueType: "number"},
@@ -154,7 +154,7 @@ define([
           });
         });
 
-        describe("= value.type", function() {
+        describe("= value.$type", function() {
 
           describe("when keyArgs.forceType", function() {
 
@@ -163,7 +163,7 @@ define([
               describe("when keyArgs.preferPropertyArray: false", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -171,7 +171,7 @@ define([
                 });
 
                 it("should not include the type", function() {
-                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -182,7 +182,7 @@ define([
               describe("when keyArgs.preferPropertyArray: true", function() {
 
                 it("should return an Array", function() {
-                  var spec = value.toSpecInContext({declaredType: value.type, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({declaredType: value.$type, preferPropertyArray: true});
 
                   scope.dispose();
 
@@ -196,7 +196,7 @@ define([
               describe("when keyArgs.preferPropertyArray: false", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -204,7 +204,7 @@ define([
                 });
 
                 it("should not include the type", function() {
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -215,7 +215,7 @@ define([
               describe("when keyArgs.preferPropertyArray: true", function() {
 
                 it("should return an Array", function() {
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type, preferPropertyArray: true});
 
                   scope.dispose();
 
@@ -229,7 +229,7 @@ define([
               describe("when keyArgs.preferPropertyArray: false", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -237,7 +237,7 @@ define([
                 });
 
                 it("should include the type", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -248,7 +248,7 @@ define([
               describe("when keyArgs.preferPropertyArray: true", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type, preferPropertyArray: true});
 
                   scope.dispose();
 
@@ -256,7 +256,7 @@ define([
                 });
 
                 it("should include the type", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type, preferPropertyArray: true});
 
                   scope.dispose();
 
@@ -267,7 +267,7 @@ define([
           });
         });
 
-        describe("= ascendant.type", function() {
+        describe("= ascendant.$type", function() {
 
           describe("when keyArgs.forceType", function() {
 
@@ -277,7 +277,7 @@ define([
 
                 it("should return a plain Object", function() {
 
-                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -286,7 +286,7 @@ define([
 
                 it("should include the type", function() {
 
-                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -298,7 +298,7 @@ define([
 
                 it("should return a plain Object", function() {
 
-                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -307,7 +307,7 @@ define([
 
                 it("should include the type", function() {
 
-                  var spec = value.toSpecInContext({declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -322,7 +322,7 @@ define([
 
                 it("should return a plain Object", function() {
 
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -331,7 +331,7 @@ define([
 
                 it("should include the type", function() {
 
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -343,7 +343,7 @@ define([
 
                 it("should return a plain Object", function() {
 
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -352,7 +352,7 @@ define([
 
                 it("should not include the type", function() {
 
-                  var spec = value.toSpecInContext({forceType: false, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: false, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -366,7 +366,7 @@ define([
               describe("when keyArgs.preferPropertyArray: false", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -374,7 +374,7 @@ define([
                 });
 
                 it("should include the type", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: false});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type.ancestor, preferPropertyArray: false});
 
                   scope.dispose();
 
@@ -385,7 +385,7 @@ define([
               describe("when keyArgs.preferPropertyArray: true", function() {
 
                 it("should return a plain Object", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type.ancestor, preferPropertyArray: true});
 
                   scope.dispose();
 
@@ -393,7 +393,7 @@ define([
                 });
 
                 it("should include the type", function() {
-                  var spec = value.toSpecInContext({forceType: true, declaredType: value.type.ancestor, preferPropertyArray: true});
+                  var spec = value.toSpecInContext({forceType: true, declaredType: value.$type.ancestor, preferPropertyArray: true});
 
                   scope.dispose();
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -184,10 +184,10 @@ define([
       });
     });
 
-    describe("#key", function() {
+    describe("#$key", function() {
       it("should return the value of #uid", function() {
         var value = new Complex();
-        expect(value.$uid).toBe(value.key);
+        expect(value.$uid).toBe(value.$key);
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -87,7 +87,7 @@ define([
 
       it("should have type.count = 0", function() {
         var complex = new Complex({});
-        expect(complex.type.count).toBe(0);
+        expect(complex.$type.count).toBe(0);
       });
     });
 
@@ -96,7 +96,7 @@ define([
 
       beforeEach(function() {
         Derived = Complex.extend({
-          type: {
+          $type: {
             label: "Derived",
             props: [
               "x",
@@ -196,7 +196,7 @@ define([
       describe("#get(name[, sloppy])", function() {
         it("should return the `Value` of an existing singular property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
+            $type: {props: [{name: "x", valueType: "string"}]}
           });
 
           var derived = new Derived({x: "1"});
@@ -209,7 +209,7 @@ define([
 
         it("should return the value of an existing property given its type object", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
+            $type: {props: [{name: "x", valueType: "string"}]}
           });
 
           var derived = new Derived({x: "1"});
@@ -225,7 +225,7 @@ define([
 
         it("should return the `List` value of an existing list property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"]}]}
+            $type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
           var derived = new Derived();
@@ -238,7 +238,7 @@ define([
 
         it("should return the same `List` of an existing list property every time", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"]}]}
+            $type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
           var derived = new Derived({x: ["1"]});
@@ -262,7 +262,7 @@ define([
 
         describe("when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -281,7 +281,7 @@ define([
       describe("#getv(name[, sloppy])", function() {
 
         var Derived = Complex.extend({
-          type: {props: [
+          $type: {props: [
             {name: "x", valueType: "string"},
             {name: "z", valueType: "object"}
           ]}
@@ -325,7 +325,7 @@ define([
 
       describe("#getf(name[, sloppy])", function() {
 
-        var Derived = Complex.extend({type: {
+        var Derived = Complex.extend({$type: {
           props: [
             {name: "x", valueType: "string"},
             {name: "z", valueType: "object"}
@@ -372,7 +372,7 @@ define([
       describe("#set(name, valueSpec)", function() {
         it("should set the value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
+            $type: {props: [{name: "x", valueType: "string"}]}
           });
 
           var derived = new Derived();
@@ -386,7 +386,7 @@ define([
         it("should throw a TypeError if the property is read-only", function() {
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string", isReadOnly: true, defaultValue: "2"}]}
+            $type: {props: [{name: "x", valueType: "string", isReadOnly: true, defaultValue: "2"}]}
           });
 
           var derived = new Derived();
@@ -400,7 +400,7 @@ define([
 
         it("should set the value of an existing list property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"]}]}
+            $type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
           var derived = new Derived();
@@ -414,7 +414,7 @@ define([
 
         it("should keep the value of property if the new is equals", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
+            $type: {props: [{name: "x", valueType: "string"}]}
           });
 
           var derived = new Derived({"x": "1"});
@@ -430,7 +430,7 @@ define([
 
         it("should replace the value of property if the new is different", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
+            $type: {props: [{name: "x", valueType: "string"}]}
           });
 
           var derived = new Derived({"x": "1"});
@@ -446,7 +446,7 @@ define([
 
         it("should throw when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -461,7 +461,7 @@ define([
           var complex;
           var THREE = 3;
           var Derived = Complex.extend({
-            type: {props: [
+            $type: {props: [
               {name: "x", valueType: "number"},
               {name: "y", valueType: ["number"]}
             ]}
@@ -638,7 +638,7 @@ define([
 
         describe("when `name` is that of an element property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           describe("when the property value is null", function() {
@@ -660,7 +660,7 @@ define([
 
         describe("when `name` is that of a list property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"]}]}
+            $type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
           var result;
@@ -691,7 +691,7 @@ define([
         it("should make the list of a read-only list property, read-only", function() {
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"], isReadOnly: true}]}
+            $type: {props: [{name: "x", valueType: ["string"], isReadOnly: true}]}
           });
 
           var derived = new Derived();
@@ -702,7 +702,7 @@ define([
         it("should make the list of a writable list property, writable", function() {
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: ["string"]}]}
+            $type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
           var derived = new Derived();
@@ -714,7 +714,7 @@ define([
       describe("#isApplicableOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", isApplicable: false}]}
+            $type: {props: [{name: "x", isApplicable: false}]}
           });
 
           var derived = new Derived();
@@ -724,7 +724,7 @@ define([
 
         it("should return the evaluated dynamic value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [{
                 name: "x", isApplicable: function() {
                   return this.foo;
@@ -746,7 +746,7 @@ define([
 
         it("should throw when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -758,10 +758,10 @@ define([
 
         it("should throw when given a property type object not owned by the complex, " +
            "even if of same name as an existing one", function() {
-          var Other = Complex.extend({type: {props: [{name: "x"}]}});
+          var Other = Complex.extend({$type: {props: [{name: "x"}]}});
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -775,7 +775,7 @@ define([
       describe("#isEnabledOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", isEnabled: true}]}
+            $type: {props: [{name: "x", isEnabled: true}]}
           });
 
           var derived = new Derived();
@@ -785,7 +785,7 @@ define([
 
         it("should return the evaluated dynamic value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [{
                 name: "x", isEnabled: function() {
                   return this.foo;
@@ -807,7 +807,7 @@ define([
 
         it("should throw when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -819,10 +819,10 @@ define([
 
         it("should throw when given a property type object not owned by the complex, " +
            "even if of same name as an existing one", function() {
-          var Other = Complex.extend({type: {props: [{name: "x"}]}});
+          var Other = Complex.extend({$type: {props: [{name: "x"}]}});
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -836,7 +836,7 @@ define([
       describe("#isRequiredOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", isRequired: true}]}
+            $type: {props: [{name: "x", isRequired: true}]}
           });
 
           var derived = new Derived();
@@ -846,7 +846,7 @@ define([
 
         it("should return the evaluated dynamic value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [{
                 name: "x", isRequired: function() {
                   return this.foo;
@@ -868,7 +868,7 @@ define([
 
         it("should throw when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -880,10 +880,10 @@ define([
 
         it("should throw when given a property type object not owned by the complex, " +
            "even if of same name as an existing one", function() {
-          var Other = Complex.extend({type: {props: [{name: "x"}]}});
+          var Other = Complex.extend({$type: {props: [{name: "x"}]}});
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -897,7 +897,7 @@ define([
       describe("#countRangeOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x", countMin: 1, countMax: 1}]}
+            $type: {props: [{name: "x", countMin: 1, countMax: 1}]}
           });
 
           var derived = new Derived();
@@ -909,7 +909,7 @@ define([
 
         it("should return the evaluated dynamic value of an existing property", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [{
                 name: "x", countMin: function() {
                   return this.fooMin;
@@ -931,7 +931,7 @@ define([
 
         it("should throw when given the name of an undefined property", function() {
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -943,10 +943,10 @@ define([
 
         it("should throw when the given property type object is not owned by the complex, " +
            "even if of an existing name", function() {
-          var Other = Complex.extend({type: {props: [{name: "x"}]}});
+          var Other = Complex.extend({$type: {props: [{name: "x"}]}});
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -962,7 +962,7 @@ define([
         it("should return the evaluated value of an existing property", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: "string", domain: ["1", "2", "3"]}
               ]
@@ -982,7 +982,7 @@ define([
         it("should throw when given the name of an undefined property", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: "string"}
               ]
@@ -999,10 +999,10 @@ define([
         it("should throw when given a property type object not owned by the complex, " +
             "even if of same name as an existing one", function() {
 
-          var Other = Complex.extend({type: {props: [{name: "x"}]}});
+          var Other = Complex.extend({$type: {props: [{name: "x"}]}});
 
           var Derived = Complex.extend({
-            type: {props: [{name: "x"}]}
+            $type: {props: [{name: "x"}]}
           });
 
           var derived = new Derived();
@@ -1042,7 +1042,7 @@ define([
       it("should create an object having the same element value instances", function() {
         var MyComplex1 = Complex.extend();
         var MyComplex2 = Complex.extend({
-          type: {
+          $type: {
             props: ["a", "b", {name: "c", valueType: MyComplex1}]
           }
         });
@@ -1057,7 +1057,7 @@ define([
       it("should create an object having distinct list value instances but the same list elements", function() {
         var MyComplex1 = Complex.extend();
         var MyComplex2 = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "a", valueType: [MyComplex1]}
             ]
@@ -1081,8 +1081,8 @@ define([
 
       describe("when config is a complex that is not a subtype of it", function() {
         it("should do nothing, even if properties has the same names and types", function() {
-          var Derived1 = Complex.extend({type: {props: ["a", "b"]}});
-          var Derived2 = Complex.extend({type: {props: ["a", "b"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a", "b"]}});
+          var Derived2 = Complex.extend({$type: {props: ["a", "b"]}});
 
           var derived1 = new Derived1({a: "a1", b: "b1"});
           var derived2 = new Derived2({a: "a2", b: "b2"});
@@ -1100,7 +1100,7 @@ define([
       describe("when config is a complex from a subtype of it", function() {
 
         it("should copy all base properties", function() {
-          var Derived1 = Complex.extend({type: {props: ["a", "b"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a", "b"]}});
           var Derived2 = Derived1.extend();
 
           var derived1 = new Derived1({a: "a1", b: "b1"});
@@ -1116,8 +1116,8 @@ define([
         });
 
         it("should copy all base properties even when overridden", function() {
-          var Derived1 = Complex.extend({type: {props: ["a"]}});
-          var Derived2 = Derived1.extend({type: {props: [
+          var Derived1 = Complex.extend({$type: {props: ["a"]}});
+          var Derived2 = Derived1.extend({$type: {props: [
             {name: "a", label: "A2"}
           ]}});
 
@@ -1132,8 +1132,8 @@ define([
         });
 
         it("should copy ignore properties of the subtype", function() {
-          var Derived1 = Complex.extend({type: {props: ["a"]}});
-          var Derived2 = Derived1.extend({type: {props: ["c"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a"]}});
+          var Derived2 = Derived1.extend({$type: {props: ["c"]}});
 
           var derived1 = new Derived1({a: "a1"});
           var derived2 = new Derived2({a: "a2", c: "c2"});
@@ -1146,7 +1146,7 @@ define([
         });
 
         it("should copy when target property is null and config is not", function() {
-          var Derived1 = Complex.extend({type: {props: ["a"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a"]}});
           var Derived2 = Derived1.extend();
 
           var derived1 = new Derived1();
@@ -1160,7 +1160,7 @@ define([
         });
 
         it("should copy when config property is null and target is not", function() {
-          var Derived1 = Complex.extend({type: {props: ["a"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a"]}});
           var Derived2 = Derived1.extend();
 
           var derived1 = new Derived1({a: "a1"});
@@ -1177,7 +1177,7 @@ define([
       describe("when config is a not a complex", function() {
 
         it("should copy all own properties", function() {
-          var Derived1 = Complex.extend({type: {props: ["a", "b"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a", "b"]}});
 
           var derived1 = new Derived1({a: "a1", b: "b1"});
           var derived2 = {a: "a2", b: "b2"};
@@ -1192,7 +1192,7 @@ define([
         });
 
         it("should ignore non-own properties", function() {
-          var Derived1 = Complex.extend({type: {props: ["a", "b"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a", "b"]}});
 
           var derived1 = new Derived1({a: "a1", b: "b1"});
           var derived2 = Object.create({a: "a3"});
@@ -1208,7 +1208,7 @@ define([
         });
 
         it("should throw on an undefined property (non-sloppy)", function() {
-          var Derived1 = Complex.extend({type: {props: ["a", "b"]}});
+          var Derived1 = Complex.extend({$type: {props: ["a", "b"]}});
 
           var derived1 = new Derived1({a: "a1", b: "b1"});
           var derived2 = {c: "c2"};
@@ -1224,7 +1224,7 @@ define([
 
       it("should be called when a complex container is set to this value", function() {
         var Derived = Complex.extend();
-        var Container = Complex.extend({type: {props: [{name: "a", valueType: Derived}]}});
+        var Container = Complex.extend({$type: {props: [{name: "a", valueType: Derived}]}});
 
         spyOn(Derived.prototype, "__addReference");
 
@@ -1236,7 +1236,7 @@ define([
 
       it("should be called with the complex container and its property type", function() {
         var Derived = Complex.extend();
-        var Container = Complex.extend({type: {props: [{name: "a", valueType: Derived}]}});
+        var Container = Complex.extend({$type: {props: [{name: "a", valueType: Derived}]}});
 
         spyOn(Derived.prototype, "__addReference");
 
@@ -1248,7 +1248,7 @@ define([
 
       it("should be called when added to a list container", function() {
         var Derived = Complex.extend();
-        var Container = Complex.extend({type: {props: [{name: "as", valueType: [Derived]}]}});
+        var Container = Complex.extend({$type: {props: [{name: "as", valueType: [Derived]}]}});
 
         spyOn(Derived.prototype, "__addReference");
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -23,6 +23,8 @@ define([
 
   /* global describe:false, it:false, expect:false, beforeEach:false */
 
+  /* eslint max-nested-callbacks: 0 */
+
   var context = new Context();
   var Value = context.get("value");
   var Complex = context.get("complex");
@@ -173,9 +175,9 @@ define([
       });
 
       it("should have a distinct value for every instance", function() {
-        var uid1 = new Complex().$uid,
-          uid2 = new Complex().$uid,
-          uid3 = new Complex().$uid;
+        var uid1 = new Complex().$uid;
+        var uid2 = new Complex().$uid;
+        var uid3 = new Complex().$uid;
         expect(uid1).not.toBe(uid2);
         expect(uid2).not.toBe(uid3);
         expect(uid3).not.toBe(uid1);
@@ -319,7 +321,7 @@ define([
 
           expect(derived.getv("z", 0, false)).toBe(v);
         });
-      }); // end atv
+      }); // end getv
 
       describe("#getf(name[, sloppy])", function() {
 
@@ -355,7 +357,7 @@ define([
 
           expectIt(["x", false], "");
           expectIt(["x", false], "");
-          expectIt(["y",  true], "");
+          expectIt(["y", true], "");
         });
 
         it("should return the toString() of the result of `get`, if it is not nully", function() {
@@ -365,7 +367,7 @@ define([
 
           expect(derived.getf("z", false)).toBe(f);
         });
-      }); // end atf
+      }); // end getf
 
       describe("#set(name, valueSpec)", function() {
         it("should set the value of an existing property", function() {
@@ -455,14 +457,15 @@ define([
         });
 
         describe("events -", function() {
-          var listeners, complex;
-          var THREE = 3,
-              Derived = Complex.extend({
-                type: {props: [
-                  {name: "x", valueType: "number"},
-                  {name: "y", valueType: ["number"]}
-                ]}
-              });
+          var listeners;
+          var complex;
+          var THREE = 3;
+          var Derived = Complex.extend({
+            type: {props: [
+              {name: "x", valueType: "number"},
+              {name: "y", valueType: ["number"]}
+            ]}
+          });
 
           beforeEach(function() {
             listeners = jasmine.createSpyObj("listeners", [
@@ -476,21 +479,22 @@ define([
             complex = new Derived({x: 0});
           });
 
-
           describe("Without listeners -", function() {
+
             it("should not call _emitSafe.", function() {
+
               spyOn(complex, "_emitSafe");
 
               complex.set("x", 1);
               expect(complex._emitSafe).not.toHaveBeenCalled();
             });
-          }); //end without listeners
+          }); // end without listeners
 
           describe("With listeners -", function() {
             beforeEach(function() {
-              complex.on("will:change",     listeners.will);
+              complex.on("will:change", listeners.will);
               complex.on("rejected:change", listeners.rejected);
-              complex.on("did:change",      listeners.did);
+              complex.on("did:change", listeners.did);
             });
 
             it("should call the will change listener", function() {
@@ -588,8 +592,8 @@ define([
 
               expect(listeners.will).toHaveBeenCalled();
 
-              expect(complex.atv("y", 0)).toBe(1);
-              expect(complex.atv("y", 1)).toBe(2);
+              expect(complex.y.at(0).value).toBe(1);
+              expect(complex.y.at(1).value).toBe(2);
             });
 
             it("should allow changing directly the list value from within the `will:change` event", function() {
@@ -610,408 +614,15 @@ define([
           }); // end with listeners
         });
       }); // end set
-
-      describe("#path(steps[, sloppy])", function() {
-
-        function buildGetter(derived) {
-          return function(args) {
-            return derived.path.apply(derived, args);
-          };
-        }
-
-        describe("when given an empty steps array", function() {
-          var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
-          });
-          var derived = new Derived({x: "1"});
-          var getter  = buildGetter(derived);
-
-          var result  = derived;
-          sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [[]], result);
-        });
-
-        describe("when all the steps are _defined_ along the way", function() {
-
-          describe("when given a property name", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: "string"}]}
-            });
-            var simple  = new PentahoString(1);
-            var derived = new Derived({x: simple});
-            var getter  = buildGetter(derived);
-
-            var result  = simple;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x"]], result);
-          });
-
-          describe("when given a property name and an index", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: ["string"]}]}
-            });
-            var simple1 = new PentahoString(1);
-            var simple2 = new PentahoString(2);
-            var derived = new Derived({x: [simple1, simple2]});
-            var getter  = buildGetter(derived);
-
-            var result  = simple1;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", 0]], result);
-
-            result  = simple2;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", 1]], result);
-          });
-
-          describe("when given a property name and a list element key", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: ["string"]}]}
-            });
-            var simple1 = new PentahoString(1);
-            var simple2 = new PentahoString(2);
-            var derived = new Derived({x: [simple1, simple2]});
-            var getter  = buildGetter(derived);
-
-            var result  = simple1;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", "1"]], result);
-
-            result  = simple2;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", "2"]], result);
-          });
-
-          describe("when given a path having multiple steps", function() {
-            var Derived = Complex.extend({
-              type: {
-                props: [
-                  {
-                    name: "x", valueType: [
-                    {
-                      props: [
-                        {name: "y", valueType: ["string"]}
-                      ]
-                    }
-                  ]
-                  }
-                ]
-              }
-            });
-            var simple1 = new PentahoString(1);
-            var simple2 = new PentahoString(2);
-            var derived = new Derived({x: [{y: [simple1, simple2]}]});
-            var getter  = buildGetter(derived);
-            var result  = simple2;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", 0, "y", 1]], result);
-          });
-        });
-
-        describe("when some steps are _undefined_ along the way", function() {
-          describe("when a property has a null value", function() {
-            var Derived = Complex.extend({
-              type: {
-                props: [
-                  {
-                    name: "x",
-                    valueType: {
-                      props: [
-                        {name: "y", valueType: ["number"]}
-                      ]
-                    }
-                  }
-                ]
-              }
-            });
-            var derived = new Derived({x: null});
-            var getter  = buildGetter(derived);
-            var result  = null;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", "y", 1]], result);
-          });
-
-          describe("when an index is out of range", function() {
-            var Derived = Complex.extend({
-              type: {
-                props: [
-                  {
-                    name: "x",
-                    valueType: {
-                      props: [
-                        {name: "y", valueType: ["number"]}
-                      ]
-                    }
-                  }
-                ]
-              }
-            });
-            var derived = new Derived({x: {y: [1]}});
-            var getter  = buildGetter(derived);
-            var result  = null;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, [["x", "y", 1]], result);
-          });
-
-          describe("when a property is undefined", function() {
-            var Derived = Complex.extend({
-              type: {
-                props: [
-                  {
-                    name: "x",
-                    valueType: {
-                      props: [
-                        {name: "y", valueType: ["number"]}
-                      ]
-                    }
-                  }
-                ]
-              }
-            });
-
-            var derived = new Derived({x: {y: [1]}});
-            var getter  = buildGetter(derived);
-            var sloppyResult;// = undefined;
-            var strictError = errorMatch.argInvalid("name");
-            sloppyModeUtil.itShouldBehaveStrictlyUnlessSloppyIsTrue(getter, [["x", "z", 1]], sloppyResult, strictError);
-          });
-        });
-      });
-
-      describe("#path(step1, step2, ...)", function() {
-        it("should call `_path` with ([step1, step2, ...], false)", function() {
-          var Derived = Complex.extend({
-            type: {props: [{name: "x", valueType: "string"}]}
-          });
-
-          function expectIt(args) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "_path");
-
-            derived.path.apply(derived, args);
-
-            var realArgs = derived._path.calls.argsFor(0);
-            expect(realArgs.length).toBe(2);
-            expect(Array.prototype.slice.call(realArgs[0])).toEqual(args);
-            expect(realArgs[1]).toBe(false);
-          }
-
-          expectIt(["x"]);
-          expectIt(["x", "1"]);
-          expectIt(["1"]);
-          expectIt([1]);
-          expectIt([]);
-        });
-      }); // end path
     });
 
     describe("Property As List", function() {
 
-      describe("#at(name, index[, sloppy])", function() {
-
-        describe("when `name` is not that of a defined property", function() {
-          var Derived = Complex.extend();
-          var derived = new Derived();
-
-          var getter = function(args) {
-            return derived.at.apply(derived, args);
-          };
-
-          var sloppyResult;// = undefined;
-          var strictError = errorMatch.argInvalid("name");
-          sloppyModeUtil.itShouldBehaveStrictlyUnlessSloppyIsTrue(getter, ["y", 0], sloppyResult, strictError);
-        });
-
-        describe("when `name` is that of an element property", function() {
-
-          describe("when index is 0 and the property value is non-null", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: "string"}]}
-            });
-
-            var derived = new Derived({x: "1"});
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var elem = derived.get("x");
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", 0], elem);
-          });
-
-          describe("when index is <> 0 and the property value is non-null", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: "string"}]}
-            });
-
-            var derived = new Derived({x: "1"});
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var result = null;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", -1], result);
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", +1], result);
-          });
-
-          describe("when the property value is null, for any non-null index", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: "string"}]}
-            });
-
-            var derived = new Derived();
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var result = null;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", -1], result);
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x",  0], result);
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", +1], result);
-          });
-
-          describe("when index is nully", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: "string"}]}
-            });
-
-            var derived = new Derived();
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var strictError = errorMatch.argRequired("index");
-            sloppyModeUtil.itShouldThrowWhateverTheSloppyValue(getter, ["x", null], strictError);
-            sloppyModeUtil.itShouldThrowWhateverTheSloppyValue(getter, ["x", undefined], strictError);
-          });
-        });
-
-        describe("when `name` is that of a list property", function() {
-          describe("when index exists", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: ["string"]}]}
-            });
-
-            var derived = new Derived({"x": ["1", "2"]});
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var list = derived.get("x");
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", 0], list.at(0));
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", 1], list.at(1));
-          });
-
-          describe("when index is out of range", function() {
-            var Derived = Complex.extend({
-              type: {props: [{name: "x", valueType: ["string"]}]}
-            });
-
-            var derived = new Derived({"x": ["1", "2"]});
-
-            var getter = function(args) {
-              return derived.at.apply(derived, args);
-            };
-
-            var result = null;
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", -1], result);
-            sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x", +2], result);
-          });
-        });
-      }); // end at
-
-      describe("#atv(name, index[, sloppy])", function() {
-
-        var Derived = Complex.extend({
-          type: {props: [
-            {name: "x", valueType: "string"},
-            {name: "z", valueType: "object"}
-          ]}
-        });
-
-        it("should call `at` with the given arguments", function() {
-
-          function expectIt(args, argsExpected) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "at");
-
-            derived.atv.apply(derived, args);
-
-            expect(derived.at.calls.argsFor(0)).toEqual(argsExpected);
-          }
-
-          expectIt(["x", 0], ["x", 0, undefined]);
-          expectIt(["x", 0, true], ["x", 0, true]);
-        });
-
-        it("should return the result of `at`, if it is nully", function() {
-          var derived = new Derived();
-
-          function expectIt(args, resultExpected) {
-            expect(derived.atv.apply(derived, args)).toBe(resultExpected);
-          }
-
-          expectIt(["x", 0, false], null);
-          expectIt(["x", 1, false], null);
-          expectIt(["y", 0,  true], undefined);
-        });
-
-        it("should return the value of the result of `at`, if it is not nully", function() {
-          var v = {};
-          var derived = new Derived({z: {v: v}});
-
-          expect(derived.atv("z", 0, false)).toBe(v);
-        });
-      }); // end atv
-
-      describe("#atf(name, index[, sloppy])", function() {
-
-        var Derived = Complex.extend({type: {
-          props: [
-            {name: "x", valueType: "string"},
-            {name: "z", valueType: "object"}
-          ]
-        }});
-
-        it("should call `at` with the given arguments", function() {
-
-          function expectIt(args, argsExpected) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "at");
-
-            derived.atf.apply(derived, args);
-
-            expect(derived.at.calls.argsFor(0)).toEqual(argsExpected);
-          }
-
-          expectIt(["x", 0], ["x", 0, undefined]);
-          expectIt(["x", 0, true], ["x", 0, true]);
-        });
-
-        it("should return '' if the result of `at` is nully", function() {
-          var derived = new Derived();
-
-          function expectIt(args, resultExpected) {
-            expect(derived.atf.apply(derived, args)).toBe(resultExpected);
-          }
-
-          expectIt(["x", 0, false], "");
-          expectIt(["x", 1, false], "");
-          expectIt(["y", 0,  true], "");
-        });
-
-        it("should return the toString() of the result of `at`, if it is not nully", function() {
-          var v = {};
-          var f = "foo";
-          var derived = new Derived({z: {v: v, f: f}});
-
-          expect(derived.atf("z", 0, false)).toBe(f);
-        });
-      }); // end atf
-
-      describe("#count(name[, sloppy])", function() {
+      describe("#countOf(name[, sloppy])", function() {
 
         function buildGetter(derived) {
           return function(args) {
-            return derived.count.apply(derived, args);
+            return derived.countOf.apply(derived, args);
           };
         }
 
@@ -1052,7 +663,9 @@ define([
             type: {props: [{name: "x", valueType: ["string"]}]}
           });
 
-          var result, derived, getter;
+          var result;
+          var derived;
+          var getter;
 
           // ---
           derived = new Derived([[1]]);
@@ -1068,121 +681,7 @@ define([
           result = 2;
           sloppyModeUtil.itShouldReturnValueWhateverTheSloppyValue(getter, ["x"], result);
         });
-      }); // end count
-    });
-
-    describe("Property As Element", function() {
-
-      describe("#first(name[, sloppy])", function() {
-        var Derived = Complex.extend({type: {
-          props: [
-            {name: "x", valueType: "string"},
-            {name: "z", valueType: "string"}
-          ]
-        }});
-
-        it("should call `at` with (name, 0, sloppy)", function() {
-
-          function expectIt(args, argsExpected) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "at");
-
-            derived.first.apply(derived, args);
-
-            expect(derived.at.calls.argsFor(0)).toEqual(argsExpected);
-          }
-
-          expectIt(["x"], ["x", 0, undefined]);
-          expectIt(["x", true], ["x", 0, true]);
-          expectIt(["x", false], ["x", 0, false]);
-        });
-
-        it("should return the value returned by at", function() {
-          var derived = new Derived({x: "1"});
-
-          expect(derived.first("x").value).toBe("1");
-          expect(derived.first("y", true)).toBe(undefined);
-          expect(derived.first("z")).toBe(null);
-        });
-      }); // end first
-
-      describe("#firstv(name[, sloppy])", function() {
-        var Derived = Complex.extend({type: {
-          props: [
-            {name: "x", valueType: "string"},
-            {name: "z", valueType: "object"}
-          ]
-        }});
-
-        it("should call `atv` with (name, 0, sloppy)", function() {
-
-          function expectIt(args, argsExpected) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "atv");
-
-            derived.firstv.apply(derived, args);
-
-            expect(derived.atv.calls.argsFor(0)).toEqual(argsExpected);
-          }
-
-          expectIt(["x"], ["x", 0, undefined]);
-          expectIt(["x", true], ["x", 0, true]);
-          expectIt(["x", false], ["x", 0, false]);
-        });
-
-        it("should return the value returned by atv", function() {
-          var v = {};
-          var derived = new Derived({x: "1", z: {v: v}});
-
-          expect(derived.firstv("x")).toBe("1");
-          expect(derived.firstv("y", true)).toBe(undefined);
-          expect(derived.firstv("z")).toBe(v);
-
-          derived = new Derived();
-          expect(derived.firstv("x")).toBe(null);
-        });
-      }); // end firstv
-
-      describe("#firstf(name[, sloppy])", function() {
-        var Derived = Complex.extend({type: {
-          props: [
-            {name: "x", valueType: "string"},
-            {name: "z", valueType: "object"}
-          ]
-        }});
-
-        it("should call `atf` with (name, 0, sloppy)", function() {
-
-          function expectIt(args, argsExpected) {
-            var derived = new Derived({x: "1"});
-
-            spyOn(derived, "atf");
-
-            derived.firstf.apply(derived, args);
-
-            expect(derived.atf.calls.argsFor(0)).toEqual(argsExpected);
-          }
-
-          expectIt(["x"], ["x", 0, undefined]);
-          expectIt(["x", true], ["x", 0, true]);
-          expectIt(["x", false], ["x", 0, false]);
-        });
-
-        it("should return the value returned by atf", function() {
-          var v = {};
-          var f = "foo";
-          var derived = new Derived({x: "1", z: {v: v, f: f}});
-
-          expect(derived.firstf("x")).toBe("1");
-          expect(derived.firstf("y", true)).toBe("");
-          expect(derived.firstf("z")).toBe(f);
-
-          derived = new Derived();
-          expect(derived.firstf("x")).toBe("");
-        });
-      }); // end firstf
+      }); // end countOf
     });
 
     describe("Property Attributes", function() {
@@ -1212,7 +711,7 @@ define([
         });
       });
 
-      describe("#isApplicable(name)", function() {
+      describe("#isApplicableOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
             type: {props: [{name: "x", isApplicable: false}]}
@@ -1220,7 +719,7 @@ define([
 
           var derived = new Derived();
 
-          expect(derived.isApplicable("x")).toBe(false);
+          expect(derived.isApplicableOf("x")).toBe(false);
         });
 
         it("should return the evaluated dynamic value of an existing property", function() {
@@ -1238,11 +737,11 @@ define([
 
           derived.foo = true;
 
-          expect(derived.isApplicable("x")).toBe(true);
+          expect(derived.isApplicableOf("x")).toBe(true);
 
           derived.foo = false;
 
-          expect(derived.isApplicable("x")).toBe(false);
+          expect(derived.isApplicableOf("x")).toBe(false);
         });
 
         it("should throw when given the name of an undefined property", function() {
@@ -1253,7 +752,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isApplicable("y");
+            derived.isApplicableOf("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1268,12 +767,12 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isApplicable(Other.type.get("x"));
+            derived.isApplicableOf(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end applicable
+      }); // end isApplicableOf
 
-      describe("#isEnabled(name)", function() {
+      describe("#isEnabledOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
             type: {props: [{name: "x", isEnabled: true}]}
@@ -1281,7 +780,7 @@ define([
 
           var derived = new Derived();
 
-          expect(derived.isEnabled("x")).toBe(true);
+          expect(derived.isEnabledOf("x")).toBe(true);
         });
 
         it("should return the evaluated dynamic value of an existing property", function() {
@@ -1299,11 +798,11 @@ define([
 
           derived.foo = false;
 
-          expect(derived.isEnabled("x")).toBe(false);
+          expect(derived.isEnabledOf("x")).toBe(false);
 
           derived.foo = true;
 
-          expect(derived.isEnabled("x")).toBe(true);
+          expect(derived.isEnabledOf("x")).toBe(true);
         });
 
         it("should throw when given the name of an undefined property", function() {
@@ -1314,7 +813,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isEnabled("y");
+            derived.isEnabledOf("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1329,12 +828,12 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isEnabled(Other.type.get("x"));
+            derived.isEnabledOf(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end isEnabled
+      }); // end isEnabledOf
 
-      describe("#isRequired(name)", function() {
+      describe("#isRequiredOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
             type: {props: [{name: "x", isRequired: true}]}
@@ -1342,7 +841,7 @@ define([
 
           var derived = new Derived();
 
-          expect(derived.isRequired("x")).toBe(true);
+          expect(derived.isRequiredOf("x")).toBe(true);
         });
 
         it("should return the evaluated dynamic value of an existing property", function() {
@@ -1360,11 +859,11 @@ define([
 
           derived.foo = true;
 
-          expect(derived.isRequired("x")).toBe(true);
+          expect(derived.isRequiredOf("x")).toBe(true);
 
           derived.foo = false;
 
-          expect(derived.isRequired("x")).toBe(false);
+          expect(derived.isRequiredOf("x")).toBe(false);
         });
 
         it("should throw when given the name of an undefined property", function() {
@@ -1375,7 +874,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isRequired("y");
+            derived.isRequiredOf("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1390,12 +889,12 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.isRequired(Other.type.get("x"));
+            derived.isRequiredOf(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end required
+      }); // end isRequiredOf
 
-      describe("#countRange(name)", function() {
+      describe("#countRangeOf(name)", function() {
         it("should return the evaluated static value of an existing property", function() {
           var Derived = Complex.extend({
             type: {props: [{name: "x", countMin: 1, countMax: 1}]}
@@ -1403,7 +902,7 @@ define([
 
           var derived = new Derived();
 
-          var range = derived.countRange("x");
+          var range = derived.countRangeOf("x");
           expect(range.min).toBe(1);
           expect(range.max).toBe(1);
         });
@@ -1423,11 +922,11 @@ define([
 
           derived.fooMin = 0;
 
-          expect(derived.countRange("x").min).toBe(0);
+          expect(derived.countRangeOf("x").min).toBe(0);
 
           derived.fooMin = 1;
 
-          expect(derived.countRange("x").min).toBe(1);
+          expect(derived.countRangeOf("x").min).toBe(1);
         });
 
         it("should throw when given the name of an undefined property", function() {
@@ -1438,7 +937,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.countRange("y");
+            derived.countRangeOf("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1453,12 +952,12 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.countRange(Other.type.get("x"));
+            derived.countRangeOf(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end countRange
+      }); // end countRangeOf
 
-      describe("#getPropDomain(name)", function() {
+      describe("#domainOf(name)", function() {
 
         it("should return the evaluated value of an existing property", function() {
 
@@ -1472,7 +971,7 @@ define([
 
           var derived = new Derived();
 
-          var domain = derived.getPropDomain("x");
+          var domain = derived.domainOf("x");
           expect(Array.isArray(domain)).toBe(true);
           expect(domain.length).toBe(3);
           expect(domain[0].value).toBe("1");
@@ -1493,7 +992,7 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.getPropDomain("y");
+            derived.domainOf("y");
           }).toThrow(errorMatch.argInvalid("name"));
         });
 
@@ -1509,10 +1008,10 @@ define([
           var derived = new Derived();
 
           expect(function() {
-            derived.getPropDomain(Other.type.get("x"));
+            derived.domainOf(Other.type.get("x"));
           }).toThrow(errorMatch.argInvalid("name"));
         });
-      }); // end getPropDomain
+      }); // end domainOf
 
     });
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -696,7 +696,7 @@ define([
 
           var derived = new Derived();
 
-          expect(derived.x.isReadOnly).toBe(true);
+          expect(derived.x.$isReadOnly).toBe(true);
         });
 
         it("should make the list of a writable list property, writable", function() {
@@ -707,7 +707,7 @@ define([
 
           var derived = new Derived();
 
-          expect(derived.x.isReadOnly).toBe(false);
+          expect(derived.x.$isReadOnly).toBe(false);
         });
       });
 

--- a/impl/client/src/test/javascript/pentaho/type/complex.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.validation.spec.js
@@ -29,7 +29,7 @@ define([
     describe("#validate()", function() {
       it("should call each property's validateOn with the owner complex instance", function() {
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: "number"},
               {name: "y", valueType: "string"},
@@ -40,9 +40,9 @@ define([
 
         var derived = new Derived({x: 5, y: "a", z: true});
 
-        var xPropType = derived.type.get("x");
-        var yPropType = derived.type.get("y");
-        var zPropType = derived.type.get("z");
+        var xPropType = derived.$type.get("x");
+        var yPropType = derived.$type.get("y");
+        var zPropType = derived.$type.get("z");
 
         spyOn(xPropType, "validateOn");
         spyOn(yPropType, "validateOn");

--- a/impl/client/src/test/javascript/pentaho/type/instance.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/instance.spec.js
@@ -79,35 +79,35 @@ define([
       });
 
       it("should have name receive the type `id` when name is not specified", function() {
-        var Derived = Instance.extend({type: {id: "foo"}});
+        var Derived = Instance.extend({$type: {id: "foo"}});
         expect(Derived.name || Derived.displayName).toBe("foo");
       });
 
       it("should set the corresponding type constructor name by suffixing '.Type' when " +
           "the name name of the instance constructor is defaulted from the id", function() {
-        var Derived = Instance.extend({type: {id: "foo"}});
+        var Derived = Instance.extend({$type: {id: "foo"}});
         expect(Derived.Type.name || Derived.Type.displayName).toBe("foo.Type");
       });
 
       it("should have name receive the type's `sourceId` when name is not specified", function() {
-        var Derived = Instance.extend({type: {sourceId: "foo"}});
+        var Derived = Instance.extend({$type: {sourceId: "foo"}});
         expect(Derived.name || Derived.displayName).toBe("foo");
       });
 
       it("should respect name when specified and not use the type's `id` or `sourceId`", function() {
-        var Derived = Instance.extend("foo", {type: {id: "bar"}});
+        var Derived = Instance.extend("foo", {$type: {id: "bar"}});
 
         expect(Derived.name || Derived.displayName).toBe("foo");
 
         // ----
 
-        Derived = Instance.extend("foo", {type: {sourceId: "bar"}});
+        Derived = Instance.extend("foo", {$type: {sourceId: "bar"}});
 
         expect(Derived.name || Derived.displayName).toBe("foo");
       });
 
       it("should allow a type factory module id to default the type name", function() {
-        var Derived = Instance.extend({type: {id: "my/special/model"}});
+        var Derived = Instance.extend({$type: {id: "my/special/model"}});
         expect(Derived.name || Derived.displayName).toBe("my.special.Model");
       });
     }); // .extend({...})
@@ -115,14 +115,14 @@ define([
     describe("get/set type of a derived class - ", function() {
       var Derived;
       beforeEach(function() {
-        Derived = Instance.extend({type: {"someAttribute": "someValue"}});
+        Derived = Instance.extend({$type: {"someAttribute": "someValue"}});
       });
 
       it("setting a falsy type has no consequence", function() {
         ["", null, undefined, false, 0, {}].forEach(function(type) {
           Derived.type = type;
           var inst = new Derived();
-          expect(inst.type.someAttribute).toBe("someValue");
+          expect(inst.$type.someAttribute).toBe("someValue");
         });
       });
 
@@ -140,23 +140,23 @@ define([
       });
 
       it("sets/gets some type attribute correctly", function() {
-        expect(inst.type.someAttribute).toBeUndefined();
-        inst.type = {someAttribute: "someValue"};
-        expect(inst.type.someAttribute).toBe("someValue");
+        expect(inst.$type.someAttribute).toBeUndefined();
+        inst.$type= {someAttribute: "someValue"};
+        expect(inst.$type.someAttribute).toBe("someValue");
       });
 
       it("setting type to a falsy value has no consequence", function() {
         ["", null, undefined, false, 0].forEach(function(value) {
-          inst.type = value;
-          expect(inst.type).not.toBeFalsy();
+          inst.$type = value;
+          expect(inst.$type).not.toBeFalsy();
         });
       });
 
       it("setting type to an empty object has no consequence", function() {
-        var id = inst.type.id;
-        inst.type = {};
-        expect(inst.type).not.toBeFalsy();
-        expect(inst.type.id).toBe(id);
+        var id = inst.$type.id;
+        inst.$type = {};
+        expect(inst.$type).not.toBeFalsy();
+        expect(inst.$type.id).toBe(id);
       });
     });
   }); // pentaho.type.Instance

--- a/impl/client/src/test/javascript/pentaho/type/list.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.Type.serialization.spec.js
@@ -82,7 +82,7 @@ define([
 
       describe("#id", function() {
         it("should serialize the #id of a type using #id when no alias is defined", function() {
-          var derivedType = List.extend({type: {id: "pentaho/type/test"}}).type;
+          var derivedType = List.extend({$type: {id: "pentaho/type/test"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -95,7 +95,7 @@ define([
         });
 
         it("should serialize the #id of a type using #alias when an alias is defined", function() {
-          var derivedType = List.extend({type: {id: "pentaho/type/test", alias: "test"}}).type;
+          var derivedType = List.extend({$type: {id: "pentaho/type/test", alias: "test"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -109,7 +109,7 @@ define([
 
         it("should serialize with an anonymous #id when the type is anonymous", function() {
           // Force generic object spec by specifying a label.
-          var derivedType = List.extend({type: {label: "Foo"}}).type;
+          var derivedType = List.extend({$type: {label: "Foo"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -124,7 +124,7 @@ define([
 
         it("should serialize with the existing anonymous id, " +
             "already in the scope, when the type is anonymous", function() {
-          var derivedType = List.extend({type: {label: "Foo"}}).type;
+          var derivedType = List.extend({$type: {label: "Foo"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -156,7 +156,7 @@ define([
       describe("#of", function() {
         it("should serialize the #of of a type when it is different from base", function() {
           // Force generic object spec by specifying a label.
-          var derivedType = List.extend({type: {of: "string", label: "Foo"}}).type;
+          var derivedType = List.extend({$type: {of: "string", label: "Foo"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -170,7 +170,7 @@ define([
 
         it("should not serialize the #of of a type when it is inherited", function() {
           // Force generic object spec by specifying a label.
-          var derivedType = List.extend({type: {label: "Foo"}}).type;
+          var derivedType = List.extend({$type: {label: "Foo"}}).type;
 
           var scope = new SpecificationScope();
 

--- a/impl/client/src/test/javascript/pentaho/type/list.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.serialization.spec.js
@@ -72,7 +72,7 @@ define([
         it("should return an empty array for an empty list", function() {
 
           var list = new List();
-          var spec = list.toSpec({declaredType: list.type});
+          var spec = list.toSpec({declaredType: list.$type});
 
           expect(spec).toEqual([]);
         });
@@ -80,7 +80,7 @@ define([
         it("should return an array of serialized elements for a list of elements", function() {
 
           var list = new NumberList([1, 2, 3]);
-          var spec = list.toSpec({declaredType: list.type});
+          var spec = list.toSpec({declaredType: list.$type});
 
           expect(spec).toEqual([1, 2, 3]);
         });
@@ -90,7 +90,7 @@ define([
           it("should return a spec with an inline type and an empty 'd' property, for an empty list", function() {
 
             var list = new List();
-            var spec = list.toSpec({forceType: true, declaredType: list.type});
+            var spec = list.toSpec({forceType: true, declaredType: list.$type});
 
             expect(spec).toEqual({_: jasmine.any(String), d: []});
           });
@@ -99,7 +99,7 @@ define([
               "array of serialized elements for a list of elements", function() {
 
             var list = new NumberList([1, 2, 3]);
-            var spec = list.toSpec({forceType: true, declaredType: list.type});
+            var spec = list.toSpec({forceType: true, declaredType: list.$type});
 
             expect(spec).toEqual({_: jasmine.any(Object), d: [1, 2, 3]});
           });
@@ -111,7 +111,7 @@ define([
         it("should return a spec with an inline type and an empty 'd' property, for an empty list", function() {
 
           var list = new List();
-          var spec = list.toSpec({declaredType: list.type.ancestor});
+          var spec = list.toSpec({declaredType: list.$type.ancestor});
 
           expect(spec).toEqual({_: jasmine.any(String), d: []});
         });
@@ -120,7 +120,7 @@ define([
            "array of serialized elements for a list of elements", function() {
 
           var list = new NumberList([1, 2, 3]);
-          var spec = list.toSpec({declaredType: list.type.ancestor});
+          var spec = list.toSpec({declaredType: list.$type.ancestor});
 
           expect(spec).toEqual({_: jasmine.any(Object), d: [1, 2, 3]});
         });

--- a/impl/client/src/test/javascript/pentaho/type/list.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.spec.js
@@ -316,10 +316,10 @@ define([
       });
     });
 
-    describe("#key -", function() {
+    describe("#$key -", function() {
       it("should return the value of #uid", function() {
         var value = new List();
-        expect(value.$uid).toBe(value.key);
+        expect(value.$uid).toBe(value.$key);
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/type/list.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.spec.js
@@ -40,7 +40,7 @@ define([
   }
 
   var NumberList = List.extend({
-    type: {of: PentahoNumber}
+    $type: {of: PentahoNumber}
   });
 
   describe("pentaho.type.List -", function() {
@@ -67,7 +67,7 @@ define([
       it("should throw if given a nully `of` property", function() {
         expect(function() {
           List.extend({
-            type: {of: null}
+            $type: {of: null}
           });
         }).toThrow(errorMatch.argRequired("of"));
       });
@@ -76,14 +76,14 @@ define([
         var DerivedList = List.extend();
         expect(DerivedList.type.of).toBe(List.type.of);
 
-        DerivedList = List.extend({type: {of: undefined}});
+        DerivedList = List.extend({$type: {of: undefined}});
         expect(DerivedList.type.of).toBe(List.type.of);
       });
 
       it("should throw if given a null `of` property", function() {
         expect(function() {
           List.extend({
-            type: {of: null}
+            $type: {of: null}
           });
         }).toThrow(errorMatch.argRequired("of"));
       });
@@ -91,7 +91,7 @@ define([
       it("should throw if given an `of` property of a type not a subtype of `Element`", function() {
         expect(function() {
           List.extend({
-            type: {of: Value}
+            $type: {of: Value}
           });
         }).toThrow(errorMatch.argInvalid("of"));
       });
@@ -672,7 +672,7 @@ define([
       it("should emit will and did change events on the containing complex object", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: {
               foo: {valueType: NumberList}
             }
@@ -835,7 +835,7 @@ define([
       it("should emit will and did change events on the containing complex object", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: {
               foo: {valueType: NumberList, defaultValue: [1, 2, 3]}
             }
@@ -945,7 +945,7 @@ define([
       it("should emit will and did change events on the containing complex object", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: {
               foo: {valueType: NumberList, defaultValue: [1, 2, 3]}
             }
@@ -999,7 +999,7 @@ define([
       it("should emit will and did change events on the containing complex object", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: {
               foo: {valueType: NumberList, defaultValue: [1, 2, 3, 4]}
             }
@@ -1168,7 +1168,7 @@ define([
 
       it("preserves the order of new elements when they are complex objects", function() {
         var MyComplex = Complex.extend({
-          type: {
+          $type: {
             props: [{
               name: "k",
               valueType: "number"
@@ -1177,7 +1177,7 @@ define([
         });
 
         var ComplexList = List.extend({
-          type: {of: MyComplex}
+          $type: {of: MyComplex}
         });
 
         var list = new ComplexList();
@@ -1319,7 +1319,7 @@ define([
       it("should emit will and did change events on the containing complex object", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: {
               foo: {valueType: NumberList, defaultValue: [4, 2, 1, 3]}
             }

--- a/impl/client/src/test/javascript/pentaho/type/list.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.spec.js
@@ -540,20 +540,20 @@ define([
     });
     // endregion
 
-    // region isReadOnly
-    describe("#isReadOnly", function() {
+    // region $isReadOnly
+    describe("#$isReadOnly", function() {
 
       it("should be false by default", function() {
         var list = new NumberList();
 
-        expect(list.isReadOnly).toBe(false);
+        expect(list.$isReadOnly).toBe(false);
       });
 
       it("should allow creating a read-only list by specifying keyArgs.isReadOnly: true", function() {
 
         var list = new NumberList(null, {isReadOnly: true});
 
-        expect(list.isReadOnly).toBe(true);
+        expect(list.$isReadOnly).toBe(true);
       });
     });
     // endregion
@@ -1379,7 +1379,7 @@ define([
 
         var clone = list.clone();
 
-        expect(clone.isReadOnly).toBe(false);
+        expect(clone.$isReadOnly).toBe(false);
       });
 
       it("should return a list instance with the same count", function() {

--- a/impl/client/src/test/javascript/pentaho/type/list.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.spec.js
@@ -36,7 +36,7 @@ define([
   var PentahoNumber = context.get(numberFactory);
 
   function expectNoChanges(list) {
-    expect(list.changeset).toBe(null);
+    expect(list.$changeset).toBe(null);
   }
 
   var NumberList = List.extend({

--- a/impl/client/src/test/javascript/pentaho/type/list.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/list.validation.spec.js
@@ -32,7 +32,7 @@ define([
       it("should call _validate(.) of the list element type with each of its members", function() {
         var PentahoNumber = context.get(numberFactory);
         var NumberList = List.extend({
-          type: {of: PentahoNumber}
+          $type: {of: PentahoNumber}
         });
 
         spyOn(PentahoNumber.type, "_validate");
@@ -52,7 +52,7 @@ define([
         var PentahoInteger = PentahoNumber.extend();
 
         var NumberList = List.extend({
-          type: {of: PentahoNumber}
+          $type: {of: PentahoNumber}
         });
 
         spyOn(PentahoInteger.type, "_validate");

--- a/impl/client/src/test/javascript/pentaho/type/mixins/discreteDomain.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/mixins/discreteDomain.spec.js
@@ -66,7 +66,7 @@ define([
           it("should default to an unset local value", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number"}]
               }
             });
@@ -79,13 +79,13 @@ define([
           it("should throw when set and property already has descendant properties", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number"}]
               }
             });
 
             ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA"}]
               }
             });
@@ -100,7 +100,7 @@ define([
           it("should respect a static value", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
@@ -119,7 +119,7 @@ define([
           it("should ignore setting to null or undefined", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
@@ -140,7 +140,7 @@ define([
           it("should cast non-function spec values to the property's elemType", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
@@ -153,7 +153,7 @@ define([
           it("should cast non-function spec values to the property's elemType when a list", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: ["number"], domain: [1, 2, 3]}]
               }
             });
@@ -168,7 +168,7 @@ define([
             var f = function() {};
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: f}]
               }
             });
@@ -183,7 +183,7 @@ define([
             var f = jasmine.createSpy().and.callFake(function() { return [1, 2, 3]; });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: f}]
               }
             });
@@ -207,7 +207,7 @@ define([
             var f = jasmine.createSpy();
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: f}]
               }
             });
@@ -226,7 +226,7 @@ define([
             var f = jasmine.createSpy();
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: f}]
               }
             });
@@ -244,14 +244,14 @@ define([
           it("should default to the domain of the value type when it is an enum type", function() {
 
             var MyString = PentahoString.extend({
-              type: {
+              $type: {
                 mixins: ["enum"],
                 domain: ["a", "b", "c"]
               }
             });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: MyString}]
               }
             });
@@ -271,14 +271,14 @@ define([
           it("should intersect with the domain of the value type when it is an enum type", function() {
 
             var MyString = PentahoString.extend({
-              type: {
+              $type: {
                 mixins: ["enum"],
                 domain: ["a", "b", "c"]
               }
             });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: MyString, domain: ["b", "c"]}]
               }
             });
@@ -297,14 +297,14 @@ define([
           it("should use the order in the domain attribute even when the value type is an enum type", function() {
 
             var MyString = PentahoString.extend({
-              type: {
+              $type: {
                 mixins: ["enum"],
                 domain: ["a", "b", "c"]
               }
             });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: MyString, domain: ["c", "b"]}]
               }
             });
@@ -324,14 +324,14 @@ define([
               "is an enum type", function() {
 
             var MyString = PentahoString.extend({
-              type: {
+              $type: {
                 mixins: ["enum"],
                 domain: [{v: "a", f: "AA"}]
               }
             });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: MyString, domain: [{v: "a", f: "AAA"}]}]
               }
             });
@@ -350,14 +350,14 @@ define([
           it("should use the formatted value of the enum when the domain attribute has no formatted value", function() {
 
             var MyString = PentahoString.extend({
-              type: {
+              $type: {
                 mixins: ["enum"],
                 domain: [{v: "a", f: "AA"}]
               }
             });
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: MyString, domain: ["a"]}]
               }
             });
@@ -379,13 +379,13 @@ define([
           it("should evaluate to the domain of the base property when unspecified", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
 
             var ComplexB = ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA"}]
               }
             });
@@ -405,13 +405,13 @@ define([
           it("should evaluate to the intersection of the local and base domain", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
 
             var ComplexB = ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", domain: [1, 3]}]
               }
             });
@@ -430,13 +430,13 @@ define([
           it("should use the order of the local domain", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
               }
             });
 
             var ComplexB = ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", domain: [3, 2, 1]}]
               }
             });
@@ -456,13 +456,13 @@ define([
           it("should use the local formatted value, if there is one", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [{v: 1, f: "One"}]}]
               }
             });
 
             var ComplexB = ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", domain: [{v: 1, f: "Uno"}]}]
               }
             });
@@ -481,13 +481,13 @@ define([
           it("should use the base formatted value, when there isn't one locally", function() {
 
             var ComplexA = Complex.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", valueType: "number", domain: [{v: 1, f: "One"}]}]
               }
             });
 
             var ComplexB = ComplexA.extend({
-              type: {
+              $type: {
                 props: [{name: "propA", domain: [{v: 1}]}]
               }
             });
@@ -511,7 +511,7 @@ define([
         it("should validate that a singular property has as value one of the domain values", function() {
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
             }
           });
@@ -528,7 +528,7 @@ define([
         it("should validate that a plural property does contains only domain values", function() {
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: ["number"], domain: [1, 2, 3]}]
             }
           });
@@ -545,7 +545,7 @@ define([
         it("should validate that a singular property does not have as value one of the domain values", function() {
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
             }
           });
@@ -564,7 +564,7 @@ define([
         it("should validate that a plural property does not contain one of the domain values", function() {
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: ["number"], domain: [1, 2, 3]}]
             }
           });
@@ -590,7 +590,7 @@ define([
           var scope = new SpecificationScope();
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
             }
           });
@@ -614,13 +614,13 @@ define([
           var scope = new SpecificationScope();
 
           var ComplexA = Complex.extend({
-            type: {
+            $type: {
               props: [{name: "propA", valueType: "number", domain: [1, 2, 3]}]
             }
           });
 
           var ComplexB = ComplexA.extend({
-            type: {
+            $type: {
               props: [{name: "propA"}]
             }
           });

--- a/impl/client/src/test/javascript/pentaho/type/mixins/enum.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/mixins/enum.spec.js
@@ -39,7 +39,7 @@ define([
       it("should throw if extended", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: [Enum],
             domain: [1, 2, 3]
           }
@@ -57,7 +57,7 @@ define([
 
         expect(function() {
           PentahoNumber.extend({
-            type: {
+            $type: {
               mixins: [Enum]
             }
           });
@@ -67,7 +67,7 @@ define([
       it("should respect the specified domain", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: [Enum],
             domain: [1, 2, 3]
           }
@@ -90,7 +90,7 @@ define([
 
         function expectIt(newDomain) {
           var MyNumber = PentahoNumber.extend({
-            type: {
+            $type: {
               mixins: Enum,
               domain: [1, 2, 3]
             }
@@ -115,7 +115,7 @@ define([
       it("should allow setting to an object after initialization, for configuration", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: Enum,
             domain: [1, 2, 3]
           }
@@ -144,7 +144,7 @@ define([
       it("should return null on a value that is equal to one of `domain`", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: Enum,
             domain: [1, 2, 3]
           }
@@ -158,7 +158,7 @@ define([
       it("should return an Error on a value that is not equal to one of `domain`", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: Enum,
             domain: [1, 2, 3]
           }
@@ -177,7 +177,7 @@ define([
       it("should serialize `domain` using array form", function() {
 
         var MyNumber = PentahoNumber.extend({
-          type: {
+          $type: {
             mixins: Enum,
             domain: [1, 2, 3]
           }
@@ -199,7 +199,7 @@ define([
 
       beforeEach(function() {
         MyString = PentahoString.extend({
-          type: {
+          $type: {
             mixins: Enum,
             domain: ["Xau", "Wow", "Beu"]
           }

--- a/impl/client/src/test/javascript/pentaho/type/model.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/model.spec.js
@@ -56,7 +56,7 @@ define([
 
       it("should be valid without an application defined", function() {
         var m = new Model();
-        expect(m.isValid).toBe(true);
+        expect(m.$isValid).toBe(true);
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/type/object.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/object.spec.js
@@ -81,7 +81,7 @@ define([
       });
     });
 
-    describe("#key -", function() {
+    describe("#$key -", function() {
       var PentahoObject;
 
       beforeEach(function() {
@@ -89,22 +89,22 @@ define([
       });
 
       it("should return a string value", function() {
-        var key = new PentahoObject({v: {}}).key;
+        var key = new PentahoObject({v: {}}).$key;
         expect(typeof key).toBe("string");
       });
 
       it("should have distinct values for distinct primitive instances", function() {
         var emptyObjA = {};
         var emptyObjB = {};
-        var keyA = new PentahoObject({v: emptyObjA}).key;
-        var keyB = new PentahoObject({v: emptyObjB}).key;
+        var keyA = new PentahoObject({v: emptyObjA}).$key;
+        var keyB = new PentahoObject({v: emptyObjB}).$key;
         expect(keyA).not.toBe(keyB);
       });
 
       it("should have the same value for the same primitive instance", function() {
         var emptyObj = {};
-        var key1 = new PentahoObject({v: emptyObj}).key;
-        var key2 = new PentahoObject({v: emptyObj}).key;
+        var key1 = new PentahoObject({v: emptyObj}).$key;
+        var key2 = new PentahoObject({v: emptyObj}).$key;
         expect(key1).toBe(key2);
       });
     });

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
@@ -176,7 +176,7 @@ define([
                  "base": "property"
                },
                "name": "foo",
-               "type": "number"
+               "valueType": "number"
              }
          */
       });
@@ -279,10 +279,10 @@ define([
 
         scope.dispose();
 
-        expect(spec.type).toBe("string");
+        expect(spec.valueType).toBe("string");
 
         // console.log(JSON.stringify(spec));
-        // > {"base": "property", "type": "string"}
+        // > {"base": "property", "valueType": "string"}
       });
 
       it("should include `id` if defined when serializing an abstract property", function() {

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.serialization.spec.js
@@ -270,7 +270,7 @@ define([
       it("should include `type` if != from 'value' when serializing an abstract property", function() {
         var scope = new SpecificationScope();
 
-        var SubProperty = Property.extend({type: {valueType: "string"}});
+        var SubProperty = Property.extend({$type: {valueType: "string"}});
         var propType = SubProperty.type;
 
         spyOn(propType, "_fillSpecInContext").and.returnValue(false);
@@ -290,7 +290,7 @@ define([
 
         spyOn(Property.type, "_fillSpecInContext").and.returnValue(false);
 
-        var SubProperty = Property.extend({type: {id: "my/foo"}});
+        var SubProperty = Property.extend({$type: {id: "my/foo"}});
         var propType = SubProperty.type;
 
         var spec = propType.toSpecInContext();

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.spec.js
@@ -154,7 +154,7 @@ define([
           var Complex2 = context2.get("complex");
           expect(function() {
             Property.extend({
-              type: {name: "foo"}
+              $type: {name: "foo"}
             }, null, {
               declaringType: Complex2.type,
               index: 1,
@@ -437,7 +437,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend({
-            type: {name: "foo1"}
+            $type: {name: "foo1"}
           }, null, {
             declaringType: Derived2.type
           }); // keyArgs
@@ -636,7 +636,7 @@ define([
           var Derived2 = Derived.extend();
 
           propType.instance.constructor.extend(
-              {type: {name: "foo1"}}, null,
+              {$type: {name: "foo1"}}, null,
               {declaringType: Derived2.type}); // keyArgs
 
           expect(function() {
@@ -739,7 +739,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend(
-              {type: {name: "foo"}}, // spec
+              {$type: {name: "foo"}}, // spec
               null,
               {declaringType: Derived2.type}); // keyArgs
 
@@ -938,7 +938,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend(
-              {type: {name: "foo"}}, // spec
+              {$type: {name: "foo"}}, // spec
               null,
               {declaringType: Derived2.type}); // keyArgs
 
@@ -1057,7 +1057,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend(
-              {type: {name: "foo"}}, // spec
+              {$type: {name: "foo"}}, // spec
               null,
               {declaringType: Derived2.type}); // keyArgs
 
@@ -1159,7 +1159,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend(
-              {type: {name: "foo"}}, // spec
+              {$type: {name: "foo"}}, // spec
               null,
               {declaringType: Derived2.type}); // keyArgs
 
@@ -1261,7 +1261,7 @@ define([
 
           // Create a descendant property
           propType.instance.constructor.extend(
-              {type: {name: "foo"}}, // spec
+              {$type: {name: "foo"}}, // spec
               null,
               {declaringType: Derived2.type}); // keyArgs
 
@@ -1397,7 +1397,7 @@ define([
           var context2 = new Context();
           var Property2 = context2.get("property")
                 .implement({
-                  type: {
+                  $type: {
                     dynamicAttributes: {
                       isFoo: {
                         defaultValue: false,
@@ -1415,7 +1415,7 @@ define([
 
           var fValue = function() { return true; };
           var SubProperty2 = Property2.extend({
-            type: {
+            $type: {
               isFoo: fValue
             }
           });
@@ -1444,7 +1444,7 @@ define([
 
         it("should read the valueOf of the value of the property", function() {
           var Derived2 = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "foo", valueType: "string"}
               ]
@@ -1458,7 +1458,7 @@ define([
 
         it("should set the value of the property", function() {
           var Derived2 = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "foo", valueType: "string"}
               ]
@@ -2270,7 +2270,7 @@ define([
 
         it("should allow deriving the base property type without specifying it", function() {
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "postalCode", valueType: PentahoString}
               ]
@@ -2278,7 +2278,7 @@ define([
           });
 
           var Derived2 = Derived.extend({
-            type: {
+            $type: {
               props: [
                 {name: "postalCode", valueType: {}}
               ]

--- a/impl/client/src/test/javascript/pentaho/type/property.Type.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/property.Type.validation.spec.js
@@ -40,7 +40,7 @@ define([
 
         beforeEach(function() {
           Derived = Complex.extend({
-            type: {
+            $type: {
               label: "Derived",
               props: [
                 {name: "x", valueType: "string", isRequired: true},
@@ -66,7 +66,7 @@ define([
 
       it("should be considered valid when not applicable", function() {
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: "string", isRequired: true, isApplicable: false}
             ]
@@ -86,7 +86,7 @@ define([
       it("should call value.validate when not null and singular", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: "string"}
             ]
@@ -109,7 +109,7 @@ define([
       it("should call value.validate when not null and plural", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: ["string"]}
             ]
@@ -132,7 +132,7 @@ define([
       it("should call _validateValueOn with owner and value when not null and singular", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: "string"}
             ]
@@ -154,7 +154,7 @@ define([
       it("should call _validateValueOn with owner and value when not null and plural", function() {
 
         var Derived = Complex.extend({
-          type: {
+          $type: {
             props: [
               {name: "x", valueType: ["string"]}
             ]
@@ -181,7 +181,7 @@ define([
         it("should call _collectElementValidators with a function, the owner and value", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: "string"}
               ]
@@ -204,7 +204,7 @@ define([
             "with the owner, value and 0-index", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: "string"}
               ]
@@ -230,7 +230,7 @@ define([
         it("should fail validation with errors returned by validators", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: "string"}
               ]
@@ -261,7 +261,7 @@ define([
         it("should not call _collectElementValidators if list is empty", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: ["string"]}
               ]
@@ -282,7 +282,7 @@ define([
         it("should call _collectElementValidators with a function, the owner and value", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: ["string"]}
               ]
@@ -305,7 +305,7 @@ define([
             "with the owner, element and index", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: ["string"]}
               ]
@@ -334,7 +334,7 @@ define([
         it("should fail validation with errors returned by validators", function() {
 
           var Derived = Complex.extend({
-            type: {
+            $type: {
               props: [
                 {name: "x", valueType: ["string"]}
               ]

--- a/impl/client/src/test/javascript/pentaho/type/propertyTypeUtil.js
+++ b/impl/client/src/test/javascript/pentaho/type/propertyTypeUtil.js
@@ -34,7 +34,7 @@ define([
     var Property = declaringType.context.get(baseId || "property");
 
     var SubProperty = Property.extend({
-      type: typeSpec
+      $type: typeSpec
     }, null, {
       declaringType: declaringType,
       index: 1,
@@ -49,7 +49,7 @@ define([
     var basePropType = declaringType.ancestor.get(baseProperty);
     var BaseProperty = basePropType.instance.constructor;
     var SubProperty = BaseProperty.extend({
-      type: subPropTypeSpec
+      $type: subPropTypeSpec
     }, null, {
       declaringType: declaringType,
       index: -1,

--- a/impl/client/src/test/javascript/pentaho/type/serializationUtil.js
+++ b/impl/client/src/test/javascript/pentaho/type/serializationUtil.js
@@ -28,7 +28,7 @@ define([
   };
 
   function fillSpec(BaseInstCtor, spec, typeSpec, keyArgs) {
-    var derivedType = BaseInstCtor.extend({type: typeSpec}).type;
+    var derivedType = BaseInstCtor.extend({$type: typeSpec}).type;
 
     var scope = new SpecificationScope();
 

--- a/impl/client/src/test/javascript/pentaho/type/simple.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/simple.spec.js
@@ -199,10 +199,10 @@ define([
       });
     });
 
-    describe("#key -", function() {
+    describe("#$key -", function() {
       it("Should convert the given value to a string", function() {
         var simple1 = new Simple(123);
-        expect(simple1.key).toBe(String(123));
+        expect(simple1.$key).toBe(String(123));
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/type/simple.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/simple.spec.js
@@ -282,7 +282,7 @@ define([
         });
 
         it("should be overridable", function() {
-          var Derived = Simple.extend({type: {
+          var Derived = Simple.extend({$type: {
             cast: function(v) {
               return v * 2;
             }
@@ -292,13 +292,13 @@ define([
         });
 
         it("should be possible to call base", function() {
-          var Derived1 = Simple.extend({type: {
+          var Derived1 = Simple.extend({$type: {
             cast: function(v) {
               return v * 2;
             }
           }});
 
-          var Derived2 = Derived1.extend({type: {
+          var Derived2 = Derived1.extend({$type: {
             cast: function(v) {
               return this.base(v) * 5;
             }

--- a/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.Type.serialization.spec.js
@@ -101,7 +101,7 @@ define([
 
       describe("#id", function() {
         it("should serialize the #id of a type using #shortId, if an #alias is defined", function() {
-          var derivedType = Value.extend({type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
+          var derivedType = Value.extend({$type: {id: "pentaho/type/test", alias: "testAlias"}}).type;
 
           var scope = new SpecificationScope();
 
@@ -114,7 +114,7 @@ define([
         });
 
         it("should serialize the #id of a type using #shortId, if an #alias is not defined", function() {
-          var derivedType = Value.extend({type: {id: "pentaho/type/test"}}).type;
+          var derivedType = Value.extend({$type: {id: "pentaho/type/test"}}).type;
 
           var scope = new SpecificationScope();
 

--- a/impl/client/src/test/javascript/pentaho/type/value.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.spec.js
@@ -94,8 +94,8 @@ define([
           var vb = new Value();
 
           // Override/Redefine getter property
-          Object.defineProperty(va, "key", {value: "A"});
-          Object.defineProperty(vb, "key", {value: "B"});
+          Object.defineProperty(va, "$key", {value: "A"});
+          Object.defineProperty(vb, "$key", {value: "B"});
 
           expect(va.type._isEqual(va, vb)).toBe(false);
         });
@@ -215,16 +215,16 @@ define([
 
     }); // .extend({...})
 
-    describe("#key", function() {
+    describe("#$key", function() {
       it("should return the result of toString()", function() {
         var va = new Value();
 
         spyOn(va, "toString").and.returnValue("FOOO");
 
-        expect(va.key).toBe("FOOO");
+        expect(va.$key).toBe("FOOO");
         expect(va.toString).toHaveBeenCalled();
       });
-    });// end #key
+    });// end #$key
 
     describe("#equals", function() {
       it("should return `true` if given the same value", function() {

--- a/impl/client/src/test/javascript/pentaho/type/value.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.spec.js
@@ -74,7 +74,7 @@ define([
           Object.defineProperty(va, "key", {value: "A"});
           Object.defineProperty(vb, "key", {value: "A"});
 
-          expect(va.type._isEqual(va, vb)).toBe(true);
+          expect(va.$type._isEqual(va, vb)).toBe(true);
         });
 
         it("should return `false` if two distinct values have different constructors and the same key", function() {
@@ -86,7 +86,7 @@ define([
           Object.defineProperty(va, "key", {value: "A"});
           Object.defineProperty(vb, "key", {value: "A"});
 
-          expect(va.type._isEqual(va, vb)).toBe(false);
+          expect(va.$type._isEqual(va, vb)).toBe(false);
         });
 
         it("should return `false` if two distinct values have the same constructor and different keys", function() {
@@ -97,13 +97,13 @@ define([
           Object.defineProperty(va, "$key", {value: "A"});
           Object.defineProperty(vb, "$key", {value: "B"});
 
-          expect(va.type._isEqual(va, vb)).toBe(false);
+          expect(va.$type._isEqual(va, vb)).toBe(false);
         });
       });
 
       describe("_areEqual(va, vb)", function() {
 
-        it("should call va.type._isEqual if va is a Value", function() {
+        it("should call va.$type._isEqual if va is a Value", function() {
           var Value2 = Value.extend();
 
           spyOn(Value2.type, "_isEqual").and.returnValue(true);
@@ -113,10 +113,10 @@ define([
 
           Value.type._areEqual(va, vb);
 
-          expect(va.type._isEqual).toHaveBeenCalledWith(va, vb);
+          expect(va.$type._isEqual).toHaveBeenCalledWith(va, vb);
         });
 
-        it("should call vb.type._isEqual if va is not a Value but vb is", function() {
+        it("should call vb.$type._isEqual if va is not a Value but vb is", function() {
           var Value2 = Value.extend();
 
           spyOn(Value2.type, "_isEqual").and.returnValue(true);
@@ -126,7 +126,7 @@ define([
 
           Value.type._areEqual(va, vb);
 
-          expect(vb.type._isEqual).toHaveBeenCalledWith(vb, va);
+          expect(vb.$type._isEqual).toHaveBeenCalledWith(vb, va);
         });
 
         it("should return false and not call Value.type._isEqual if neither va nor vb are Value instances", function() {
@@ -162,10 +162,10 @@ define([
         it("should return `true` when given the same value instances and not call the _areEqual method", function() {
           var va = new Value();
 
-          spyOn(va.type, "_areEqual").and.callThrough();
+          spyOn(va.$type, "_areEqual").and.callThrough();
 
           expect(Value.type.areEqual(va, va)).toBe(true);
-          expect(va.type._areEqual).not.toHaveBeenCalled();
+          expect(va.$type._areEqual).not.toHaveBeenCalled();
         });
 
         it("should call the _areEqual method when given two distinct, non-nully arguments", function() {
@@ -244,10 +244,10 @@ define([
         var va = new Value();
         var vb = new Value();
 
-        spyOn(va.type, "_isEqual").and.returnValue(false);
+        spyOn(va.$type, "_isEqual").and.returnValue(false);
 
         expect(va.equals(vb)).toBe(false);
-        expect(va.type._isEqual).toHaveBeenCalledWith(va, vb);
+        expect(va.$type._isEqual).toHaveBeenCalledWith(va, vb);
       });
     }); // end #equals
 

--- a/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
@@ -34,9 +34,9 @@ define([
         expect(va.validate()).toBe(null);
       });
 
-      it("should be overridable using {type: {instance: {}}", function() {
+      it("should be overridable using {$type: {instance: {}}", function() {
         var Derived = Value.extend({
-          type: {
+          $type: {
             instance: {
               validate: function() {
                 return [new ValidationError("Foo")];

--- a/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/value.validation.spec.js
@@ -50,26 +50,26 @@ define([
       });
     }); // #validate
 
-    describe("#isValid -", function() {
+    describe("#$isValid -", function() {
       it("should call #validate()", function() {
         var va = new Value();
         spyOn(va, "validate").and.returnValue(null);
-        var isValid = va.isValid;
+        var isValid = va.$isValid;
         expect(va.validate).toHaveBeenCalled();
       });
 
       it("should return `false` if #validate() returns a truthy value", function() {
         var va = new Value();
         spyOn(va, "validate").and.returnValue([new ValidationError()]);
-        expect(va.isValid).toBe(false);
+        expect(va.$isValid).toBe(false);
       });
 
       it("should return `true` if #validate() returns a nully value", function() {
         var va = new Value();
         spyOn(va, "validate").and.returnValue(null);
-        expect(va.isValid).toBe(true);
+        expect(va.$isValid).toBe(true);
       });
-    });// end #isValid
+    });// end #$isValid
 
     describe("#assertValid() -", function() {
       it("should not throw an error if the value is valid", function() {

--- a/impl/client/src/test/javascript/pentaho/visual/base/model.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/base/model.spec.js
@@ -184,7 +184,7 @@ define([
 
         beforeEach(function() {
 
-          DerivedModel = Model.extend({type: {
+          DerivedModel = Model.extend({$type: {
             props: [
               {name: "vr1", base: rolePropFactory},
               {name: "vr2", base: rolePropFactory},

--- a/impl/client/src/test/javascript/pentaho/visual/base/view.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/base/view.spec.js
@@ -960,7 +960,7 @@ define([
           model: model
         });
 
-        expect(view.isValid).toBe(true);
+        expect(view.$isValid).toBe(true);
 
         view.__dirtyPropGroups.clear(); // view is clean
 
@@ -1005,7 +1005,7 @@ define([
           model: model
         });
 
-        expect(view.isValid).toBe(true);
+        expect(view.$isValid).toBe(true);
 
         view.__dirtyPropGroups.clear(); // view is clean
 

--- a/impl/client/src/test/javascript/pentaho/visual/base/view.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/base/view.spec.js
@@ -871,7 +871,7 @@ define([
 
       beforeEach(function() {
         SubView = View.extend({
-          type: {
+          $type: {
             props: [
               {name: "foo", valueType: "string"}
             ]
@@ -1603,7 +1603,7 @@ define([
 
       it("should return a promise", function() {
 
-        var p = View.getClassAsync(model.type);
+        var p = View.getClassAsync(model.$type);
 
         expect(p instanceof Promise).toBe(true);
       });
@@ -1618,7 +1618,7 @@ define([
       it("should return a promise that is rejected when the type of model does not have " +
           "a registered view type", function() {
 
-        var SubModel = Model.extend({type: {defaultView: null}});
+        var SubModel = Model.extend({$type: {defaultView: null}});
 
         return testUtils.expectToRejectWith(View.getClassAsync(SubModel.type), {
           asymmetricMatch: function(error) { return error instanceof Error; }
@@ -1628,7 +1628,7 @@ define([
       it("should return a promise that is rejected when the type of model refers an " +
           "undefined view type", function() {
 
-        var SubModel = Model.extend({type: {defaultView: "test/foo/bar/view"}});
+        var SubModel = Model.extend({$type: {defaultView: "test/foo/bar/view"}});
 
         return testUtils.expectToRejectWith(View.getClassAsync(SubModel.type), {
           asymmetricMatch: function(error) { return error instanceof Error; }
@@ -1646,7 +1646,7 @@ define([
          "the registered default view type", function() {
 
         var SubView  = View.extend();
-        var SubModel = Model.extend({type: {defaultView: SubView}});
+        var SubModel = Model.extend({$type: {defaultView: SubView}});
 
         return View.getClassAsync(SubModel.type)
             .then(function(ViewCtor) {
@@ -1657,7 +1657,7 @@ define([
       it("should return a promise that is fulfilled with the view constructor of " +
           "the registered default view type identifier", function() {
 
-        var SubModel = Model.extend({type: {defaultView: "pentaho/visual/base/view"}});
+        var SubModel = Model.extend({$type: {defaultView: "pentaho/visual/base/view"}});
 
         return View.getClassAsync(SubModel.type)
             .then(function(ViewCtor) {
@@ -1710,7 +1710,7 @@ define([
               var View = context.get(baseViewFactory);
 
               return View.extend({
-                type: {
+                $type: {
                   id: "test/foo/view"
                 }
               });
@@ -1728,7 +1728,7 @@ define([
 
               return View.createAsync({_: "test/foo/view"}).then(function(fooView) {
                 expect(fooView instanceof View).toBe(true);
-                expect(fooView.type.id).toBe("test/foo/view");
+                expect(fooView.$type.id).toBe("test/foo/view");
               });
             });
       });
@@ -1745,7 +1745,7 @@ define([
               var View = context.get(baseViewFactory);
 
               return View.extend({
-                type: {
+                $type: {
                   id: "test/foo/view",
                   props: {a: {valueType: "string"}}
                 }
@@ -1760,7 +1760,7 @@ define([
               var Model = context.get(baseModelFactory);
 
               return Model.extend({
-                type: {
+                $type: {
                   id: "test/foo/model",
                   defaultView: "test/foo/view"
                 }
@@ -1785,7 +1785,7 @@ define([
               return View.createAsync(viewSpec).then(function(fooView) {
 
                 expect(fooView instanceof View).toBe(true);
-                expect(fooView.type.id).toBe("test/foo/view");
+                expect(fooView.$type.id).toBe("test/foo/view");
                 expect(fooView.a).toBe("b");
               });
             });
@@ -1803,7 +1803,7 @@ define([
               var View = context.get(baseViewFactory);
 
               return View.extend({
-                type: {
+                $type: {
                   id: "test/foo/view",
                   props: {a: {valueType: "string"}}
                 }
@@ -1818,7 +1818,7 @@ define([
               var Model = context.get(baseModelFactory);
 
               return Model.extend({
-                type: {
+                $type: {
                   id: "test/foo/model",
                   defaultView: "test/foo/view"
                 }
@@ -1843,7 +1843,7 @@ define([
               return View.createAsync(viewSpec).then(function(fooView) {
 
                 expect(fooView instanceof View).toBe(true);
-                expect(fooView.type.id).toBe("test/foo/view");
+                expect(fooView.$type.id).toBe("test/foo/view");
                 expect(fooView.a).toBe("b");
                 expect(fooView.model).toBe(fooModel);
               });
@@ -1856,7 +1856,7 @@ define([
 
         it("should respect a specified object value", function() {
           var ext = {foo: "bar"};
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: ext
           }});
 
@@ -1864,7 +1864,7 @@ define([
         });
 
         it("should convert a falsy value to null", function() {
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: false
           }});
 
@@ -1873,7 +1873,7 @@ define([
 
         it("should read the local value and not an inherited base value", function() {
           var ext = {foo: "bar"};
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: ext
           }});
 
@@ -1899,7 +1899,7 @@ define([
           var ext = {foo: "bar"};
 
           var DerivedView = View.extend({
-            type: {
+            $type: {
               extension: ext
             }
           });
@@ -1911,7 +1911,7 @@ define([
           var ext = {foo: "bar"};
 
           var DerivedView = View.extend({
-            type: {
+            $type: {
               extension: ext
             }
           });
@@ -1925,7 +1925,7 @@ define([
         it("should reflect an inherited object value", function() {
 
           var ext = {foo: "bar"};
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: ext
           }});
 
@@ -1936,11 +1936,11 @@ define([
 
         it("should merge local and inherited object values", function() {
 
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: {foo: "bar"}
           }});
 
-          var DerivedView2 = DerivedView.extend({type: {
+          var DerivedView2 = DerivedView.extend({$type: {
             extension: {bar: "foo"}
           }});
 
@@ -1952,11 +1952,11 @@ define([
 
         it("should override inherited properties with local properties", function() {
 
-          var DerivedView = View.extend({type: {
+          var DerivedView = View.extend({$type: {
             extension: {foo: "bar"}
           }});
 
-          var DerivedView2 = DerivedView.extend({type: {
+          var DerivedView2 = DerivedView.extend({$type: {
             extension: {foo: "gugu"}
           }});
 

--- a/impl/client/src/test/javascript/pentaho/visual/role/mapping.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/role/mapping.spec.js
@@ -47,7 +47,7 @@ define([
       it("should have #model return the container `derived`", function() {
 
         var Derived = VisualModel.extend({
-          type: {
+          $type: {
             props: [
               {name: "foo", base: "pentaho/visual/role/property"}
             ]

--- a/impl/client/src/test/javascript/pentaho/visual/role/mappingAttribute.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/role/mappingAttribute.spec.js
@@ -129,7 +129,7 @@ define([
 
       beforeEach(function() {
 
-        var DerivedModel = VisualModel.extend({type: {
+        var DerivedModel = VisualModel.extend({$type: {
           props: [
             {name: "propRole", base: "pentaho/visual/role/property"}
           ]
@@ -171,7 +171,7 @@ define([
 
       beforeEach(function() {
 
-        var DerivedModel = VisualModel.extend({type: {
+        var DerivedModel = VisualModel.extend({$type: {
           props: [
             {name: "propRole", base: "pentaho/visual/role/property"}
           ]

--- a/impl/client/src/test/javascript/pentaho/visual/role/property.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/role/property.spec.js
@@ -65,7 +65,7 @@ define([
       function createFullValidQualitativeMapping() {
 
         var DerivedVisualModel = VisualModel.extend({
-          type: {
+          $type: {
             props: {
               propRole: {
                 base: "pentaho/visual/role/property",
@@ -90,7 +90,7 @@ define([
       function createFullValidQuantitativeMapping() {
 
         var DerivedVisualModel = VisualModel.extend({
-          type: {
+          $type: {
             props: {
               propRole: {
                 base: "pentaho/visual/role/property",
@@ -125,7 +125,7 @@ define([
           var expectedLevels = ["nominal", "ordinal"];
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -143,7 +143,7 @@ define([
         it("should sort the values specified on the spec", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -161,7 +161,7 @@ define([
         it("should allow removing values by setting", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property"
@@ -184,7 +184,7 @@ define([
           expect(function() {
 
             VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property",
@@ -199,7 +199,7 @@ define([
         it("should allow a derived property to remove measurement levels", function() {
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -210,7 +210,7 @@ define([
           });
 
           var ModelB = ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   levels: ["nominal"]
@@ -229,7 +229,7 @@ define([
           var baseLevels = ["nominal", "ordinal"];
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -255,7 +255,7 @@ define([
             var expectedLevels = ["nominal", "ordinal"];
 
             var Model = VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property",
@@ -288,7 +288,7 @@ define([
         it("should throw an error, when levels is set and the mapping type already has descendants.", function() {
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -299,7 +299,7 @@ define([
           });
 
           ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {}
               }
@@ -329,7 +329,7 @@ define([
         it("should be true if any level is quantitative", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -347,7 +347,7 @@ define([
         it("should be false if not any level is quantitative", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -368,7 +368,7 @@ define([
         it("should be true if any level is qualitative", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRoleA: {
                   base: "pentaho/visual/role/property",
@@ -394,7 +394,7 @@ define([
         it("should be false if not any level is qualitative", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -416,7 +416,7 @@ define([
           var dataTypeB = Complex.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -429,7 +429,7 @@ define([
 
           expect(function() {
             ModelA.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     dataType: dataTypeB
@@ -447,7 +447,7 @@ define([
           var dataTypeB = DataTypeA.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -459,7 +459,7 @@ define([
           });
 
           var ModelB = ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   dataType: dataTypeB
@@ -476,7 +476,7 @@ define([
           var dataTypeA = Complex.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -488,7 +488,7 @@ define([
           });
 
           var ModelB = ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {}
               }
@@ -503,7 +503,7 @@ define([
           var dataTypeA = Complex.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -531,7 +531,7 @@ define([
           var dataTypeA = Complex.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -554,7 +554,7 @@ define([
           var dataTypeA = Complex.extend().type;
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -568,7 +568,7 @@ define([
           var roleAPropType = ModelA.type.get("propRole");
 
           ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {}
               }
@@ -585,7 +585,7 @@ define([
         it("should resolve values through the context", function() {
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -611,7 +611,7 @@ define([
             "one of the role's levels is quantitative", function() {
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -642,7 +642,7 @@ define([
         it("should be undefined by default", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -660,7 +660,7 @@ define([
         it("should respect a specified boolean false value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -679,7 +679,7 @@ define([
         it("should respect a specified boolean true value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -698,7 +698,7 @@ define([
         it("should consider as true a specified truthy value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -717,7 +717,7 @@ define([
         it("should consider as false a specified falsey, non-nully value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -736,7 +736,7 @@ define([
         it("should ignore a specified null value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -755,7 +755,7 @@ define([
         it("should ignore a specified undefined value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -774,7 +774,7 @@ define([
         it("should ignore setting to an undefined value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -797,7 +797,7 @@ define([
         it("should ignore setting to a null value", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -820,7 +820,7 @@ define([
         it("should respect setting to the value true", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -840,7 +840,7 @@ define([
         it("should respect setting to the value false", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -862,7 +862,7 @@ define([
           var fIsKey = function() { return true; };
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -886,7 +886,7 @@ define([
         it("should get an object that conforms to the interface IPropertyAttributes", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -909,7 +909,7 @@ define([
         it("should get the same object each time", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -935,7 +935,7 @@ define([
           };
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -966,7 +966,7 @@ define([
         it("should return undefined, when the mapping contains no attributes", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -979,7 +979,7 @@ define([
           var model = new Model({
             data: new Table(getDataSpec1())
           });
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           // Assumptions
           assertIsValid(model);
@@ -992,7 +992,7 @@ define([
         it("should return undefined, when one of the attributes is not defined in the model's data", function() {
 
           var model = createFullValidQualitativeMapping();
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           model.propRole.attributes.add({name: "mugambo"});
 
@@ -1002,7 +1002,7 @@ define([
         it("should return undefined, when the attributes' level is incompatible with the role's levels", function() {
 
           var model = createFullValidQuantitativeMapping();
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           model.propRole.attributes.set(["country"]);
 
@@ -1015,7 +1015,7 @@ define([
           // properly determines the lowest attribute level of measurement.
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1030,7 +1030,7 @@ define([
             propRole: {attributes: ["product", "sales"]}
           });
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.levelAutoOn(model)).toBe("ordinal");
         });
@@ -1039,7 +1039,7 @@ define([
             "qualitative and quantitative", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1054,7 +1054,7 @@ define([
             propRole: {attributes: ["sales"]}
           });
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.levelAutoOn(model)).toBe("quantitative");
         });
@@ -1063,7 +1063,7 @@ define([
             "both nominal and ordinal", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1078,7 +1078,7 @@ define([
             propRole: {attributes: ["country"]}
           });
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.levelAutoOn(model)).toBe("ordinal");
         });
@@ -1086,7 +1086,7 @@ define([
         it("should return nominal, when the attributes level is quantitative and the role is nominal", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1101,7 +1101,7 @@ define([
             propRole: {attributes: ["sales"]}
           });
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.levelAutoOn(model)).toBe("nominal");
         });
@@ -1109,7 +1109,7 @@ define([
         it("should return ordinal, when the attributes level is quantitative and the role is ordinal", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1124,7 +1124,7 @@ define([
             propRole: {attributes: ["sales"]}
           });
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.levelAutoOn(model)).toBe("ordinal");
         });
@@ -1135,7 +1135,7 @@ define([
         it("should be equal to the auto level when the level is null", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1147,7 +1147,7 @@ define([
 
           var model = new Model();
           var mapping = model.propRole;
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           // Assumptions
           expect(mapping.level).toBe(null);
@@ -1165,7 +1165,7 @@ define([
         it("should be equal to the level, when the level is not null", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1177,7 +1177,7 @@ define([
 
           var level = "nominal";
           var model = new Model({propRole: {level: level}});
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           spyOn(rolePropType, "levelAutoOn").and.returnValue("foo-level");
 
@@ -1195,7 +1195,7 @@ define([
         function testItLocal(valueSpec, valueExpected) {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1219,7 +1219,7 @@ define([
         function testItInherited(value1Spec, value2Spec, valueExpected) {
 
           var ModelA = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1231,7 +1231,7 @@ define([
           });
 
           var ModelB = ModelA.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   isVisualKey: value2Spec
@@ -1253,7 +1253,7 @@ define([
         it("should be false for an unmapped quantitative visual role", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1275,7 +1275,7 @@ define([
         it("should be false for an unmapped qualitative visual role", function() {
 
           var Model = VisualModel.extend({
-            type: {
+            $type: {
               props: {
                 propRole: {
                   base: "pentaho/visual/role/property",
@@ -1298,7 +1298,7 @@ define([
 
           var model = createFullValidQualitativeMapping();
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.isVisualKeyOn(model)).toBe(true);
         });
@@ -1309,7 +1309,7 @@ define([
           var model = createFullValidQuantitativeMapping();
           model.propRole.attributes.add(["date"]);
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.isVisualKeyOn(model)).toBe(true);
         });
@@ -1318,7 +1318,7 @@ define([
 
           var model = createFullValidQuantitativeMapping();
 
-          var rolePropType = model.type.get("propRole");
+          var rolePropType = model.$type.get("propRole");
 
           expect(rolePropType.isVisualKeyOn(model)).toBe(false);
         });
@@ -1374,19 +1374,19 @@ define([
               if(txnScope) txnScope.acceptWill();
 
               // this way, errors are shown in the console...
-              expect(model.type.get("propRole").validateOn(model)).toBe(null);
+              expect(model.$type.get("propRole").validateOn(model)).toBe(null);
             }
 
             function assertIsInvalid(model) {
               if(txnScope) txnScope.acceptWill();
 
-              expect(model.type.get("propRole").validateOn(model) != null).toBe(true);
+              expect(model.$type.get("propRole").validateOn(model) != null).toBe(true);
             }
 
             it("should stop validation if base validation returns errors", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1413,7 +1413,7 @@ define([
             it("should be invalid when attributes.isRequired and there are no attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1441,7 +1441,7 @@ define([
             it("should be valid when attributes.isRequired and there are attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1469,7 +1469,7 @@ define([
             it("should be invalid when attributes.countMin = 2 and there are no attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1497,7 +1497,7 @@ define([
             it("should be valid when attributes.countMin = 2 and there are 2 attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1525,7 +1525,7 @@ define([
             it("should be invalid when attributes.countMax = 1 and there are 2 attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1554,7 +1554,7 @@ define([
             it("should be valid when attributes.countMax = 1 and there are 1 attributes", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1643,7 +1643,7 @@ define([
                 "but its data type is not a subtype", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1667,7 +1667,7 @@ define([
                 "compatible with the role's levels", function() {
 
               var Model = VisualModel.extend({
-                type: {
+                $type: {
                   props: {
                     propRole: {
                       base: "pentaho/visual/role/property",
@@ -1738,7 +1738,7 @@ define([
             var scope = new SpecificationScope();
 
             var DerivedVisualModel = VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property"
@@ -1764,7 +1764,7 @@ define([
             var scope = new SpecificationScope();
 
             var DerivedVisualModel = VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property",
@@ -1797,7 +1797,7 @@ define([
             var scope = new SpecificationScope();
 
             var DerivedVisualModel = VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property"
@@ -1823,7 +1823,7 @@ define([
             var scope = new SpecificationScope();
 
             var DerivedVisualModel = VisualModel.extend({
-              type: {
+              $type: {
                 props: {
                   propRole: {
                     base: "pentaho/visual/role/property",


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.

Merge followed by the following PRs:
* https://github.com/pentaho/pentaho-analyzer/pull/1567
* https://github.com/pentaho/pentaho-det/pull/916
* https://github.com/pentaho/pentaho-platform-plugin-geo/pull/199
* https://github.com/pentaho/eng-sandbox/pull/21

The following two PRs cannot yet be merged and will be merged later to complete the story:
* https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1111 (guidance)
* https://github.com/pentaho/pentaho-engineering-samples/pull/30  (guidance)