### PR TITLE
[SP-3693]-[PRD-5909] - Using the a period (.) in parameter name makes…

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -498,6 +498,7 @@ define(['cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/uti
           this.guid = this.promptGUIDHelper.generateGUID();
 
           this.dashboard = new Dashboard();
+          this.dashboard.flatParameters = true;  // PRD-5909
 
           this.paramDiffer = new ParamDiff();
 

--- a/test-js/unit/prompting/PromptPanelSpec.js
+++ b/test-js/unit/prompting/PromptPanelSpec.js
@@ -40,6 +40,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
         expect(panel.autoSubmit).toBeTruthy();
         expect(panel.guid).toBeDefined();
         expect(panel.dashboard).toBeDefined();
+        expect(panel.dashboard.flatParameters).toBe(true);
         expect(panel.promptGUIDHelper).toBeDefined();
         expect(panel.parametersChanged).toBeFalsy();
       });


### PR DESCRIPTION
… this

parameter selection unworkable (7.1 Suite)