### PR TITLE
[SP-3570][PIR-1351]-XSS vulnerability in DataSource name when creating new PIR

### DIFF
--- a/src/org/pentaho/common/ui/metadata/service/MetadataService.java
+++ b/src/org/pentaho/common/ui/metadata/service/MetadataService.java
@@ -43,7 +43,6 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.pentahometadata.MetadataQueryComponent;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
-import org.apache.commons.lang.StringEscapeUtils;
 import flexjson.JSONSerializer;
 
 /**
@@ -166,7 +165,7 @@ public class MetadataService extends PentahoBase {
       ModelInfo modelInfo = new ModelInfo();
       modelInfo.setDomainId( domain );
       modelInfo.setModelId( model.getId() );
-      modelInfo.setModelName( StringEscapeUtils.escapeHtml( model.getName( locale ) ) );
+      modelInfo.setModelName( model.getName( locale ).replaceAll( "<", "&lt;" ).replaceAll( ">", "&gt;" ) );
       if ( model.getDescription() != null ) {
         String modelDescription = model.getDescription( locale );
         modelInfo.setModelDescription( modelDescription );


### PR DESCRIPTION
 - fix for regression: foreign names in datasources list
 (should be at the bottom of the list)