### PR TITLE
[BACKLOG-16943] Fixing 'pentaho/i18n' for embedded scenarios

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/environment/impl/Environment.js
+++ b/impl/client/src/main/javascript/web/pentaho/environment/impl/Environment.js
@@ -144,7 +144,11 @@ define(["pentaho/util/has"], function(has) {
         host: m[3] + (m[4] != null ? m[4] : ""),
         port: (m[4] != null ? m[4].substring(1) : ""),
         origin: m[1] + "//" + m[3] + (m[4] != null ? m[4] : ""),
-        pathname: m[5]
+        pathname: m[5],
+
+        toString: function() {
+          return url;
+        }
       };
     }
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review
 - Fix for the embedded scenario (in a Pentaho Server and on an external one)
 - Added the toString method to the fake URL object, this way we won't run into problems again
 by doing `server.root + "some/path"` instead of `server.root.href + "some/path"` in older browsers.