### PR TITLE
[BACKLOG-18929] DET - First "Drag and Drop" into a drop-zone doesn't work

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/type/changes/Changeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/Changeset.js
@@ -71,28 +71,35 @@ define([
       this.__isReadOnly = false;
       this.__ownerVersion = owner.$version;
 
-      // The longest path by which this changeset can be reached following the path of changesets
-      // and their owner's references.
+      // The longest path by which this changeset can be reached following the path of children changesets.
       this._netOrder = 0;
 
       transaction.__addChangeset(this);
     },
 
     /**
-     * Updates the order of this changeset to reflect its topological sort order.
+     * Updates the order of this changeset, and of any child changesets, to reflect its topological sort order.
      *
      * @param {number} netOrder - The net order.
-     * @return {boolean} `true` if the order was updated; `false`, otherwise.
      * @private
      * @internal
      */
     __updateNetOrder: function(netOrder) {
       if(this._netOrder < netOrder) {
         this._netOrder = netOrder;
-        return true;
+        this.__updateChildChangesetsNetOrder(netOrder + 1);
       }
-      return false;
     },
+
+    /**
+     * Updates the topological order of any child changesets.
+     *
+     * @name pentaho.type.changes.Changeset#__updateChildChangesetsNetOrder
+     * @param {number} childrenNetOrder - The minimum net order of children.
+     *
+     * @private
+     * @internal
+     */
 
     // Should be marked protected abstract, but that would show in the docs.
     /**

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ComplexChangeset.js
@@ -111,6 +111,19 @@ define([
     },
 
     /** @inheritDoc */
+    __updateChildChangesetsNetOrder: function(childrenNetOrder) {
+      var changes = this._changes;
+      for(var name in changes) {
+        if(O.hasOwn(changes, name)) {
+          var change = changes[name];
+          if(change instanceof Changeset) {
+            change.__updateNetOrder(childrenNetOrder);
+          }
+        }
+      }
+    },
+
+    /** @inheritDoc */
     __setNestedChangeset: function(csetNested, propType) {
       // Cannot set changesets like this over Replace changes, or the latter would be, well... , overwritten.
       // this._changes[propType.name] = csetNested;
@@ -180,9 +193,6 @@ define([
 
     // ATTENTION: This method's name and signature must be in sync with that of Complex#__getStateByName.
     // NOTE: Can be called for both list and element properties.
-    // TODO: this method may not work well before Transaction#__buildGraph runs (acceptwill)...
-    // until then, bubbled changes may not be detected.
-    // Would need the graph to be built as Changesets are being created...
     __getStateByName: function(name) {
       var change = O.getOwn(this._changes, name);
       if(!change) return this.owner.__getStateByName(name);

--- a/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/changes/ListChangeset.js
@@ -133,6 +133,16 @@ define([
     },
 
     /** @inheritDoc */
+    __updateChildChangesetsNetOrder: function(childrenNetOrder) {
+      var changesByKey = this._changesByElemKey;
+      for(var key in changesByKey) { // nully tolerant
+        if(O.hasOwn(changesByKey, key)) {
+          changesByKey[key].__updateNetOrder(childrenNetOrder);
+        }
+      }
+    },
+
+    /** @inheritDoc */
     __setNestedChangeset: function(csetNested) {
       this._changesByElemKey[csetNested.owner.$key] = csetNested;
     },

--- a/impl/client/src/test/javascript/pentaho/type/complex.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/complex.spec.js
@@ -1199,6 +1199,101 @@ define([
         });
       }); // end domainOf
 
+      describe("#isDefaultedOf(name)", function() {
+
+        var Derived;
+
+        beforeEach(function() {
+          Derived = Complex.extend({
+            $type: {
+              props: [
+                {name: "x", valueType: "string"},
+                {name: "y", valueType: ["string"]}
+              ]
+            }
+          });
+        });
+
+        describe("element valueType property", function() {
+
+          it("should be true when a value has not been specified", function() {
+
+            var derived = new Derived();
+
+            expect(derived.isDefaultedOf("x")).toBe(true);
+          });
+
+          it("should be false when a value has been specified", function() {
+
+            var derived = new Derived({"x": "a"});
+
+            expect(derived.isDefaultedOf("x")).toBe(false);
+          });
+
+          it("should be true after being set", function() {
+
+            var derived = new Derived();
+
+            derived.x = "a";
+
+            expect(derived.isDefaultedOf("x")).toBe(false);
+          });
+
+          it("should be true after being set, within a transaction", function() {
+
+            var derived = new Derived();
+
+            var txnScope = context.enterChange();
+            try {
+              derived.x = "a";
+
+              expect(derived.isDefaultedOf("x")).toBe(false);
+            } finally {
+              txnScope.dispose();
+            }
+          });
+        });
+
+        describe("list valueType property", function() {
+
+          it("should be true when a value has not been specified", function() {
+
+            var derived = new Derived();
+
+            expect(derived.isDefaultedOf("y")).toBe(true);
+          });
+
+          it("should be false when a value has been specified", function() {
+
+            var derived = new Derived({"y": ["a"]});
+
+            expect(derived.isDefaultedOf("y")).toBe(false);
+          });
+
+          it("should be true after being set", function() {
+
+            var derived = new Derived();
+
+            derived.y = ["a"];
+
+            expect(derived.isDefaultedOf("y")).toBe(false);
+          });
+
+          it("should be true after being set, within a transaction", function() {
+
+            var derived = new Derived();
+
+            var txnScope = context.enterChange();
+            try {
+              derived.y = ["a"];
+
+              expect(derived.isDefaultedOf("y")).toBe(false);
+            } finally {
+              txnScope.dispose();
+            }
+          });
+        });
+      }); // isDefaultedOf
     });
 
     describe("#clone", function() {


### PR DESCRIPTION
`Complex#isDefaultedOf(propName)` would not return `false` when a remote nested
changeset existed in that property's path and when under a transaction.

This affected `Complex#toSpec`, which would not return correct results when
evaluated during a transaction.

All accessible changesets are now created and connected immediately once a primitive change is performed.

@pentaho/millenniumfalcon please review.