### PR TITLE
[BACKLOG-19060] Created the pentaho/ccc/visual/all module to help r.js.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/all.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/all.js
@@ -13,39 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// This exists only so that r.js sees otherwise invisible dependencies.
 define([
-  "module"
-], function(module) {
-
+  "./abstract",
+  "./axes/Axis",
+  "./area",
+  "./areaAbstract",
+  "./areaStacked",
+  "./bar",
+  "./barAbstract",
+  "./barHorizontal",
+  "./barLine",
+  "./barNormalized",
+  "./barNormalizedAbstract",
+  "./barNormalizedHorizontal",
+  "./barStacked",
+  "./barStackedHorizontal",
+  "./boxplot",
+  "./bubble",
+  "./cartesianAbstract",
+  "./categoricalContinuousAbstract",
+  "./donut",
+  "./heatGrid",
+  "./line",
+  "./metricPointAbstract",
+  "./pie",
+  "./pointAbstract",
+  "./scatter",
+  "./sunburst",
+  "./treemap",
+  "./waterfall"
+], function() {
   "use strict";
-
-  return [
-    "./barAbstract",
-    "pentaho/visual/models/barNormalizedAbstract",
-    function(BaseView, Model) {
-
-      return BaseView.extend({
-        $type: {
-          id: module.id,
-          props: {
-            model: {valueType: Model}
-          }
-        },
-        _options: {
-          valuesNormalized: true,
-          stacked: true
-        },
-
-        _configureOptions: function() {
-          this.base();
-
-          this.options.orthoAxisTickFormatter = formatTickPercent;
-        }
-      });
-    }
-  ];
-
-  function formatTickPercent(v) {
-    return v + "%";
-  }
 });

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/area.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/area.js
@@ -19,7 +19,7 @@ define([
 
   "use strict";
 
-  return ["pentaho/ccc/visual/areaAbstract", function(BaseView) {
+  return ["./areaAbstract", function(BaseView) {
 
     return BaseView.extend({
       $type: {

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaAbstract.js
@@ -19,7 +19,7 @@ define([
 
   "use strict";
 
-  return ["pentaho/ccc/visual/pointAbstract", function(BaseView) {
+  return ["./pointAbstract", function(BaseView) {
 
     return BaseView.extend({
       _cccClass: "AreaChart",

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/areaStacked.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/areaAbstract",
+    "./areaAbstract",
     "pentaho/visual/models/areaStacked",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/bar.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/bar.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     "pentaho/visual/models/bar",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barAbstract.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/categoricalContinuousAbstract",
+    "./categoricalContinuousAbstract",
     "pentaho/visual/models/barAbstract",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barHorizontal.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     "pentaho/visual/models/barHorizontal",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barLine.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barLine.js
@@ -22,7 +22,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     "pentaho/visual/models/barLine",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalized.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalized.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barNormalizedAbstract",
+    "./barNormalizedAbstract",
     "pentaho/visual/models/barNormalized",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barNormalizedHorizontal.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barNormalizedAbstract",
+    "./barNormalizedAbstract",
     "pentaho/visual/models/barNormalizedHorizontal",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStacked.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStacked.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     "pentaho/visual/models/barStacked",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStackedHorizontal.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/barStackedHorizontal.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     "pentaho/visual/models/barStackedHorizontal",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/boxplot.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/boxplot.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/categoricalContinuousAbstract",
+    "./categoricalContinuousAbstract",
     function(BaseView) {
 
       return BaseView.extend({

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/bubble.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/bubble.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/metricPointAbstract",
+    "./metricPointAbstract",
     "pentaho/visual/models/bubble",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/cartesianAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/cartesianAbstract.js
@@ -22,7 +22,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/abstract",
+    "./abstract",
     "pentaho/visual/models/cartesianAbstract",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/categoricalContinuousAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/categoricalContinuousAbstract.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/cartesianAbstract",
+    "./cartesianAbstract",
     "pentaho/visual/models/categoricalContinuousAbstract",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/donut.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/donut.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/pie",
+    "./pie",
     "pentaho/visual/models/donut",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/heatGrid.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/heatGrid.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/cartesianAbstract",
+    "./cartesianAbstract",
     "pentaho/visual/models/heatGrid",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/line.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/pointAbstract",
+    "./pointAbstract",
     "pentaho/visual/models/line",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/metricPointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/metricPointAbstract.js
@@ -21,7 +21,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/cartesianAbstract",
+    "./cartesianAbstract",
     "pentaho/visual/models/metricPointAbstract",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/pie.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/pie.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/abstract",
+    "./abstract",
     "pentaho/visual/models/pie",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/pointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/pointAbstract.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/categoricalContinuousAbstract",
+    "./categoricalContinuousAbstract",
     "pentaho/visual/models/pointAbstract",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/scatter.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/scatter.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/metricPointAbstract",
+    "./metricPointAbstract",
     "pentaho/visual/models/scatter",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/sunburst.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/sunburst.js
@@ -24,7 +24,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/abstract",
+    "./abstract",
     "pentaho/visual/models/sunburst",
     function(BaseView, Model) {
 

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/treemap.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/treemap.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/abstract",
+    "./abstract",
     function(BaseView) {
 
       return BaseView.extend({

--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/waterfall.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/waterfall.js
@@ -20,7 +20,7 @@ define([
   "use strict";
 
   return [
-    "pentaho/ccc/visual/barAbstract",
+    "./barAbstract",
     function(BaseView) {
 
       return BaseView.extend({

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/view.js
@@ -35,7 +35,10 @@ define([
   "pentaho/visual/base/model",
   "pentaho/type/action/base",
   "pentaho/data/filter/abstract",
-  "pentaho/visual/action/base"
+  "pentaho/visual/action/base",
+  "pentaho/visual/action/data",
+  "pentaho/visual/action/select",
+  "pentaho/visual/action/execute"
 ], function(module, ComplexChangeset, bundle, WillUpdate, DidUpdate, RejectedUpdate, UserError,
             O, arg, F, BitSet, error, logger, promise, specUtil) {
 


### PR DESCRIPTION
* Fixed CCC views to use relative names to reference base types.

@pentaho/millenniumfalcon please review.