### PR TITLE
[SP-3810]: Backport of PRD-5939 - Unable to open a prpt that uses several timezones (7.1 Suite)

### DIFF
--- a/impl/client/src/main/javascript/web/util/formatting.js
+++ b/impl/client/src/main/javascript/web/util/formatting.js
@@ -220,7 +220,7 @@ define("common-ui/util/formatting", ['common-ui/util/timeutil', 'common-ui/util/
     convertTimeStampToTimeZone: function(value, timezone) {
       this._initDateFormatters();
       // Lookup the offset in minutes
-      var offset = ReportTimeUtil.getOffset(timezone, date);
+      var offset = ReportTimeUtil.getOffset(timezone, value);
 
       var localDate = this.parseDateWithoutTimezoneInfo(value);
       var utcDate = this.dateFormatters['with-timezone'].parse(value);


### PR DESCRIPTION
This is the cherry-pick of the fix for [PRD-5939]: Unable to open a prpt that uses several timezones
Fixed typo in parameter name.