### PR TITLE
[BACKLOG-19446] PAZ - Browser freezes when selecting a lot of plot po…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
@@ -287,22 +287,21 @@ define([
       return rows;
     },
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     filter: function(filter) {
-
-      filter.assertValid();
 
       var filteredRows = [];
       var L = this.getNumberOfRows();
-      if(L) {
+      if(L > 0) {
+        var predicate = filter.compile();
+
         var elem = new ElementMock(this, null);
         var i = -1;
         while(++i < L) {
           elem.rowIdx = i;
-          // TODO: Ugly, but until isValid is cached...
-          if(filter._contains(elem)) filteredRows.push(i);
+          if(predicate(elem)) {
+            filteredRows.push(i);
+          }
         }
       }
 
@@ -313,10 +312,9 @@ define([
 
     filterMatchesRow: function(filter, rowIndex) {
 
-      filter.assertValid();
-
       var elem = new ElementMock(this, rowIndex);
-      return filter._contains(elem);
+
+      return filter.contains(elem);
     },
 
     /**

--- a/impl/client/src/main/javascript/web/pentaho/data/_Table.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_Table.js
@@ -20,8 +20,9 @@ define([
   "./_plain/Table",
   "./_cross/Table",
   "./AtomicTypeName",
-  "../util/arg"
-], function(AbstractTable, Model, PlainTable, CrossTable, AtomicTypeName, arg) {
+  "../util/arg",
+  "../util/object"
+], function(AbstractTable, Model, PlainTable, CrossTable, AtomicTypeName, arg, O) {
 
   // Map of CDA lowercase colType to DataTable type
   // CDA column types (method AbstractExporter.getColTypes)
@@ -242,16 +243,29 @@ define([
      * with the same keyword arguments,
      * and is returned.
      *
+     * @param {Object} [keyArgs] Keyword arguments.
+     * @param {boolean} [keyArgs.skipRowsWithAllNullMeasures=false] Indicates that rows whose
+     *    cross-tab measure cells are all null can be skipped from the output.
+     *
      * @return {pentaho.data.Table} A table with a plain structure.
      * @see pentaho.data.Table#toSpecPlain
      */
-    toPlainTable: function() {
+    toPlainTable: function(keyArgs) {
       if(this.isPlainTable) return this;
 
       // assert this.isCrossTable
 
-      var plainTable = this._cachedPlainTable;
-      if(!plainTable) plainTable = this._cachedPlainTable = new Table(this.toSpecPlain({shareModel: true}));
+      var skipRowsWithAllNullMeasures = !!O.getOwn(keyArgs, "skipRowsWithAllNullMeasures");
+      var cacheProp = skipRowsWithAllNullMeasures ? "_cachedPlainTableNoNulls" : "_cachedPlainTable";
+
+      var plainTable = this[cacheProp];
+      if(!plainTable) {
+        plainTable = this[cacheProp] = new Table(this.toSpecPlain({
+          shareModel: true,
+          skipRowsWithAllNullMeasures: skipRowsWithAllNullMeasures
+        }));
+      }
+
       return plainTable;
     },
 
@@ -275,6 +289,9 @@ define([
      * @param {boolean} [keyArgs.shareModel=false] Indicates that
      *    the model of the resulting specification will be
      *    the model object itself and not its specification.
+     * @param {boolean} [keyArgs.skipRowsWithAllNullMeasures=false] Indicates that rows whose
+     *    cross-tab measure cells are all null can be skipped from the output.
+     *
      * @return {pentaho.data.spec.IPlainTable} A plain-structure specification of the table.
      * @see pentaho.data.Table#toPlainTable
      */
@@ -290,6 +307,8 @@ define([
      * @param {boolean} [keyArgs.shareModel=false] Indicates that
      *    the model of the resulting specification will be
      *    the model object itself and not its specification.
+     * @param {boolean} [keyArgs.skipRowsWithAllNullMeasures=false] Indicates that rows whose
+     *    cross-tab measure cells are all null can be skipped from the output.
      *
      * @return {pentaho.data.spec.ITable} A specification of the table.
      */

--- a/impl/client/src/main/javascript/web/pentaho/data/_cross/Table.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_cross/Table.js
@@ -575,6 +575,7 @@ define([
             rowsAxis.structure.toSpec(keyArgs),
             colsAxis.structure.toSpec(keyArgs),
             meas.structure.toSpec(keyArgs));
+      var skipRowsWithAllNullMeasures = xM > 0 && !!O.getOwn(keyArgs, "skipRowsWithAllNullMeasures");
       var r = -1;
 
       while(++r < R1) {
@@ -598,12 +599,21 @@ define([
           }
 
           k = xM;
+          var isAllNullMeasures = skipRowsWithAllNullMeasures;
           while(k--) {
             var cell = meas.get(r, c, k, true);
-            plainRowCellSpecs[RC + k] = cell && cell.toSpec();
+            var value = cell && cell.toSpec();
+
+            if(isAllNullMeasures && value !== null) {
+              isAllNullMeasures = false;
+            }
+
+            plainRowCellSpecs[RC + k] = value;
           }
 
-          plainRowSpecs.push({c: plainRowCellSpecs});
+          if(!isAllNullMeasures) {
+            plainRowSpecs.push({c: plainRowCellSpecs});
+          }
         }
       }
 

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/and.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/and.js
@@ -61,12 +61,19 @@ define([
       },
 
       /** @inheritDoc */
-      _contains: function(elem) {
-        var ops = this.operands;
-        var i = -1;
-        var L = ops.count;
-        while(++i < L) if(!ops.at(i)._contains(elem)) return false;
-        return true;
+      _compile: function() {
+
+        var compiledOps = this.operands.toArray(function(op) {
+          return op.compile();
+        });
+
+        var L = compiledOps.length;
+
+        return function andContains(elem) {
+          var i = -1;
+          while(++i < L) if(!compiledOps[i](elem)) return false;
+          return true;
+        };
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/false.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/false.js
@@ -71,8 +71,8 @@ define([
       },
 
       /** @inheritDoc */
-      _contains: function() {
-        return false;
+      _compile: function() {
+        return function() { return false; };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isEqual.js
@@ -67,9 +67,16 @@ define([
        */
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        return this.value === value;
+      _compile: function() {
+
+        var property = this.property;
+        // Can be null.
+        var referenceValue = this.value;
+
+        return function isEqualContains(elem) {
+          var value = elem.getv(property, true);
+          return value === referenceValue;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isGreater.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isGreater.js
@@ -72,9 +72,15 @@ define([
       },
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        return this.value > value;
+      _compile: function() {
+
+        var property = this.property;
+        var referenceValue = this.value;
+
+        return function isGreaterContains(elem) {
+          var value = elem.getv(property, true);
+          return value !== null && referenceValue > value;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isGreaterOrEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isGreaterOrEqual.js
@@ -72,9 +72,15 @@ define([
       },
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        return this.value >= value;
+      _compile: function() {
+
+        var property = this.property;
+        var referenceValue = this.value;
+
+        return function isGreaterOrEqualContains(elem) {
+          var value = elem.getv(property, true);
+          return value !== null && referenceValue >= value;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isIn.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isIn.js
@@ -77,16 +77,21 @@ define([
       },
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        if(value != null) {
-          var values = this.values;
-          var L = values.count;
-          var i = -1;
-          while(++i < L) if(values.at(i).valueOf() === value) return true;
-        }
+      _compile: function() {
 
-        return false;
+        var property = this.property;
+        var values = this.values.toArray(function(value) { return value.valueOf(); });
+        var L = values.length;
+
+        return function isInContains(elem) {
+          var value = elem.getv(property, true);
+          if(value !== null) {
+            var i = -1;
+            while(++i < L) if(values[i] === value) return true;
+          }
+
+          return false;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLess.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLess.js
@@ -72,9 +72,15 @@ define([
       },
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        return this.value < value;
+      _compile: function() {
+
+        var property = this.property;
+        var referenceValue = this.value;
+
+        return function isLessContains(elem) {
+          var value = elem.getv(property, true);
+          return value !== null && referenceValue < value;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLessOrEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLessOrEqual.js
@@ -72,9 +72,15 @@ define([
       },
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        return this.value <= value;
+      _compile: function() {
+
+        var property = this.property;
+        var referenceValue = this.value;
+
+        return function isLessOrEqualContains(elem) {
+          var value = elem.getv(property, true);
+          return value !== null && referenceValue <= value;
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLike.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isLike.js
@@ -67,24 +67,27 @@ define([
        */
 
       /** @inheritDoc */
-      _operation: function(elem) {
-        var value = elem.getv(this.property);
-        var formattedValue = elem.getf(this.property);
-        var anchorStart = this.getv("anchorStart");
-        var anchorEnd = this.getv("anchorEnd");
-        var caption = this.getf("value") || this.getv("value");
+      _compile: function() {
 
-        var reference = formattedValue;
-        if(reference == null) {
-          reference = value;
-        }
+        var property = this.property;
+        var anchorStart = this.anchorStart;
+        var anchorEnd = this.anchorEnd;
+        var referenceFormatted = this.getf("value") || this.value.toString();
 
-        var firstOccurrence = reference.indexOf(caption);
+        return function isLikeContains(elem) {
 
-        return firstOccurrence > -1 &&
-          (!anchorStart || firstOccurrence === 0) &&
-          (!anchorEnd || firstOccurrence + caption.length === reference.length);
+          var formatted;
+          if((formatted = elem.getf(property, true)) == null &&
+             (formatted = elem.getv(property, true)) == null) {
+            return false;
+          }
 
+          var firstOccurrence = formatted.indexOf(referenceFormatted);
+
+          return firstOccurrence > -1 &&
+              (!anchorStart || firstOccurrence === 0) &&
+              (!anchorEnd   || (firstOccurrence + referenceFormatted.length === formatted.length));
+        };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/not.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/not.js
@@ -89,8 +89,13 @@ define([
       },
 
       /** @inheritDoc */
-      _contains: function(elem) {
-        return !this.operand._contains(elem);
+      _compile: function() {
+
+        var compiledOp = this.operand.compile();
+
+        return function notContains(elem) {
+          return !compiledOp(elem);
+        };
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/or.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/or.js
@@ -59,12 +59,19 @@ define([
       },
 
       /** @inheritDoc */
-      _contains: function(elem) {
-        var ops = this.operands;
-        var i = -1;
-        var L = ops.count;
-        while(++i < L) if(ops.at(i)._contains(elem)) return true;
-        return false;
+      _compile: function() {
+
+        var compiledOps = this.operands.toArray(function(op) {
+          return op.compile();
+        });
+
+        var L = compiledOps.length;
+
+        return function orContains(elem) {
+          var i = -1;
+          while(++i < L) if(compiledOps[i](elem)) return true;
+          return false;
+        };
       },
 
       /**

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/property.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/property.js
@@ -63,32 +63,6 @@ define(function() {
         return true;
       },
 
-      /**
-       * Determines if a property value is such that the owner element is selected by this filter.
-       *
-       * @name _operation
-       * @memberOf pentaho.data.filter.Property#
-       * @method
-       *
-       * @param {!pentaho.type.Element} elem - The element to be tested
-       *
-       * @returns {boolean} `true` if the element is selected; `false`, otherwise.
-       *
-       * @protected
-       * @abstract
-       */
-
-      /**
-       * Determines if an element is selected by this filter.
-       *
-       * @param {!pentaho.type.Element} elem - The element to be tested.
-       *
-       * @return {boolean} `true` if `elem` is selected; `false`, otherwise.
-       */
-      _contains: function(elem) {
-        return elem.$type.has(this.property) && this._operation(elem);
-      },
-
       $type: /** @lends pentaho.data.filter.Property.Type# */{
         id: "pentaho/data/filter/property",
         isAbstract: true,

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/tree.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/tree.js
@@ -207,7 +207,8 @@ define([
 
       // region __equalityLiteralsByPropertyName
       get __equalityLiteralsByPropertyName() {
-        return this.__equalityLiteralsByName || (this.__equalityLiteralsByName = Object.freeze(this.__buildEqualityLiteralsByName()));
+        return this.__equalityLiteralsByName ||
+            (this.__equalityLiteralsByName = Object.freeze(this.__buildEqualityLiteralsByName()));
       },
 
       __equalityLiteralsByName: null,

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/true.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/true.js
@@ -71,8 +71,8 @@ define([
       },
 
       /** @inheritDoc */
-      _contains: function() {
-        return true;
+      _compile: function() {
+        return function() { return true; };
       },
 
       /** @inheritDoc */

--- a/impl/client/src/test/javascript/pentaho/data/Table.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/Table.spec.js
@@ -305,7 +305,11 @@ define([
 
                 return context.getDependencyApplyAsync(["pentaho/data/filter/abstract"], function(AbstractFilter) {
 
-                  CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+                  CustomFilter = AbstractFilter.extend({
+                    compile: function() {
+                      return function() { return false; };
+                    }
+                  });
                 });
               })
               .then(done, done.fail);
@@ -347,7 +351,7 @@ define([
         it("should return a view with a single result", function() {
           var filter = new CustomFilter();
 
-          spyOn(filter, "_contains").and.callFake(function(elem) {
+          spyOn(filter, "compile").and.returnValue(function(elem) {
             return elem.getv("product") === "A";
           });
 
@@ -369,7 +373,7 @@ define([
         it("should return a view with multiple results", function() {
           var filter = new CustomFilter();
 
-          spyOn(filter, "_contains").and.callFake(function(elem) {
+          spyOn(filter, "compile").and.returnValue(function(elem) {
             return elem.$type.has("sales") && elem.getv("sales") === 12000;
           });
 
@@ -395,7 +399,11 @@ define([
 
                 return context.getDependencyApplyAsync(["pentaho/data/filter/abstract"], function(AbstractFilter) {
 
-                  CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+                  CustomFilter = AbstractFilter.extend({
+                    compile: function() {
+                      return function() { return false; };
+                    }
+                  });
                 });
               })
               .then(done, done.fail);
@@ -429,7 +437,7 @@ define([
         it("should return `true` when a filter does select the row", function() {
           var filter = new CustomFilter();
 
-          spyOn(filter, "_contains").and.callFake(function(elem) {
+          spyOn(filter, "compile").and.returnValue(function(elem) {
             return elem.getv("product") === "A";
           });
 
@@ -441,7 +449,7 @@ define([
         it("should return `false` when a filter selects another row", function() {
           var filter = new CustomFilter();
 
-          spyOn(filter, "_contains").and.callFake(function(elem) {
+          spyOn(filter, "compile").and.returnValue(function(elem) {
             return elem.getv("product") === "A";
           });
 

--- a/impl/client/src/test/javascript/pentaho/data/filter/abstract.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/abstract.spec.js
@@ -56,7 +56,11 @@ define([
               TrueFilter = True;
               FalseFilter = False;
 
-              CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+              CustomFilter = AbstractFilter.extend({
+                compile: function() {
+                  return function() { return false; };
+                }
+              });
             });
           })
           .then(done, done.fail);

--- a/impl/client/src/test/javascript/pentaho/data/filter/and.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/and.spec.js
@@ -59,7 +59,11 @@ define([
               AndFilter = And;
               OrFilter = Or;
 
-              CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+              CustomFilter = AbstractFilter.extend({
+                compile: function() {
+                  return function() { return false; };
+                }
+              });
             });
           })
           .then(done, done.fail);
@@ -95,8 +99,10 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(true);
+        function isTrue() { return true; }
+
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isTrue);
 
         var filter  = new AndFilter({operands: [oper1, oper2]});
 
@@ -110,8 +116,11 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        function isTrue() { return true; }
+        function isFalse() { return false; }
+
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new AndFilter({operands: [oper1, oper2]});
 
@@ -125,8 +134,11 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        function isTrue() { return true; }
+        function isFalse() { return false; }
+
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new AndFilter({operands: [oper1, oper2]});
 
@@ -146,8 +158,10 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(false);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        function isFalse() { return false; }
+
+        spyOn(oper1, "compile").and.returnValue(isFalse);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new AndFilter({operands: [oper1, oper2]});
 

--- a/impl/client/src/test/javascript/pentaho/data/filter/not.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/not.spec.js
@@ -28,6 +28,9 @@ define([
     var CustomFilter;
     var ProductSummary;
 
+    function isTrue() { return true; }
+    function isFalse() { return false; }
+
     beforeEach(function(done) {
       Context.createAsync()
           .then(function(_context) {
@@ -53,7 +56,11 @@ define([
               AbstractFilter = Abstract;
               NotFilter = Not;
 
-              CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+              CustomFilter = AbstractFilter.extend({
+                compile: function() {
+                  return isFalse;
+                }
+              });
             });
           })
           .then(done, done.fail);
@@ -113,7 +120,7 @@ define([
 
         var oper1 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(false);
+        spyOn(oper1, "compile").and.returnValue(isFalse);
 
         var filter  = new NotFilter({operand: oper1});
 
@@ -126,7 +133,7 @@ define([
 
         var oper1 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
+        spyOn(oper1, "compile").and.returnValue(isTrue);
 
         var filter  = new NotFilter({operand: oper1});
 

--- a/impl/client/src/test/javascript/pentaho/data/filter/or.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/or.spec.js
@@ -30,6 +30,9 @@ define([
     var CustomFilter;
     var ProductSummary;
 
+    function isTrue() { return true; }
+    function isFalse() { return false; }
+
     beforeEach(function(done) {
       Context.createAsync()
           .then(function(_context) {
@@ -59,7 +62,11 @@ define([
               AndFilter = And;
               OrFilter = Or;
 
-              CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
+              CustomFilter = AbstractFilter.extend({
+                compile: function() {
+                  return isFalse;
+                }
+              });
             });
           })
           .then(done, done.fail);
@@ -96,8 +103,8 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(true);
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isTrue);
 
         var filter  = new OrFilter({operands: [oper1, oper2]});
 
@@ -111,8 +118,8 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new OrFilter({operands: [oper1, oper2]});
 
@@ -126,8 +133,8 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(true);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        spyOn(oper1, "compile").and.returnValue(isTrue);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new OrFilter({operands: [oper1, oper2]});
 
@@ -147,8 +154,8 @@ define([
         var oper1 = new CustomFilter();
         var oper2 = new CustomFilter();
 
-        spyOn(oper1, "_contains").and.returnValue(false);
-        spyOn(oper2, "_contains").and.returnValue(false);
+        spyOn(oper1, "compile").and.returnValue(isFalse);
+        spyOn(oper2, "compile").and.returnValue(isFalse);
 
         var filter  = new OrFilter({operands: [oper1, oper2]});
 

--- a/impl/client/src/test/javascript/pentaho/data/filter/tree.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/filter/tree.spec.js
@@ -32,6 +32,8 @@ define([
     var CustomTreeFilter;
     var ProductSummary;
 
+    function isFalse() { return false; }
+
     beforeEach(function(done) {
       Context.createAsync()
           .then(function(_context) {
@@ -56,8 +58,16 @@ define([
               AbstractFilter = Abstract;
               TreeFilter = Tree;
 
-              CustomFilter = AbstractFilter.extend({_contains: function() { return false; }});
-              CustomTreeFilter = TreeFilter.extend({_contains: function() { return false; }});
+              CustomFilter = AbstractFilter.extend({
+                compile: function() {
+                  return isFalse;
+                }
+              });
+              CustomTreeFilter = TreeFilter.extend({
+                compile: function() {
+                  return isFalse;
+                }
+              });
             });
           })
           .then(done, done.fail);


### PR DESCRIPTION
…ints in scatter chart.

Merge followed by https://github.com/pentaho/pentaho-analyzer/pull/1648.

Implemented several improvements:
1. Filters are applied to data table only after removing rows whose measures are all null; these are always excluded from selection; reducing rows from ~30,000 to ~3,000.
2. Compiled filters into an optimized representation before evaluation.
3. Handled additional degenerate cases in the toggle behaviour.

Time went from several minutes to ~8 seconds.
In my machine, 7.1 code takes ~30 seconds.

@pentaho/millenniumfalcon please review.