### PR TITLE
[CLEANUP] i18nMock does not need to declare dependency on "text" upfr…

### DIFF
--- a/impl/client/src/test/javascript/pentaho/i18nMock.js
+++ b/impl/client/src/test/javascript/pentaho/i18nMock.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-define(["pentaho/i18n/MessageBundle", "json"], function(MessageBundle) {
+define(["pentaho/i18n/MessageBundle"], function(MessageBundle) {
   return {
     load: function(bundlePath, require, onLoad, config) {
       var bundleUrl = require.toUrl(bundlePath) + ".properties";


### PR DESCRIPTION
…ont; much less on "json", which it does not use.

@pentaho/millenniumfalcon please review.