### PR TITLE
[PDB-1987] Check box filters with no default value set, display the first checkbox as selected

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/builders/DropDownBuilder.js
+++ b/impl/client/src/main/javascript/web/prompting/builders/DropDownBuilder.js
@@ -76,10 +76,10 @@ define(["cdf/components/SelectComponent", "./ValueBasedParameterWidgetBuilder", 
         $.extend(widget, {
           type: "SelectComponent",
           preExecution: function() {
-            // SelectComponent defines defaultIfEmpty = true for non-multi selects.
+            // SelectComponent defines useFirstValue as `true` for non-multi selects.
             // We can't override any properties of the component so we must set them just before update() is called. :(
             // Only select the first item if we have no selection and are not ignoring BISERVER-5538
-            this.defaultIfEmpty = !args.promptPanel.paramDefn.ignoreBiServer5538 && !args.param.hasSelection();
+            this.useFirstValue = !args.promptPanel.paramDefn.ignoreBiServer5538 && !args.param.hasSelection();
           },
           externalPlugin: args.param.attributes.externalPlugin,
           extraOptions: args.param.attributes.extraOptions

--- a/impl/client/src/test/javascript/prompting/builders/DropDownBuilder.spec.js
+++ b/impl/client/src/test/javascript/prompting/builders/DropDownBuilder.spec.js
@@ -73,13 +73,13 @@ define(["common-ui/prompting/builders/DropDownBuilder"], function(DropDownBuilde
       expect(component.valuesArray[1][1]).toEqual("");
     });
 
-    it("should set defaultIfEmpty to true for non-multi select on preExecution", function() {
+    it("should set useFirstValue to true for non-multi select on preExecution", function() {
       var component = dropDownBuilder.build(args);
 
       spyOn(component, "preExecution").and.callThrough();
       component.preExecution();
       expect(component.preExecution).toHaveBeenCalled();
-      expect(component.defaultIfEmpty).toBeFalsy();
+      expect(component.useFirstValue).toBeFalsy();
     });
 
     describe("build", function() {


### PR DESCRIPTION
  - renamed the component property that controls first value selection, from `defaultIfEmpty` to `useFirstValue`, to be consistent with dashboards and common-ui plugins across the platform