### PR TITLE
[PRD-5827] - Browser freezes when marking elements on the report toolbar and trying to put data in from keyboard - prevent default handler

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/RowLimitControl.html
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/RowLimitControl.html
@@ -6,5 +6,4 @@
   <div class='rl_rowsNumberInput'>
     <input id='rowsNumberInput' data-dojo-type='dijit.form.ValidationTextBox' value='' data-dojo-attach-point='rowsNumberInput'></input>
   </div>
-  <div id='row-limit-number-label' class='rl_rowLimitLabel' data-dojo-attach-point='rowLimitNumberLabel'></div>
 </div>

--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/RowLimitControl.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/RowLimitControl.js
@@ -52,6 +52,11 @@ define(["dojo/_base/declare", "dijit/form/Select", "dijit/form/ValidationTextBox
               this.inherited(arguments);
               on(this.rowLimitRestrictions, 'change', lang.hitch(this, '_onSelect'));
               on(this.rowsNumberInput, 'keydown, focusout', lang.hitch(this, '_onRowLimitSubmit'));
+              on(this.rowsNumberInput, 'mousedown', function(e){
+                if (this.disabled) {
+                  e.preventDefault();
+                }
+              });
             },
 
             registerLocalizationLookup: function (f) {
@@ -196,7 +201,6 @@ define(["dojo/_base/declare", "dijit/form/Select", "dijit/form/ValidationTextBox
                   }
                 } else if (this._systemRowLimit == this._selectedRowLimit) {
                   this.setRowLimit(this._selectedRowLimit);
-                  this.rowLimitNumberLabel.innerHTML = this._systemRowLimit > 0 && this._systemRowLimit !== Infinity ? this._systemRowLimit : '';
                   if (this._getRowLimitRestrictions() === 'MAXIMUM') {
                     this._setRowsNumberInputDisabled(true);
                     this._showSystemMessage();
@@ -254,13 +258,6 @@ define(["dojo/_base/declare", "dijit/form/Select", "dijit/form/ValidationTextBox
             _setRowsNumberInputDisabled: function (isDisabled) {
               this.rowsNumberInput.set('disabled', isDisabled);
               this.rowsNumberInput.set('readonly', isDisabled);
-              if(isDisabled) {
-                 $(".rl_rowsNumberInput").hide();
-                 this.rowLimitNumberLabel.hidden = false;
-               } else {
-                 $(".rl_rowsNumberInput").show();
-                 this.rowLimitNumberLabel.hidden = true;
-               }
             },
 
             _setRowLimitRestrictionDisabled: function (isDisabled) {


### PR DESCRIPTION
The fix from https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1221/commits/c67ab3d677f85e821e5e57c8777e6dafcdf61365 doesn't not work for all cases so it should be replaced with a custom event handling.
@tmorgner , @kcruzada, @Aliaksandr-Kastenka, @annapopova1 please review.