### PR TITLE
[BACKLOG-22097] Filter rows with all null measures on SelectionModes.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
@@ -145,6 +145,7 @@ define([
               return c;
         }
       }
+
       return -1;
     },
 

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isEqual.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/_core/isEqual.js
@@ -75,7 +75,10 @@ define([
 
         return function isEqualContains(elem) {
           var value = elem.getv(property, true);
-          return value === referenceValue;
+
+          // valueOf fallback added allowing to compare Dates
+          return value === referenceValue
+            || value != null && referenceValue != null && value.valueOf() === referenceValue.valueOf();
         };
       },
 

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
@@ -491,8 +491,8 @@ define([
        * If the resulting filtered data of a filter is empty then the [false filter]{@link pentaho.data.filter.False}
        * is returned
        *
-       * @param {!pentaho.data.ITable} dataPlain - The data to be used when determining the values of the key columns
-       * used in the extensional representation of the filter.
+       * @param {!pentaho.data.ITable} dataPlain - The plain data table to be used when determining the values of
+       * the key columns used in the extensional representation of the filter.
        * @param {string[]} keyColumnNames - The names of the columns from the `dataPlain` that are considered key.
        *
        * @return {!pentaho.data.filter.Or|!pentaho.data.filter.False} The extensional filter.

--- a/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/filter/abstract.js
@@ -491,20 +491,20 @@ define([
        * If the resulting filtered data of a filter is empty then the [false filter]{@link pentaho.data.filter.False}
        * is returned
        *
-       * @param {!pentaho.data.ITable} dataTable - The data to be used when determining the values of the key columns
+       * @param {!pentaho.data.ITable} dataPlain - The data to be used when determining the values of the key columns
        * used in the extensional representation of the filter.
-       * @param {string[]} keyColumnNames - The names of the columns from the {@code dataTable} that are considered key.
+       * @param {string[]} keyColumnNames - The names of the columns from the `dataPlain` that are considered key.
        *
        * @return {!pentaho.data.filter.Or|!pentaho.data.filter.False} The extensional filter.
        *
-       * @throws {pentaho.lang.ArgumentInvalidError} When the resulting filtered data is not empty and keyColumnNames
+       * @throws {pentaho.lang.ArgumentInvalidError} When the resulting filtered data is not empty and `keyColumnNames`
        * is empty.
        */
-      toExtensional: function(dataTable, keyColumnNames) {
+      toExtensional: function(dataPlain, keyColumnNames) {
 
         if(__isDebugMode) logger.log("toExtensional BEGIN");
         try {
-          var filteredData = dataTable.toPlainTable().filter(this);
+          var filteredData = dataPlain.filter(this);
           var numRows = filteredData.getNumberOfRows();
           // Applying the filter returns no data therefore select nothing (False filter)
           if(numRows === 0) {
@@ -550,7 +550,7 @@ define([
           keyColumnNames.forEach(function(columnName) {
             var colIdx = dataTable.getColumnIndexById(columnName);
             if(colIdx === -1) {
-              throw error.argInvalid("keyColumnNames", "The column name " + columnName + " is not in the dataTable.");
+              throw error.argInvalid("keyColumnNames", "The column name " + columnName + " is not in the dataPlain.");
             }
             columnNameToIdx[columnName] = colIdx;
           });

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
@@ -145,11 +145,6 @@ define([
         /**
          * Gets an array of the names of fields which are mapped to _key_ visual roles.
          *
-         * Conveniently,
-         * the returned array contains an extra property, `set`,
-         * which contains an object whose keys are the field names and
-         * whose values are the value `true`.
-         *
          * @type {!Array.<string>} The array of field names.
          * @readOnly
          *
@@ -178,11 +173,6 @@ define([
         /**
          * Gets an array of the names of fields which are mapped to _measure_ visual roles
          * and which are not mapped to any _key_ visual roles.
-         *
-         * Conveniently,
-         * the returned array contains an extra property, `set`,
-         * which contains an object whose keys are the field names and
-         * whose values are the value `true`.
          *
          * @type {!Array.<string>} The array of field names.
          * @readOnly

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
@@ -142,6 +142,40 @@ define([
           }, this);
         },
 
+        _getFieldsMappedToKeyVisualRoles: function() {
+          var fields = [];
+
+          this.$type.eachVisualRole(function(vr) {
+            if(vr.isVisualKey) {
+              this.get(vr.name).fields.each(function(field) {
+                if(fields.indexOf(field.name) === -1) {
+                  fields.push(field.name);
+                }
+              });
+            }
+          }, this);
+
+          return fields;
+        },
+
+        _getFieldsNotMappedToKeyVisualRoles: function() {
+          var keyFields = this._getFieldsMappedToKeyVisualRoles();
+
+          var fields = [];
+
+          this.$type.eachVisualRole(function(vr) {
+            if(!vr.isVisualKey) {
+              this.get(vr.name).fields.each(function(field) {
+                if(keyFields.indexOf(field.name) === -1 && fields.indexOf(field.name) === -1) {
+                  fields.push(field.name);
+                }
+              });
+            }
+          }, this);
+
+          return fields;
+        },
+
         // region serialization
         /** @inheritDoc */
         toSpecInContext: function(keyArgs) {

--- a/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/base/abstractModel.js
@@ -142,38 +142,72 @@ define([
           }, this);
         },
 
-        _getFieldsMappedToKeyVisualRoles: function() {
-          var fields = [];
+        /**
+         * Gets an array of the names of fields which are mapped to _key_ visual roles.
+         *
+         * Conveniently,
+         * the returned array contains an extra property, `set`,
+         * which contains an object whose keys are the field names and
+         * whose values are the value `true`.
+         *
+         * @type {!Array.<string>} The array of field names.
+         * @readOnly
+         *
+         * @see pentaho.visual.role.AbstractProperty.Type#isVisualKey
+         */
+        get keyFieldNames() {
 
-          this.$type.eachVisualRole(function(vr) {
-            if(vr.isVisualKey) {
-              this.get(vr.name).fields.each(function(field) {
-                if(fields.indexOf(field.name) === -1) {
-                  fields.push(field.name);
+          var keyFields = [];
+          var keyFieldSet = keyFields.set = Object.create(null);
+
+          this.$type.eachVisualRole(function(propType) {
+            if(propType.isVisualKey) {
+              this.get(propType).fields.each(function(field) {
+                var name = field.name;
+                if(!O.hasOwn(keyFieldSet, name)) {
+                  keyFieldSet[name] = true;
+                  keyFields.push(name);
                 }
               });
             }
           }, this);
 
-          return fields;
+          return keyFields;
         },
 
-        _getFieldsNotMappedToKeyVisualRoles: function() {
-          var keyFields = this._getFieldsMappedToKeyVisualRoles();
+        /**
+         * Gets an array of the names of fields which are mapped to _measure_ visual roles
+         * and which are not mapped to any _key_ visual roles.
+         *
+         * Conveniently,
+         * the returned array contains an extra property, `set`,
+         * which contains an object whose keys are the field names and
+         * whose values are the value `true`.
+         *
+         * @type {!Array.<string>} The array of field names.
+         * @readOnly
+         * @see pentaho.visual.role.AbstractProperty.Type#isVisualKey
+         */
+        get measureFieldNames() {
 
-          var fields = [];
+          var keyFieldSet = this.keyFieldNames.set;
 
-          this.$type.eachVisualRole(function(vr) {
-            if(!vr.isVisualKey) {
-              this.get(vr.name).fields.each(function(field) {
-                if(keyFields.indexOf(field.name) === -1 && fields.indexOf(field.name) === -1) {
-                  fields.push(field.name);
+          var measureFields = [];
+          var measureFieldSet = measureFields.set = Object.create(null);
+
+          this.$type.eachVisualRole(function(propType) {
+            if(!propType.isVisualKey) {
+              this.get(propType).fields.each(function(field) {
+                var name = field.name;
+                if(!O.hasOwn(keyFieldSet, name) && !O.hasOwn(measureFieldSet, name)) {
+                  measureFieldSet[name] = true;
+                  measureFields.push(name);
                 }
               });
             }
           }, this);
 
-          return fields;
+          return measureFields;
         },
 
         // region serialization

--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -497,6 +497,7 @@ define(function() {
               if(this.panel.axes.base.isDiscrete()) {
                 return this.index > 0;
               }
+
               return this.delegate();
             },
             xAxisGrid_left: function() {
@@ -505,6 +506,7 @@ define(function() {
                 var halfStep = this.panel.axes.base.scale.range().step / 2;
                 return left - halfStep;
               }
+
               return left;
             },
 
@@ -801,7 +803,7 @@ define(function() {
             // If no line width was used, shapes such as crosses could not show.
             legend$Dot_shapeSize: 9, // = (radius - lineWidth / 2) ^ 2
             legend$Dot_lineWidth: 2,
-            legendMarkerSize:     8  // = diameter = 2 * radius
+            legendMarkerSize: 8 // = diameter = 2 * radius
 
           }
         }
@@ -970,11 +972,11 @@ define(function() {
     if(c) {
       c = c.rgb();
 
-      var istate = getInteractionState(this);
+      var iState = getInteractionState(this);
 
-      if(!istate.isActive && istate.isSelected < 0) {
+      if(!iState.isActive && iState.isSelected < 0) {
         c = getPv().color(notSelectedColor);
-      } else if(istate.isActive && istate.isSelected > -1) {
+      } else if(iState.isActive && iState.isSelected > -1) {
         // 20% darker
         c = c.hsl();
         c = c.lightness(c.l * (1 - 0.2));
@@ -991,17 +993,17 @@ define(function() {
     if(c) {
       c = c.rgb();
 
-      var istate = getInteractionState(this);
+      var iState = getInteractionState(this);
 
-      if(!istate.isActive) {
-        if (istate.isSelected < 0) {
+      if(!iState.isActive) {
+        if(iState.isSelected < 0) {
           // TODO: alpha value for non-selected items still under discussion by UX
           c = getPv().color(notSelectedColor);
           c = c.alpha(0.75);
         } else {
           c = c.alpha(0.5);
         }
-      } else if(istate.isActive && istate.isSelected > 0) {
+      } else if(iState.isActive && iState.isSelected > 0) {
         // 20% darker
         c = c.hsl();
         c = c.lightness(c.l * (1 - 0.2));
@@ -1018,11 +1020,11 @@ define(function() {
     if(c) {
       c = c.rgb();
 
-      var istate = getInteractionState(this);
+      var iState = getInteractionState(this);
 
-      if(!istate.isActive && istate.isSelected < 0) {
+      if(!iState.isActive && iState.isSelected < 0) {
         c = getPv().color(notSelectedColor);
-      } else if(istate.isActive && istate.isSelected > -1) {
+      } else if(iState.isActive && iState.isSelected > -1) {
         // 20% darker
         c = c.hsl();
         c = c.lightness(c.l * (1 - 0.2));
@@ -1031,7 +1033,6 @@ define(function() {
 
     return this.finished(c);
   }
-
 
   function getInteractionState(context) {
     var sign = context.sign;

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/abstractMapping.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/abstractMapping.js
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 define([
+  "pentaho/data/util",
   "pentaho/i18n!messages",
 
   // so that r.js sees otherwise invisible dependencies.
   "pentaho/visual/role/mappingField"
-], function(bundle) {
+], function(dataUtil, bundle) {
 
   "use strict";
 
@@ -109,20 +110,8 @@ define([
           if(iref !== null) {
             var data = iref.container.data;
             if(data !== null) {
-              var mappingFields = this.fields;
-              var fieldCount = mappingFields.count;
-              var mappingFieldIndex = -1;
-              fieldIndexes = new Array(fieldCount);
-
-              while(++mappingFieldIndex < fieldCount) {
-                var fieldName = mappingFields.at(mappingFieldIndex).name;
-                var fieldIndex = data.getColumnIndexById(fieldName);
-                if(fieldIndex < 0) {
-                  return null;
-                }
-
-                fieldIndexes[mappingFieldIndex] = fieldIndex;
-              }
+              var mappingFieldNames = this.fields.toArray(function(mappingField) { return mappingField.name; });
+              return dataUtil.getColumnIndexesByIds(data, mappingFieldNames);
             }
           }
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.

Merge along with https://github.com/pentaho/pentaho-analyzer/pull/1781.