### PR TITLE
[PIR-1416] When hovering a warning message on PIR a message with code…

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.html
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.html
@@ -1,4 +1,8 @@
 <div class="dialog-content pentaho-padding-sm" style="width:100%; overflow: auto">
+  <div data-dojo-attach-point="titleBar" class="dijitDialogTitleBar Caption">
+    <span data-dojo-attach-point="titleNode" class="dijitDialogTitle" role="heading" level="1">${title}</span>
+  </div>
+
 	<table width="100%">
     <tbody>
       <tr>

--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
@@ -23,7 +23,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
         messageType: null,                         // options are null, ERROR, WARN, INFO
 
         setTitle: function(title) {
-            this.set("title",title);
+            this.titleNode.innerHTML = title;
         },
 
         postCreate: function() {


### PR DESCRIPTION
… is displayed

Previously, it was used a title attribute, to define the title. But, the title attribute specifies extra information, shown as a tooltip text, when the mouse moves over the element.

@pamval @duarteteixeira 
@ricardosilva88 @pentaho-lmartins