### PR TITLE
[BACKLOG-25910] - Deselecting prompt selection in interactive report …

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/PromptPanel.js
+++ b/impl/client/src/main/javascript/web/prompting/PromptPanel.js
@@ -1156,7 +1156,7 @@ function(Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashb
             var isExist = existingErrors.some(function(item) {
               return item.label == error;
             });
-            if(!isExist) {
+            if(!isExist && !param.multiSelect) {
               var errIndex = panel.components.length - 1;
               var errorComponent = _createWidgetForErrorLabel.call(this, param, error);
               this.dashboard.addComponent(errorComponent);


### PR DESCRIPTION
…causes report to improperly refresh

To fix a regression introduced by - https://jira.pentaho.com/browse/PRD-6019

With this correction we restore the correct behavior of 8.1 GA. Besides that, I identified some more issues, that are already on 8.1 GA. I will create if doesn't exist already, JIRA tickets for these issues (edited: Just opened this ticket - https://jira.pentaho.com/browse/PIR-1418)