### PR TITLE
[SP-4626_fix] - Backport of PRD-6019 - After deleting the input field…

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/PromptPanel.js
+++ b/impl/client/src/main/javascript/web/prompting/PromptPanel.js
@@ -1156,7 +1156,7 @@ function(Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashb
             var isExist = existingErrors.some(function(item) {
               return item.label == error;
             });
-            if(!isExist) {
+            if(!isExist && !param.multiSelect) {
               var errIndex = panel.components.length - 1;
               var errorComponent = _createWidgetForErrorLabel.call(this, param, error);
               this.dashboard.addComponent(errorComponent);


### PR DESCRIPTION
… on the parameter UI, the mandatory parameters validation no longer works and no warning message occurs. (8.1 Suite)

cherry-pick of https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/6c300e9a85b40b9c6d13b3931b0cdcd553858044 - https://jira.pentaho.com/browse/BACKLOG-25910

@pentaho-lmartins or @cravobranco can you please review it?