### PR TITLE
[BACKLOG-26058] Fix `EntityWithNumberKeyStrategy` not being marked as…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/role/adaptation/EntityWithNumberKeyStrategy.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/adaptation/EntityWithNumberKeyStrategy.js
@@ -182,6 +182,11 @@ define([
       id: module.id,
 
       /** @inheritDoc */
+      get isIdentity() {
+        return true;
+      },
+
+      /** @inheritDoc */
       getInputTypeFor: function(outputDataType, isVisualKeyEf) {
 
         if(isVisualKeyEf === false || !outputDataType.isSubtypeOf(PentahoNumber.type)) {

--- a/impl/client/src/main/javascript/web/pentaho/visual/role/adaptation/Strategy.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/role/adaptation/Strategy.js
@@ -252,6 +252,19 @@ define([
       /**
        * Gets a value that indicates if the strategy is an identity strategy.
        *
+       * An _identity_ strategy is one for which each of its input fields
+       * corresponds to exactly one output field and vice-versa,
+       * under the same order.
+       * Moreover,
+       * the value of each input field is either the same as or equivalent to
+       * that of its output field.
+       *
+       * Under this definition,
+       * the following stock strategies are considered _identity_ strategies:
+       * * [IdentityStrategy]{@link pentaho.visual.role.adaptation.IdentityStrategy}
+       * * [TupleStrategy]{@link pentaho.visual.role.adaptation.TupleStrategy}
+       * * [EntityWithNumberKeyStrategy]{@link pentaho.visual.role.adaptation.EntityWithNumberKeyStrategy}
+       *
        * @type {boolean}
        * @readOnly
        * @overridable


### PR DESCRIPTION
… an "identity" strategy.

* Caused the "color" visual role of the scatter chart not to propagate DET's internal model `countMax: 1` constraint.

@kcruzada, @pvale, @pentaho-jlien, @pentaho-svigneri please merge.