### PR TITLE
[BACKLOG-26361] Fixes to VizAPI's JsDocs documentation.

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/type/InstanceType.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/InstanceType.js
@@ -57,8 +57,6 @@ define([
    *
    * For additional information, see the associated _instance class_, {@link pentaho.type.Instance}.
    *
-   * This constructor is the value of {@link pentaho.type.InstanceType}.
-   *
    * @description _Initializes_ the type's singleton object.
    * @param {Object} spec - The specification of this type.
    * @param {!Object} keyArgs - Keyword arguments.

--- a/impl/client/src/main/javascript/web/pentaho/type/loader.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/loader.js
@@ -22,5 +22,15 @@ define([
 
   "use strict";
 
+  /**
+   * The global _Type API_ loader instance.
+   *
+   * Loading this module also pre-loads all standard _Type API_ types.
+   *
+   * @name loader
+   * @type {pentaho.type.ILoader}
+   * @memberOf pentaho.type
+   */
+
   return baseLoader;
 });

--- a/impl/client/src/main/javascript/web/pentaho/util/url.js
+++ b/impl/client/src/main/javascript/web/pentaho/util/url.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2017-2018 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ define([
      * available, {@code url} is going to be parsed and a URL mock
      * will be returned instead.
      *
-     * @param {?String} url - A resource location.
+     * @param {?string} url - A resource location.
      *
      * @return {?URL} the new URL object.
      */
@@ -56,9 +56,9 @@ define([
      *  4. port (optional)
      *  5. pathname (optional)
      *
-     * @param {String} url - A resource location.
+     * @param {string} url - A resource location.
      *
-     * @return {Array.<String>} the parsed url.
+     * @return {Array.<string>} the parsed url.
      */
     parse: parseUrl
   };


### PR DESCRIPTION
These are documentation only changes, but they should enter the branch because the generated documentation will point to the 8.2.0.0-R tag and it contains links to the source code.

@kcruzada, @pamval, @pentaho-jlien, @pentaho-svigneri please merge.
