### PR TITLE
[SP-4756] Backport of BACKLOG-26574 - PAZ: With VizApi2.0, in Scatter…

### DIFF
--- a/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
+++ b/impl/client/src/main/javascript/web/vizapi/ccc/ccc_wrapper.js
@@ -260,6 +260,8 @@ define([
                     {
                         id: 'color',
                         dataType: 'number, string',
+                        // Supports Viz.API integration (`modes` construction).
+                        dataTypeAllowMultiple: {"number": false, "string": true},
                         dataStructure: 'column',
                         caption: dropZoneLabel('SCATTER_COL'),
                         required: false,


### PR DESCRIPTION
… chart it is not possible to add more than one level to "Color By" drop zone (8.2 Suite)

@pentaho/tatooine please review.
/cc @pentaho/millenniumfalcon 

Merge with: https://github.com/pentaho/pentaho-analyzer/pull/1890