### PR TITLE
[SP-4799] DET (Model view) / PAZ: Scatter allows invalid combinations…

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/data/ITable.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/data/ITable.jsdoc
@@ -84,6 +84,28 @@
  */
 
 /**
+ * Gets the name of the hierarchy of a column's attribute, if any, given its index.
+ *
+ * @name pentaho.data.ITable#getColumnHierarchyName
+ * @method
+ * @param {number} colIndex - The column index (zero-based).
+ * @return {?string} The name of the hierarchy.
+ *
+ * @see pentaho.data.ITable#getColumnHierarchyOrdinal
+ */
+
+/**
+ * Gets the ordinal in the hierarchy of a column's attribute, if any, given its index.
+ *
+ * @name pentaho.data.ITable#getColumnHierarchyOrdinal
+ * @method
+ * @param {number} colIndex - The column index (zero-based).
+ * @return {?number} The ordinal of the attribute in the hierarchy.
+ *
+ * @see pentaho.data.ITable#getColumnHierarchyName
+ */
+
+/**
  * Gets a cell, given its row and column indexes.
  *
  * Depending on the underlying implementation, this method may allocate memory.

--- a/impl/client/src/main/javascript/web/pentaho/data/Attribute.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/Attribute.js
@@ -170,6 +170,32 @@ define([
          * @see pentaho.data.Attribute#isContinuous
          */
         this.members = MemberCollection.to(spec.members || [], attrKeyArgs);
+
+        /**
+         * Gets the name of the hierarchy to which the attribute belongs, if any.
+         *
+         * This property is only non-null when the attribute is categorical.
+         *
+         * @type {?string}
+         * @readonly
+         * @see pentaho.data.Attribute#hierarchyOrdinal
+         */
+        this.hierarchyName = spec.hierarchyName || null;
+        if(this.hierarchyName === null) {
+          this.hierarchyOrdinal = null;
+        } else {
+          /**
+           * Gets the order in the hierarchy that the attribute belongs to, if any.
+           *
+           * This property is only defined when the attribute is categorical and
+           * the attribute belongs to a hierarchy.
+           *
+           * @type {?number}
+           * @readonly
+           * @see pentaho.data.Attribute#hierarchyName
+           */
+          this.hierarchyOrdinal = +spec.hierarchyOrdinal || 0;
+        }
       } else if(type === "number") {
         /**
          * Indicates if the attribute represents
@@ -233,6 +259,10 @@ define([
       return this._ord;
     },
     // endregion
+
+    members: null,
+    hierarchyName: null,
+    hierarchyOrdinal: null,
 
     /**
      * Converts a value to the type of value supported by the attribute.
@@ -314,10 +344,14 @@ define([
         isKey: this.isKey
       };
 
-      if(this.isContinuous)
+      if(this.isContinuous) {
         attrSpec.isPercent = this.isPercent;
-      else
+      } else {
         attrSpec.members = this.members.toSpec();
+
+        attrSpec.hierarchyName = this.hierarchyName;
+        attrSpec.hierarchyOrdinal = this.hierarchyOrdinal;
+      }
 
       Annotatable.toSpec(this, attrSpec);
 

--- a/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_AbstractTable.js
@@ -163,7 +163,7 @@ define([
     /** @inheritDoc */
     getColumnProperty: function(colIndex, propName) {
 
-      var attr = this.model.attributes[colIndex];
+      var attr = this.getColumnAttribute(colIndex);
       if(attr) {
         return attr.property(propName);
       }

--- a/impl/client/src/main/javascript/web/pentaho/data/_Table.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_Table.js
@@ -176,6 +176,16 @@ define([
       return this.implem.getColumnLabel(colIndex);
     },
 
+    /** @inheritDoc */
+    getColumnHierarchyName: function(colIndex) {
+      return this.implem.getColumnHierarchyName(colIndex);
+    },
+
+    /** @inheritDoc */
+    getColumnHierarchyOrdinal: function(colIndex) {
+      return this.implem.getColumnHierarchyOrdinal(colIndex);
+    },
+
     // cells
     /** @inheritdoc */
     getValue: function(rowIndex, colIndex) {

--- a/impl/client/src/main/javascript/web/pentaho/data/_TableView.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_TableView.js
@@ -223,6 +223,16 @@ define([
       return this._source.isColumnKey(this.getSourceColumnIndex(colIndex));
     },
 
+    /** @inheritDoc */
+    getColumnHierarchyName: function(colIndex) {
+      return this._source.getColumnHierarchyName(this.getSourceColumnIndex(colIndex));
+    },
+
+    /** @inheritDoc */
+    getColumnHierarchyOrdinal: function(colIndex) {
+      return this._source.getColumnHierarchyOrdinal(this.getSourceColumnIndex(colIndex));
+    },
+
     // cells
     /** @inheritdoc */
     getValue: function(rowIndex, colIndex) {

--- a/impl/client/src/main/javascript/web/pentaho/data/_cross/Table.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_cross/Table.js
@@ -471,14 +471,24 @@ define([
           : this._micCols[k].attribute;
     },
 
-    getColumnType: function(colIndexOrName) {
-      var attr = this.getColumnAttribute(colIndexOrName);
+    getColumnType: function(colIndex) {
+      var attr = this.getColumnAttribute(colIndex);
       if(attr) return attr.type;
     },
 
-    isColumnKey: function(colIndexOrName) {
-      var attr = this.getColumnAttribute(colIndexOrName);
+    isColumnKey: function(colIndex) {
+      var attr = this.getColumnAttribute(colIndex);
       if(attr) return attr.isKey;
+    },
+
+    getColumnHierarchyName: function(colIndex) {
+      var attr = this.getColumnAttribute(colIndex);
+      if(attr) return attr.hierarchyName;
+    },
+
+    getColumnHierarchyOrdinal: function(colIndex) {
+      var attr = this.getColumnAttribute(colIndex);
+      if(attr) return attr.hierarchyOrdinal;
     },
 
     getColumnId: function(colIndex) {

--- a/impl/client/src/main/javascript/web/pentaho/data/_plain/Table.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_plain/Table.js
@@ -70,6 +70,14 @@ define([
       return this.getColumnAttribute(colIndex).isKey;
     },
 
+    getColumnHierarchyName: function(colIndex) {
+      return this.getColumnAttribute(colIndex).hierarchyName;
+    },
+
+    getColumnHierarchyOrdinal: function(colIndex) {
+      return this.getColumnAttribute(colIndex).hierarchyOrdinal;
+    },
+
     // cells
     getValue: function(rowIndex, colIndex) {
       return this.getCell(rowIndex, colIndex).value;

--- a/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config/vizApi.conf.js
@@ -44,6 +44,8 @@ define(function() {
 
   return {
     rules: [
+      // Validates the _key aspect_'s consistency of a visual role's field mappings.
+      //
       // TODO: This should be in AbstractProperty code, however, this can only move
       // when a way is implemented for dealing with CDF's non-key annotated tables.
       // So, for now, this restriction is only being applied to Analyzer and DET.

--- a/impl/client/src/test/javascript/pentaho/data/Attribute.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/Attribute.spec.js
@@ -90,6 +90,31 @@ define([
           attr = expectAttribute({name: "test", isKey: false});
           expect(attr.isKey).toBe(false);
         });
+
+        it("should create an attribute with the value in property `hierarchyName`", function() {
+          var attr = expectAttribute({name: "test", hierarchyName: "Foo"});
+          expect(attr.hierarchyName).toBe("Foo");
+
+          attr = expectAttribute({name: "test"});
+          expect(attr.hierarchyName).toBe(null);
+
+          attr = expectAttribute({name: "test", type: "number", hierarchyName: "Foo"});
+          expect(attr.hierarchyName).toBe(null);
+        });
+
+        it("should create an attribute with the value in property `hierarchyOrdinal`", function() {
+          var attr = expectAttribute({name: "test", hierarchyName: "Foo", hierarchyOrdinal: 1});
+          expect(attr.hierarchyOrdinal).toBe(1);
+
+          attr = expectAttribute({name: "test", hierarchyName: "Foo"});
+          expect(attr.hierarchyOrdinal).toBe(0);
+
+          attr = expectAttribute({name: "test", hierarchyOrdinal: 1});
+          expect(attr.hierarchyOrdinal).toBe(null);
+
+          attr = expectAttribute({name: "test", type: "number", hierarchyName: "Foo", hierarchyOrdinal: 3});
+          expect(attr.hierarchyOrdinal).toBe(null);
+        });
       });
     });
 
@@ -238,7 +263,7 @@ define([
     describe("#members", function() {
       it("should be undefined for continuous attributes", function() {
         var attr = expectAttribute({name: "test", type: "number"});
-        expect(attr.members).toBe(undefined);
+        expect(attr.members).toBe(null);
       });
 
       it("should be an empty array for categorical attributes, when unspecified", function() {
@@ -351,5 +376,4 @@ define([
       });
     });
   });
-
 });

--- a/impl/client/src/test/javascript/pentaho/data/Table.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/Table.spec.js
@@ -1116,6 +1116,40 @@ define([
           expect(dataTable.isColumnKey(2)).toBe(false);
         });
       });
+
+      describe("#getColumnHierarchyName(j) -", function() {
+        it("should return the attribute hierarchyName of the attribute of given column index", function() {
+          var dataTable = new DataTable({
+            model: [
+              {name: "A", type: "number", label: "ABC"},
+              {name: "B", label: "DEF", hierarchyName: "Foo"},
+              {name: "C", label: "GHI"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnHierarchyName(0)).toBe(null);
+          expect(dataTable.getColumnHierarchyName(1)).toBe("Foo");
+          expect(dataTable.getColumnHierarchyName(2)).toBe(null);
+        });
+      });
+
+      describe("#getColumnHierarchyOrdinal(j) -", function() {
+        it("should return the attribute hierarchyOrdinal of the attribute of given column index", function() {
+          var dataTable = new DataTable({
+            model: [
+              {name: "A", type: "number", label: "ABC"},
+              {name: "B", label: "DEF", hierarchyName: "Foo", hierarchyOrdinal: 3},
+              {name: "C", label: "GHI"}
+            ],
+            rows: []
+          });
+
+          expect(dataTable.getColumnHierarchyOrdinal(0)).toBe(null);
+          expect(dataTable.getColumnHierarchyOrdinal(1)).toBe(3);
+          expect(dataTable.getColumnHierarchyOrdinal(2)).toBe(null);
+        });
+      });
     });
 
     describe("cells -", function() {

--- a/impl/client/src/test/javascript/pentaho/data/TableView.spec.js
+++ b/impl/client/src/test/javascript/pentaho/data/TableView.spec.js
@@ -25,7 +25,8 @@ define([
   function getDatasetDT1() {
     return {
       model: [
-        {name: "country", type: "string",  label: "Country", p: {foo: fooValue}, isKey: true},
+        {name: "country", type: "string",  label: "Country", p: {foo: fooValue}, isKey: true,
+          hierarchyName: "Foo", hierarchyOrdinal: 3},
         {name: "sales",   type: "number",  label: "Sales",   p: {bar: barValue}, isContinuous: true},
         {name: "euro",    type: "boolean", label: "Euro"}
       ],
@@ -278,6 +279,13 @@ define([
         });
       });
 
+      describe("#getColumnProperty(j, name) -", function() {
+        it("should return the column property of the given column index and name", function() {
+          expect(dataView.getColumnProperty(1, "foo")).toBe(fooValue);
+          expect(dataView.getColumnProperty(2, "bar")).toBe(barValue);
+        });
+      });
+
       describe("#getColumnRange(j) -", function() {
         it("should return a range object with both min and max `undefined` when there is no data", function() {
           var dataView2 = new DataTableView(dataTable);
@@ -339,6 +347,22 @@ define([
           expect(dataView.isColumnKey(0)).toBe(false);
           expect(dataView.isColumnKey(1)).toBe(true);
           expect(dataView.isColumnKey(2)).toBe(false);
+        });
+      });
+
+      describe("#getColumnHierarchyName(j) -", function() {
+        it("should return the attribute hierarchyName of the attribute of given column index", function() {
+          expect(dataView.getColumnHierarchyName(0)).toBe(null);
+          expect(dataView.getColumnHierarchyName(1)).toBe("Foo");
+          expect(dataView.getColumnHierarchyName(2)).toBe(null);
+        });
+      });
+
+      describe("#getColumnHierarchyOrdinal(j) -", function() {
+        it("should return the attribute hierarchyOrdinal of the attribute of given column index", function() {
+          expect(dataView.getColumnHierarchyOrdinal(0)).toBe(null);
+          expect(dataView.getColumnHierarchyOrdinal(1)).toBe(3);
+          expect(dataView.getColumnHierarchyOrdinal(2)).toBe(null);
         });
       });
 

--- a/impl/client/src/test/javascript/pentaho/visual/role/adaptation/EntityWithTimeIntervalKeyStrategy.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/role/adaptation/EntityWithTimeIntervalKeyStrategy.spec.js
@@ -34,7 +34,8 @@ define([
       months: 0,
       years: 1,
       other: 2,
-      measure: 3
+      years2: 3,
+      measure: 4
     };
 
     var datasetFieldIndexes2 = {
@@ -49,6 +50,7 @@ define([
           "[Time].[Months]",
           "[Time].[Years]",
           "[Time].[Other]",
+          "[Time2].[Years]",
           "[MEASURE:0]"
         ],
         "rows": [
@@ -65,6 +67,10 @@ define([
               {
                 "v": "[Time].[Other1]",
                 "f": "Other1"
+              },
+              {
+                "v": "[Time2].[2004]",
+                "f": "2004"
               },
               {
                 "v": 110756.29999999999,
@@ -87,6 +93,10 @@ define([
                 "f": "Other2"
               },
               {
+                "v": "[Time2].[2005]",
+                "f": "2005"
+              },
+              {
                 "v": 254838.01999999996,
                 "f": "254,838"
               }
@@ -99,12 +109,16 @@ define([
                 "f": "Jan"
               },
               {
-                "v": "[Time].[2004]",
+                "v": "[Time].[2005]",
                 "f": "2005"
               },
               {
                 "v": "[Time].[Other3]",
                 "f": "Other3"
+              },
+              {
+                "v": "[Time2].[2006]",
+                "f": "2006"
               },
               {
                 "v": 187418.05,
@@ -157,12 +171,16 @@ define([
               "isKey": true,
               "members": [
                 {
-                  "v": "[Time].[2003]",
-                  "f": "2003"
+                  "v": "[Time2].[2004]",
+                  "f": "2004"
                 },
                 {
-                  "v": "[Time].[2004]",
-                  "f": "2004"
+                  "v": "[Time2].[2005]",
+                  "f": "2005"
+                },
+                {
+                  "v": "[Time2].[2006]",
+                  "f": "2006"
                 }
               ],
               "p": {
@@ -191,6 +209,30 @@ define([
                   "f": "Other3"
                 }
               ]
+            },
+            {
+              "name": "[Time2].[Years]",
+              "label": "Years2",
+              "type": "string",
+              "hierarchyName": "Time2",
+              "hierarchyOrdinal": 0,
+              "isKey": true,
+              "members": [
+                {
+                  "v": "[Time2].[2003]",
+                  "f": "2003"
+                },
+                {
+                  "v": "[Time2].[2004]",
+                  "f": "2004"
+                }
+              ],
+              "p": {
+                "EntityWithTimeIntervalKey": {
+                  "duration": "year",
+                  "isStartDateTimeProvided": false
+                }
+              }
             },
             {
               "name": "[MEASURE:0]",
@@ -425,6 +467,15 @@ define([
               [datasetFieldIndexes1.years, datasetFieldIndexes1.months]
             );
             expect(result).toEqual(jasmine.objectContaining({isValid: true}));
+          });
+
+          it("should return an object with isValid: false when not all fields are " +
+            "from the same hierarchy", function() {
+            var result = Strategy.type.validateApplication(
+              dataTable,
+              [datasetFieldIndexes1.years, datasetFieldIndexes1.months, datasetFieldIndexes1.years2]
+            );
+            expect(result).toEqual(jasmine.objectContaining({isValid: false}));
           });
         });
 


### PR DESCRIPTION
… on axis drop zones (#1351)

* [BACKLOG-26166] Add `hierarchyName` and `hierarchyOrder` to the `DataTable`'s attributes and associated `ITable` methods

* [BACKLOG-26166] Fix `ITable.getColumnProperty` implementation for `DataView` and normalized `Attribute.members` to be `null` when continuous.

* [BACKLOG-26166] Rewrite `pentaho.visual.role.util.getBestRoleForAddingField` to take advantage of `ITable.getColumnHierarchyName`

* [BACKLOG-26166] Add same hierarchy validation to `pentaho.visual.role.adaptation.EntityWithTimeIntervalKeyStrategyType`

* [BACKLOG-26166] Add utility methods to `pentaho/visual/role/util`, `getRoleFirstHierarchy` and `getHierarchyNextOrdinal`.

@pentaho/tatooine please review
/cc @pentaho/millenniumfalcon 

Merge with:
* https://github.com/pentaho/pentaho-analyzer/pull/1897
* https://github.com/pentaho/pentaho-det/pull/1283
* https://github.com/pentaho/pentaho-det-ee/pull/577