### PR TITLE
[SP-4812] - Backport of PRD-6036 - After deleting the input field on …

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/parameters/ParameterValidator.js
+++ b/impl/client/src/main/javascript/web/prompting/parameters/ParameterValidator.js
@@ -107,9 +107,11 @@ define(['cdf/lib/Base'],
 
           // validate untrusted parameter value
           if(currentParameter.mandatory) {
-            if(typeof untrustedValue == 'undefined' || untrustedValue == '') {
+            if(typeof untrustedValue == 'undefined') {
               // add error
               addErrorToParameter(paramDefn, paramName, "This prompt value is of an invalid value");
+            } else if(untrustedValue == ''){
+              addErrorToParameter(paramDefn, paramName, "This prompt is mandatory");
             }
           }
           var values = [];


### PR DESCRIPTION
…the parameter UI, the wrong warning message appears (8.2 Suite)

Cherry-pick of https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/fc5403a7639ed73cd28f57f1c3f7ab9eafd26797

@ppatricio @RPAraujo 