### PR TITLE
[BACKLOG-27250] Removes unused pentaho-platform-core-tests dependency

### DIFF
--- a/impl/server/pom.xml
+++ b/impl/server/pom.xml
@@ -138,12 +138,6 @@
       <artifactId>pentaho-platform-core</artifactId>
       <version>${platform.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
@@ -192,13 +186,6 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-platform-core</artifactId>
-      <version>${platform.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
@pentaho/rogueone Please review - slightly unsure on this one as this means we are pulling in transitives for the compile target, but it leaves it available for the tests to use them (previously done by the platform-tests artifact), and it is still in the provided scope so it hasn't changed the built plugin artifacts.

Related PRs: