### PR TITLE
[BISERVER-13901] When auto-submit is off, the report parameter/prompt panel flashes/gl…

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/PromptPanel.js
+++ b/impl/client/src/main/javascript/web/prompting/PromptPanel.js
@@ -1405,7 +1405,7 @@ function(Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashb
 
         // Must submit, independently of auto-submit value.
         // All parameters are initialized, fire the submit
-        fireSubmit = !noAutoAutoSubmit;
+        fireSubmit = (noAutoAutoSubmit != null) && !noAutoAutoSubmit;
       }
 
       if(this.forceSubmit || fireSubmit) {


### PR DESCRIPTION
…ass pane appears when parameter is TEXT field.

Depends on https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/682

@pentaho/tatooine @pentaho-lmartins 
@dcleao 