### PR TITLE
[BACKLOG-27908] Fix forgotten `fdescribe`.

### DIFF
--- a/impl/client/src/test/javascript/pentaho/type/Instance.spec.js
+++ b/impl/client/src/test/javascript/pentaho/type/Instance.spec.js
@@ -139,7 +139,7 @@ define([
       });
     });
 
-    fdescribe(".configure(spec)", function() {
+    describe(".configure(spec)", function() {
 
       it("should call implement with the given spec", function() {
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.