### PR TITLE
[BACKLOG-28948] When the visualization Model was given a changeset wi…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/type/action/ComplexChangeset.js
+++ b/impl/client/src/main/javascript/web/pentaho/type/action/ComplexChangeset.js
@@ -251,7 +251,9 @@ define([
 
       var targetVersion = changeset.targetVersion;
       if(targetVersion < this.targetVersion) {
-        throw error.argInvalid("changeset.targetVersion", "Cannot compose with a changeset which has a previous target version.");
+        throw error.argInvalid(
+          "changeset.targetVersion",
+          "Cannot compose with a changeset which has a previous target version.");
       }
 
       var transaction =  changeset.transaction;

--- a/impl/client/src/main/javascript/web/pentaho/visual/Model.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/Model.js
@@ -302,10 +302,10 @@ define([
     _onChangeFinally: function(transaction) {
 
       if(transaction.isDone) {
-        if(this.isAutoUpdate) {
+        if(this.isAutoUpdate && transaction.action.hasChanges) {
           this._onAutoUpdate();
         } else {
-          // Capture change.
+          // Capture change / update version number.
           /* eslint-disable-next-line no-unused-expressions */
           this.isDirtyNew;
         }
@@ -743,6 +743,8 @@ define([
    *
    * A full changeset combined with any other changeset remains a full changeset.
    *
+   * If the composed changeset would not have changes, `null` is returned.
+   *
    * @param {?pentaho.type.action.ComplexChangeset|pentaho.visual.action.FullChangeset} changeset1 - The first
    * changeset.
    * @param {?pentaho.type.action.ComplexChangeset|pentaho.visual.action.FullChangeset} changeset2 - The second
@@ -751,6 +753,8 @@ define([
    * @return {?pentaho.type.action.ComplexChangeset|pentaho.visual.action.FullChangeset} The combined changeset.
    */
   function __combineChangesets(changeset1, changeset2) {
+    var result;
+
     if(changeset1 != null && changeset2 != null) {
       if(changeset1 === __fullChangeset) {
         return __fullChangeset;
@@ -760,9 +764,11 @@ define([
         return __fullChangeset;
       }
 
-      return changeset1.compose(changeset2);
+      result = changeset1.compose(changeset2);
+    } else {
+      result = changeset1 || changeset2;
     }
 
-    return changeset1 || changeset2;
+    return result != null && result.hasChanges ? result : null;
   }
 });

--- a/impl/client/src/test/javascript/pentaho/visual/Model.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/Model.spec.js
@@ -451,6 +451,30 @@ define([
         expect(model.update).toHaveBeenCalled();
       });
 
+      it("should not call #update when #isAutoUpdate is `true` and the properties change has no changes", function() {
+
+        var model = createValidCleanModel(true);
+
+        spyOn(model, "update").and.returnValue(Promise.resolve());
+
+        var initSpy = jasmine.createSpy().and.callFake(function() {
+          // Set to default value again.
+          this.width = null;
+        });
+
+        model.on("change", {
+          init: initSpy
+        });
+
+        model.width = 200;
+
+        expect(initSpy).toHaveBeenCalled();
+        expect(model.update).not.toHaveBeenCalled();
+
+        expect(model.isDirty).toBe(false);
+        expect(model.isDirtyNew).toBe(false);
+      });
+
       // Coverage.
       // TODO: should test that logger.debug is called.
       it("should log the rejected case of an auto-update", function() {


### PR DESCRIPTION
…th no changes (happens when an init listener resets to the original value), it still marked itself as dirty.

The fact that the DET pivot table systematically fails the conversion of the internal filter to external form, due to not having local data, this causes any attempt to modify the selection filter to turn into setting it to null (the default value). When, initially, the selectionFilter was already the default, setting it to something else would cause the model to become dirty from them on... The Pivot Table would then stop processing selections, as actions of dirty models are immediately canceled.

@pentaho/millenniumfalcon please review.

Merge with:
- https://github.com/pentaho/pentaho-analyzer/pull/1958
- https://github.com/pentaho/pentaho-det/pull/1306