### PR TITLE
[BACKLOG-29056] Unable to drag all string and number fields into Weka…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/ccc/visual/_util.js
+++ b/impl/client/src/main/javascript/web/pentaho/ccc/visual/_util.js
@@ -97,7 +97,10 @@ define([
             : cccScene.data();
 
         cccRoles = cccRoles.filter(function(cccRole) {
-          return cccRole.isMeasureEffective && cccRole.isBoundDimensionName(cccGroup, dimName);
+          // NOTE: `dimName` is assumed to belong to the measure axis, so,
+          // it doesn't really matter if it's really seen as a measure or not for CCC.
+          // CCC's isMeasureEffective is mixed with using a discrete or continuous scale.
+          return !cccRole.isMeasureEffective || cccRole.isBoundDimensionName(cccGroup, dimName);
         });
 
         if(cccRoles.length === 0) {

--- a/impl/client/src/main/javascript/web/pentaho/visual/models/MetricPointAbstract.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/models/MetricPointAbstract.js
@@ -71,7 +71,6 @@ define([
           // Modal visual role
           name: "color", // VISUAL_ROLE
           base: "pentaho/visual/role/Property",
-          isVisualKey: false,
           modes: [
             {dataType: "number"},
             {dataType: "list"} // Catch-all.

--- a/impl/client/src/test/javascript/pentaho/visual/role/adaptation/TupleStrategy.spec.js
+++ b/impl/client/src/test/javascript/pentaho/visual/role/adaptation/TupleStrategy.spec.js
@@ -260,12 +260,22 @@ define([
         ]);
       });
 
-      it("should return cell corresponding to given existing value (with undefined positions)", function() {
+      it("should return cell corresponding to given existing value (with undefined right positions)", function() {
 
         var outputCells = strategy.map(["A", undefined]);
 
         expect(outputCells).toEqual([
           jasmine.objectContaining({value: "A", formatted: "AA1"})
+        ]);
+      });
+
+      it("should return cell corresponding to given existing value (with undefined left positions)", function() {
+
+        var outputCells = strategy.map([undefined, "PT"]);
+
+        expect(outputCells).toEqual([
+          undefined,
+          jasmine.objectContaining({value: "PT", formatted: "Portugal"})
         ]);
       });
 
@@ -368,11 +378,21 @@ define([
         ]);
       });
 
-      it("should return two cells corresponding to given existing values (with undefined position)", function() {
+      it("should return two cells corresponding to given existing values (with undefined right position)", function() {
         var inputCells = strategy.invert(["A", undefined]);
 
         expect(inputCells).toEqual([
           jasmine.objectContaining({value: "A", formatted: "AA1"})
+        ]);
+      });
+
+      it("should return two cells corresponding to given existing values (with undefined left position)", function() {
+
+        var inputCells = strategy.invert([undefined, "PT"]);
+
+        expect(inputCells).toEqual([
+          undefined,
+          jasmine.objectContaining({value: "PT", formatted: "Portugal"})
         ]);
       });
     });


### PR DESCRIPTION
… visualization

- Fix CCC views's tooltip to also display measure fields which happen to be CCC discrete dimensions (part of VR with a discrete scale).
- Removed isVisualKey: false from MetrictPointAbstract - was not doing anything in a visualKeyType/dataOrdinal viz.
- Made `TupleStrategy` be able to map and invert values arrays which have `undefined` values in any position.
  This was required to be able to handle selections/drills, through the ModelAdapter, for VRs with mixed key/measure (e.g. scatter color with a measure and then a key) .

@pentaho/millenniumfalcon please review.

Merge with:
- https://github.com/pentaho/pentaho-analyzer/pull/1960
- https://github.com/webdetails/ccc/pull/363