### PR TITLE
[BACKLOG-29026] Report Viewer: report only displays the first date se…

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/PromptPanel.js
+++ b/impl/client/src/main/javascript/web/prompting/PromptPanel.js
@@ -1380,7 +1380,7 @@ function(Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashb
         if(this.onAfterRender) {
           this.onAfterRender();
         }
-      } else if(this.diff && (this.diff.toAdd.parameters || this.diff.toChangeData.parameters || this.diff.toRemove.parameters || this.isForceRefresh)) { // Perform update when there are differences
+      } else if(this.diff) {
         this.update(this.diff);
 
         var layout = this.dashboard.getComponentByName("prompt" + this.guid);


### PR DESCRIPTION
…lected on DatePicker parameter

partial revert of the issue PIR-1418 (https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1370/files)
solves BACKLOG-29026, BACKLOG-29030 and keeps PIR-1418 working as expected.

@pentaho-lmartins @pamval @ricardosilva88 @RPAraujo 