### PR TITLE
[PIR-1442] Activating auto-refresh after adding a prompt in an Interactive Report causes report to become non-responsive

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/impl/client/src/main/javascript/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,11 @@ define([], function() {
         // Force change on null value params back to originally selected value
         for (var i in nullValueParams) {
           var nullValueParam = nullValueParams[i];
+          // if the parameter is on the old definition, we ignore it as is the same
+          var oldParam = oldParamDefn.getParameter(nullValueParam.name);
+          if (oldParam && (!this._isBehavioralAttrsChanged(oldParam, nullValueParams[i]))){
+            continue;
+          }
           newParamDefn.mapParameters(function(param, group) {
             if (nullValueParam.name == param.name) {
               param.forceUpdate = true;

--- a/impl/client/src/test/javascript/prompting/parameters/ParameterDefinitionDiffer.spec.js
+++ b/impl/client/src/test/javascript/prompting/parameters/ParameterDefinitionDiffer.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,6 +210,30 @@ define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parame
                 expect(nullValueParamCallbackVal).toBe(false);
                 expect(parameterDefinitionDiffer._fillWrapObj).toHaveBeenCalledWith(jasmine.any(Object), "toChangeData",
                   nullValueParamGroupSpy, nullValueParamSpy)
+            });
+
+            it("should add null parameter if not already at paramDefOld",function(){
+                var paramDefnOld = createParamDefn("dummyOld",1);
+                var paramDefnNew = createParamDefn("dummyNew",1);
+                var paramDefNull = [paramDefnNew.getParameter("dummyNew")];
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew,paramDefNull);
+
+                expect(Object.keys(result.toAdd).length).toBe(1);
+                expect(Object.keys(result.toChangeData).length).toBe(1);
+                expect(Object.keys(result.toRemove).length).toBe(1);
+            });
+
+            it("should not add null parameter if already at paramDefOld",function(){
+                var paramDefnOld = createParamDefn("dummy",1);
+                var paramDefnNew = createParamDefn("dummy",1);
+                var paramDefNull = [paramDefnNew.getParameter("dummy")];
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew,paramDefNull);
+
+                expect(Object.keys(result.toAdd).length).toBe(0);
+                expect(Object.keys(result.toChangeData).length).toBe(0);
+                expect(Object.keys(result.toRemove).length).toBe(0);
             });
 
             it("should return result with added and removed parameters", function() {


### PR DESCRIPTION
Bug fix: Activating auto-refresh after adding a prompt in an Interactive Report causes report to become non-responsive