### PR TITLE
[PRD-6041] Data Format specified in the Parameter is not working as e…

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/builders/TextInputBuilder.js
+++ b/impl/client/src/main/javascript/web/prompting/builders/TextInputBuilder.js
@@ -93,6 +93,8 @@ define(['cdf/components/TextInputComponent', './FormattedParameterWidgetBuilderB
               if (!uiValue) {
                 uiValue = transportValue;
               }
+            } else {
+              uiValue = transportValue;
             }
             return uiValue;
           },
@@ -111,6 +113,8 @@ define(['cdf/components/TextInputComponent', './FormattedParameterWidgetBuilderB
               } else {
                 transportValue = uiValue;
               }
+            } else {
+              transportValue = uiValue;
             }
             return transportValue;
           },


### PR DESCRIPTION
…xpected.

@pentaho/tatooine @pentaho-lmartins @bantonio82 
@dcleao 

Today, I found out that if the parameter had no formatter, it was returning undefined. 
That was because we were expecting a formatter.