### PR TITLE
[PRD-6070] Date Picker showing incorrect value when client is in diff…

### DIFF
--- a/impl/client/src/test/config/javascript/karma.ci.conf.js
+++ b/impl/client/src/test/config/javascript/karma.ci.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
       "karma-requirejs",
       "karma-junit-reporter",
       "karma-coverage",
-      "karma-phantomjs-launcher"
+      "karma-chrome-launcher"
     ],
 
     reporters: ["progress", "junit", "coverage"],
@@ -55,7 +55,7 @@ module.exports = function(config) {
 
     autoWatch: false,
 
-    browsers: ["PhantomJS"],
+    browsers: ["ChromeHeadless"],
 
     singleRun: true
   });


### PR DESCRIPTION
…erent day due to Timezone difference

In the context of https://github.com/Pentaho/pentaho-platform-plugin-common-ui/commit/285f7e06daf130c448c224de560e124309cbb090 was found that the newly added test wouldn't run using the headless browser "PhantomJS". 
Changing the browser to "HeadlessChrome" makes the test work. Also, of course, all other tests still run successfully. 

@pentaho-lmartins 