### PR TITLE
[BACKLOG-29550] Fix JS documentation for class `pentaho.visual.impl.View`

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/impl/View.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/impl/View.js
@@ -41,8 +41,8 @@ define([
   var BaseView = Base.extend(module.id, /** @lends pentaho.visual.impl.View# */{
 
     /**
-     * @alias BaseView
-     * @memberOf pentaho.visual.base
+     * @alias View
+     * @memberOf pentaho.visual.impl
      *
      * @class
      * @extends pentaho.lang.Base


### PR DESCRIPTION
@kcruzada please merge.

We need to update the 8.3 branch to be able to generate the fixed JavaScript reference documentation from it.

Related master PR: https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1452.

/cc @pentaho/millenniumfalcon 