### PR TITLE
[BACKLOG-29696] Add `withCredentials` to the `pentaho/csrf/service` r…

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/csrf/service.js
+++ b/impl/client/src/main/javascript/web/pentaho/csrf/service.js
@@ -49,11 +49,15 @@ define([
         return null;
       }
 
-      var csrfServiceUrl = serverBaseUrl + "api/system/csrf";
+      // Sending the URL as a parameter and not as a header to avoid becoming a pre-flight request.
+      var csrfServiceUrl = serverBaseUrl + "api/system/csrf?url=" + encodeURIComponent(url);
 
       var xhr = service.__createXhr();
       xhr.open("GET", csrfServiceUrl, /* async: */false);
-      xhr.setRequestHeader("X-CSRF-SERVICE", url);
+
+      // In Cross-Origin contexts, the session where the token is stored must be the same
+      // as that used by the actual request...
+      xhr.withCredentials = true;
       xhr.send();
 
       if(xhr.status === 204 || xhr.status === 200) {


### PR DESCRIPTION
…equest, to support cross-origin requests.

Also, change sending the protected service's URL from a request header to a parameter.

@pentaho/millenniumfalcon please review.