### PR TITLE
[BISERVER-14306] Multi Value List parameter values are reset after changing output type in a prpt report

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/parameters/ParameterDefinition.js
+++ b/impl/client/src/main/javascript/web/prompting/parameters/ParameterDefinition.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +151,13 @@ define(['common-ui/jquery-clean'], function ($) {
             if(newParameter.name === oldParam.name){
               var index = group.parameters.indexOf(oldParam);
               group.parameters[index].values = newParameter.values;
+              /*
+               * [BISERVER-14306]
+               * In case this particular parameter has a timezoneHint, we need to persist it
+               */
+              if(newParameter.timezoneHint !== undefined){
+                group.parameters[index].timezoneHint = newParameter.timezoneHint;
+              }
               return;
             }
           }, this );

--- a/impl/client/src/test/javascript/prompting/parameters/ParameterDefinition.spec.js
+++ b/impl/client/src/test/javascript/prompting/parameters/ParameterDefinition.spec.js
@@ -119,5 +119,15 @@ define([ 'common-ui/prompting/parameters/ParameterDefinition',  'common-ui/promp
         expect(param).not.toBeDefined();
       });
     });
+
+    describe("updateParameter", function() {
+      it("should update the previous parameter to have a new timezone hint if the new parameter has one", function() {
+        parameterDefinition.parameterGroups.push({'name': "test-parameterGroup", 'parameters': [{'name': "param-to-update"}]});
+        var param = {'name': "param-to-update", 'timezoneHint': "0400"};
+        parameterDefinition.updateParameterValue(param);
+        var newParam = parameterDefinition.getParameter("param-to-update");
+        expect(newParam.timezoneHint).toBe("0400");
+      });
+    });
   });
 });


### PR DESCRIPTION
@pentaho/tatooine @ssamora @pentaho-lmartins @tmorgner

* [BISERVER-14306] Fix tied to this ticket. Needed to add a option for timezoneHints to be persisted with the parameter values (if it exists). This is because when a prompt parameter is created, it sets it to whatever the server sets it to be (checking the node value), so most of the time, it will be undefined (unless it's a date object).  So it's important to persist this, especially when you're dealing with changing from a timezone without DST and a timezone with one (i.e. March 10, 2019 -> EST, March 11, 2019 -> EDT).

Pull Request is from a set of two PRs:
* https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/738
* https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1475