### PR TITLE
[BACKLOG-31898] Hide the CSRF client API documentation.

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/csrf/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/csrf/_namespace.jsdoc
@@ -19,5 +19,6 @@
  *
  * @name pentaho.csrf
  * @namespace
+ * @private
  */
 


### PR DESCRIPTION
We don't want to reveal the documentation for the CSRF API just yet, as this will not be available for all customers in 9.0.
Also, the documented version has the identifier `pentaho/csrf/service` and, under the pending CSRF refactoring, this module has moved to a Web Package module published under the identifier `@pentaho/csrf`...

Another module, `common-ui/util/pentaho-csrf`, was defined some commits ago to be used by AMD modules which are not in WebPackages. We have not replaced all internal uses of `pentaho/csrf/service` for `common-ui/util/pentaho-csrf`, but this is acceptable, as it is an internal implementation detail.

@pentaho/millenniumfalcon please review.