### PR TITLE
[BISERVER-14512] - Text box values are only displayed for about a second in prpt reports published to PUC

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/components/StaticAutocompleteBoxComponent.js
+++ b/impl/client/src/main/javascript/web/prompting/components/StaticAutocompleteBoxComponent.js
@@ -84,7 +84,7 @@ define([ 'common-ui/util/util', 'cdf/components/BaseComponent',  'amd!cdf/lib/jq
       }.bind(this));
 
       // Obtain initial value.
-      var initialValue = null;
+      var initialValue;
       if(this.parameter) {
         $.each(this.param.values, function(i, v) {
           if(v.selected) {
@@ -98,7 +98,7 @@ define([ 'common-ui/util/util', 'cdf/components/BaseComponent',  'amd!cdf/lib/jq
       if(input.length === 0) {
         // Initialize autocomplete.
         this._createAndInitializeInputAutocompleteElement(ph, initialValue);
-      } else if(initialValue !== this.prevSelValue) {
+      } else if(initialValue !== this.prevSelValue && initialValue !== undefined) {
         //Update current value
         input.val(initialValue);
       }
@@ -132,7 +132,7 @@ define([ 'common-ui/util/util', 'cdf/components/BaseComponent',  'amd!cdf/lib/jq
     _createAndInitializeInputAutocompleteElement: function(ph, initialValue) {
       var html = '<input type="text" id="' + this.htmlObject + '-input"';
 
-      if (initialValue != null) {
+      if (initialValue !== undefined) {
         html += ' value="' + initialValue + '"';
       }
 


### PR DESCRIPTION
@pentaho-lmartins 
@ssamora 
@smmribeiro 

It was always setting a null value when it doesn't receive a initial value from parameter. 
A similar check was already in create method.