### PR TITLE
[ANALYZER-3942] Localized date tick formatting for CCC based stock visualizations

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/environment/spec/IEnvironment.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/environment/spec/IEnvironment.jsdoc
@@ -60,6 +60,8 @@
  *
  * Locales are converted to lower-case. Case differences are not significant.
  *
+ * Locales with an invalid syntax are discarded.
+ *
  * @name locale
  * @memberOf pentaho.environment.spec.IEnvironment#
  * @type {?nonEmptyString}

--- a/impl/client/src/main/javascript/web/pentaho/data/_WithCellTupleBase.js
+++ b/impl/client/src/main/javascript/web/pentaho/data/_WithCellTupleBase.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2010 - 2021 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,18 @@ define([
     // keyArgs: structure
     constructor: function(keyArgs) {
       this.cellTupleBase = CellTuple.Adhoc.to([], keyArgs);
-      this.cellTupleBase.constructor = CellTuple.Adhoc;
+
+      // Rhino complains that `constructor` is a read-only property,
+      // if we set this.cellTupleBase.constructor directly.
+      // However, per the above call, from Class.to, and then to pentaho.util.Object.applyClass,
+      // it is a writable property. This is probably a Rhino bug.
+      // Anyway, this goes around that by redefining the property.
+      Object.defineProperty(this.cellTupleBase, "constructor", {
+        // enumerable: false,
+        configurable: true,
+        writable: true,
+        value: CellTuple.Adhoc
+      });
     },
 
     // keyArgs: {}

--- a/impl/client/src/main/javascript/web/pentaho/environment/impl/Environment.js
+++ b/impl/client/src/main/javascript/web/pentaho/environment/impl/Environment.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2010 - 2021 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,22 @@ define([
      cYrL-Mn" (or any other combination), and each of these variations.
     */
     var locale = readVar(spec, "locale", defaultSpec);
+    if(locale) {
+      // Java sends these non BCP-47 conforming separators.
+      locale = locale.replace(/[_/]/, "-");
+
+      // Validate that it is a valid locale; discard, otherwise.
+      // TODO: The current testing environment, PhantomJS, does not support Intl.
+      if(typeof Intl !== "undefined") {
+        try {
+          // eslint-disable-next-line no-new
+          new Intl.Locale(locale);
+        } catch(error) {
+          locale = null;
+        }
+      }
+    }
+
     this.locale = locale && locale.toLowerCase();
 
     var propSpec = readVar(spec, "user");

--- a/impl/client/src/main/javascript/web/pentaho/i18n/serverService.js
+++ b/impl/client/src/main/javascript/web/pentaho/i18n/serverService.js
@@ -42,7 +42,7 @@ define([
         var bundleInfo = __getBundleInfo(localRequire, bundlePath);
         var serverUrl = environment.server.root;
 
-        // Taking into account embedded scenarios when the host
+        // Taking into account embedded scenarios, where the host
         // is not the Pentaho Server / PDI
         var bundleUrl = "json!" + serverUrl +
           "i18n?plugin=" + bundleInfo.pluginId + "&name=" + bundleInfo.name;

--- a/impl/client/src/main/javascript/web/pentaho/visual/config.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2016 - 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2016 - 2021 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,13 @@ define(function() {
 
   var vizApiFont = "10px OpenSansRegular";
   var maxHorizontalTextWidth = 117;
+
+  var MS_PER_DAY = 864e5;
+  var MS_PER_WEEK = 7 * MS_PER_DAY;
+  var MS_PER_MONTH = 30 * MS_PER_DAY;
+
+  var dayFormatCached = null;
+  var monthFormatCached = null;
 
   var numberFormatCache = {};
   var numberStyle = {
@@ -265,71 +272,110 @@ define(function() {
         select: {
           module: "pentaho/ccc/visual/CartesianAbstract"
         },
-        apply: {
-          extension: {
-            margins:  0,
-            paddings: 0,
+        deps: [
+          "pentaho/environment"
+        ],
+        apply: function(environment) {
+          return {
+            extension: {
+              margins:  0,
+              paddings: 0,
 
-            // Chart
-            contentMargins: {top: 30, bottom: 30},
+              // Chart
+              contentMargins: {top: 30, bottom: 30},
 
-            // Cartesian Axes
-            axisComposite: false,
-            axisSizeMax: "50%",
-            xAxisPosition: "bottom",
-            yAxisPosition: "left",
+              // Cartesian Axes
+              axisComposite: false,
+              axisSizeMax: "50%",
+              xAxisPosition: "bottom",
+              yAxisPosition: "left",
 
-            panelSizeRatio: 0.8,
+              panelSizeRatio: 0.8,
 
-            // . title
-            axisTitleVisible: true,
-            axisTitleSizeMax: "20%",
-            axisTitleLabel_textMargin: 0,
+              // . title
+              axisTitleVisible: true,
+              axisTitleSizeMax: "20%",
+              axisTitleLabel_textMargin: 0,
 
-            xAxisTitleAlign: "left",
-            x2AxisTitleAlign: "left",
-            x3AxisTitleAlign: "left",
+              xAxisTitleAlign: "left",
+              x2AxisTitleAlign: "left",
+              x3AxisTitleAlign: "left",
 
-            yAxisTitleAlign: "top",
-            y2AxisTitleAlign: "top",
-            y3AxisTitleAlign: "top",
+              yAxisTitleAlign: "top",
+              y2AxisTitleAlign: "top",
+              y3AxisTitleAlign: "top",
 
-            // . label
-            discreteAxisLabel_ibits: 0,
-            discreteAxisLabel_imask: "ShowsActivity|Hoverable",
+              // . label
+              discreteAxisLabel_ibits: 0,
+              discreteAxisLabel_imask: "ShowsActivity|Hoverable",
 
-            axisLabel_textMargin: 10,
+              axisLabel_textMargin: 10,
 
-            xAxisOverlappedLabelsMode: "rotatethenhide",
-            xAxisLabelRotationDirection: "clockwise",
-            xAxisLabelDesiredAngles: [0, 40 * (Math.PI / 180)],
+              xAxisOverlappedLabelsMode: "rotatethenhide",
+              xAxisLabelRotationDirection: "clockwise",
+              xAxisLabelDesiredAngles: [0, 40 * (Math.PI / 180)],
 
-            numericAxisTickFormatter: function(value, precision) {
-              return getNumberFormatter(precision, this.base)(value);
-            },
+              numericAxisTickFormatter: function(value, precision) {
+                return getNumberFormatter(precision, this.base)(value);
+              },
 
-            // . grid
-            axisGrid: false,
-            continuousAxisGrid: true,
+              timeSeriesAxisTickFormatter: function(value) {
+                // Use the Intl API to achieve localized date formatting.
 
-            axisGrid_lineWidth:   1,
-            axisGrid_strokeStyle: "#CCC",
+                switch(this.base) {
+                  case MS_PER_DAY:
+                  case MS_PER_WEEK:
+                    if(dayFormatCached == null) {
+                      // Empty array is to use the browser's default locale.
+                      dayFormatCached = new Intl.DateTimeFormat(environment.locale || [], {
+                        year: "numeric",
+                        month: "numeric",
+                        day: "numeric"
+                      });
+                    }
 
-            // . rule
-            axisRule_lineWidth: 1,
-            axisRule_strokeStyle: "#999999",
+                    return dayFormatCached.format(value);
 
-            // . ticks
-            axisTicks: true,
-            axisMinorTicks: false,
-            continuousAxisDesiredTickCount: 5,
-            continuousAxisLabelSpacingMin:  2, // 2em = 20px
+                  case MS_PER_MONTH:
+                    if(monthFormatCached == null) {
+                      // Empty array is to use the browser's default locale.
+                      monthFormatCached = new Intl.DateTimeFormat(environment.locale || [], {
+                        year: "numeric",
+                        month: "numeric"
+                      });
+                    }
 
-            axisTicks_lineWidth:   1,
-            axisTicks_strokeStyle: "#999999",
-            xAxisTicks_height:     3, // Account for part of the tick that gets hidden by the rule
-            yAxisTicks_width:      3
-          }
+                    return monthFormatCached.format(value);
+
+                  default:
+                    // Use the base format.
+                    return this.format(value);
+                }
+              },
+
+              // . grid
+              axisGrid: false,
+              continuousAxisGrid: true,
+
+              axisGrid_lineWidth:   1,
+              axisGrid_strokeStyle: "#CCC",
+
+              // . rule
+              axisRule_lineWidth: 1,
+              axisRule_strokeStyle: "#999999",
+
+              // . ticks
+              axisTicks: true,
+              axisMinorTicks: false,
+              continuousAxisDesiredTickCount: 5,
+              continuousAxisLabelSpacingMin:  2, // 2em = 20px
+
+              axisTicks_lineWidth:   1,
+              axisTicks_strokeStyle: "#999999",
+              xAxisTicks_height:     3, // Account for part of the tick that gets hidden by the rule
+              yAxisTicks_width:      3
+            }
+          };
         }
       },
 
@@ -1079,4 +1125,3 @@ define(function() {
   }
 
 });
-

--- a/impl/client/src/test/javascript/pentaho/environment/impl/Environment.spec.js
+++ b/impl/client/src/test/javascript/pentaho/environment/impl/Environment.spec.js
@@ -26,7 +26,7 @@ define([
     var environmentSpec = {
       application: "APP-1",
       theme: "THEME-1",
-      locale: "LOCALE-1",
+      locale: "pt-PT",
       user: {
         id:   "USER-1",
         home: "USER-HOME-1"
@@ -74,7 +74,7 @@ define([
     var defaultEnvironmentSpec = {
       application: "APP",
       theme: "THEME",
-      locale: "LOCALE",
+      locale: "pt-BR",
       user: {
         id:   "USER",
         home: "USER-HOME"
@@ -159,6 +159,25 @@ define([
         environment = new Environment(environmentSpec);
 
         expectEnvironmentAndSpec(environment, environmentSpec);
+      });
+
+      it("should normalize locale separators", function() {
+
+        var environment = new Environment({locale: "pt_PT"});
+
+        expect(environment.locale).toBe("pt-pt");
+
+        environment = new Environment({locale: "pt/PT"});
+
+        expect(environment.locale).toBe("pt-pt");
+      });
+
+      // TODO: activate test when the testing JS Engine supports Intl.
+      xit("should ignore an invalid locale", function() {
+
+        var environment = new Environment({locale: "fooo"});
+
+        expect(environment.locale).toBe(null);
       });
     });
 

--- a/impl/client/src/test/javascript/pentaho/environment/main.spec.js
+++ b/impl/client/src/test/javascript/pentaho/environment/main.spec.js
@@ -128,7 +128,7 @@ define([
     testEnvironmentProperty("user.home", "user.home", "ABC");
 
     testEnvironmentProperty("theme", "theme", "ABC");
-    testEnvironmentProperty("locale", "locale", "ABC", "abc");
+    testEnvironmentProperty("locale", "locale", "PT", "pt");
 
     testEnvironmentProperty("reservedChars", "reservedChars", "ABC");
   });


### PR DESCRIPTION
- Fix for being able to run in the new Rhino 1.7.13 used by CGG
- The Environment class now normalizes and validates the specified locale
- New formatting function for Cartesian Axes' ticks via the `timeSeriesAxisTickFormatter` extension point

This PR is part of a PR set: https://github.com/webdetails/cgg/pull/148.

@davidmsantos90, @afrjorge, @bennychow please review.
/cc @jcarneirohv 