### PR TITLE
[ANALYZER-2977] Fix incorrect use of singleDimensionType in multi-dimension visual role

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/config.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config.js
@@ -1043,7 +1043,7 @@ define(function() {
       // Inherit the dimension's numeric format style,
       // which in turn inherits from the chart option's numeric format style,
       // which in turn inherits from the chart class' numeric format style.
-      var formatProto = axis.role.grouping.singleDimensionType.format().number();
+      var formatProto = axis.role.grouping.firstDimensionType().format().number();
       numberFormat = getPvc().data.numberFormat(mask, formatProto);
       numberFormatCache[key] = numberFormat;
     }


### PR DESCRIPTION
Now using the formatting information of the _first_ dimension of the visual role.

@bennychow please review.