### PR TITLE
[ANALYZER-3942] Make date formatting robust against Intl API missing (PDI/DET)

### DIFF
--- a/impl/client/src/main/javascript/web/pentaho/visual/config.js
+++ b/impl/client/src/main/javascript/web/pentaho/visual/config.js
@@ -34,6 +34,7 @@ define(function() {
 
   var dayFormatCached = null;
   var monthFormatCached = null;
+  var supportsIntlDateTime = typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function";
 
   var numberFormatCache = {};
   var numberStyle = {
@@ -322,6 +323,12 @@ define(function() {
 
               timeSeriesAxisTickFormatter: function(value) {
                 // Use the Intl API to achieve localized date formatting.
+
+                // TODO: Needed by PDI/DET on Linux, due to SWT/WebKit version.
+                // Remove after PDI-19372 is done.
+                if(!supportsIntlDateTime) {
+                  return this.format(value);
+                }
 
                 switch(this.base) {
                   case MS_PER_DAY:


### PR DESCRIPTION
@bennychow please review and merge.

This follows from the decision to spin-off the PDI/DET support, from https://jira.pentaho.com/browse/ANALYZER-3942,  to another story https://jira.pentaho.com/browse/PDI-19372.

The proposed changes make the date formatting code tolerant to the inexistance of the `Intl` browser API, as is currently the case on PDI/DET on Linux. It will continue behaving as it did before.