### PR TITLE
[BACKLOG-36157] [Chart Options - Visualization API] Update the pentaho/visual/IView interface documentation, to accept an additional, optional constructor parameter with a configuration object

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/visual/spec/IView.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/spec/IView.jsdoc
@@ -42,3 +42,13 @@
  * @memberOf pentaho.visual.spec.IView#
  * @type {pentaho.visual.Model}
  */
+
+/**
+ * The visualization view configRules.
+ *
+ * This property is optional.
+ *
+ * @name configRules
+ * @memberOf pentaho.visual.spec.IView#
+ * @type {pentaho.type.String}
+ */

--- a/impl/client/src/main/doc-js/pentaho/visual/spec/IView.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/visual/spec/IView.jsdoc
@@ -44,11 +44,14 @@
  */
 
 /**
- * The visualization view configRules.
+ * The instance-level view configuration.
+ * Contrast this with the class-level view configuration, supported by some view classes, and which affects all instances of a view class.
+ * When both class and instance-level configuration are supported by a view class, the instance-level configuration takes precedence.
+ * For more information on supported configuration options, see the documentation of the specific view class.
  *
  * This property is optional.
  *
- * @name configRules
+ * @name config
  * @memberOf pentaho.visual.spec.IView#
- * @type {pentaho.type.String}
+ * @type {object}
  */


### PR DESCRIPTION
[BACKLOG-36157] [Chart Options - Visualization API] Update the pentaho/visual/IView interface documentation, to accept an additional, optional constructor parameter with a configuration object