### PR TITLE
[BACKLOG-36156] Create a new JS module (pentaho/config/Service) that exposes the existing Configuration Service class/constructor

### DIFF
--- a/impl/client/src/main/doc-js/pentaho/config/impl/_namespace.jsdoc
+++ b/impl/client/src/main/doc-js/pentaho/config/impl/_namespace.jsdoc
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2022 Hitachi Vantara. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The `config.impl` namespace contains configuration-related implementation classes.
+ *
+ * @name pentaho.config.impl
+ * @namespace
+ */

--- a/impl/client/src/main/javascript/web/pentaho/_core/config/Service.js
+++ b/impl/client/src/main/javascript/web/pentaho/_core/config/Service.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2010 - 2022 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,14 +60,18 @@ define([
      */
     var __ruleCounter = 0;
 
-    var ConfigurationService = Base.extend(module.id, /** @lends pentaho._core.config.Service# */{
+    // NOTE: the JSDoclets in this file are pointing to `pentaho.config.impl`,
+    // and not `pentaho._core.config` (where the file really resides).
+    // The former is the module namespace in which the final, **core-bound**
+    // configuration service class is re-exported and made available to the user.
+    var ConfigurationService = Base.extend(module.id, /** @lends pentaho.config.impl.Service# */{
 
       /**
        * @classDesc The `Service` class is an in-memory implementation of
        * the {@link pentaho.config.IService} interface.
        *
        * @alias Service
-       * @memberOf pentaho._core.config
+       * @memberOf pentaho.config.impl
        * @class
        * @extends pentaho.lang.Base
        * @implements {pentaho.config.IService}

--- a/impl/client/src/main/javascript/web/pentaho/config/impl/Service.js
+++ b/impl/client/src/main/javascript/web/pentaho/config/impl/Service.js
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2022 Hitachi Vantara. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define([
+  "../service"
+], function(globalConfigService) {
+
+  "use strict";
+
+  // Re-export `pentaho._core.config.Service`, already **core-bound**, as `pentaho.config.impl.Service`.
+  return globalConfigService.constructor;
+});

--- a/impl/client/src/main/javascript/web/pentaho/platformCore.js
+++ b/impl/client/src/main/javascript/web/pentaho/platformCore.js
@@ -15,6 +15,7 @@
  */
 define([
   "pentaho/config/service",
+  "pentaho/config/impl/Service",
   "pentaho/module/service",
   "pentaho/module/metaService",
   "pentaho/module/metaOf",

--- a/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
+++ b/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
@@ -425,6 +425,7 @@
       "pentaho/environment",
       "pentaho/_core/main",
       "pentaho/config/service",
+      "pentaho/config/impl/Service",
       "pentaho/module/service",
       "pentaho/module/metaService",
       "pentaho/module/metaOf",

--- a/impl/client/src/test/javascript/pentaho/config/impl/Service.spec.js
+++ b/impl/client/src/test/javascript/pentaho/config/impl/Service.spec.js
@@ -1,0 +1,83 @@
+/*!
+ * Copyright 2022 Hitachi Vantara. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define([
+  "pentaho/shim/es6-promise"
+], function() {
+
+  "use strict";
+
+  // NOTE: These tests only test the re-exporting of the **core-bound** pentaho._core.config.Service class;
+  // that the re-exported class is apparently functional.
+  // The tests which cover all of the functionality of the pentaho._core.config.Service class
+  // are made in src/test/javascript/pentaho/_core/config/Service.spec.js.
+
+  describe("pentaho.config.impl.Service", function() {
+
+    var localRequire;
+
+    beforeEach(function() {
+      localRequire = require.new();
+    });
+
+    afterEach(function() {
+      localRequire.dispose();
+    });
+
+    it("should return a configuration Service class", function() {
+
+      return localRequire.promise(["pentaho/config/impl/Service"])
+        .then(function(deps) {
+          var ConfigService = deps[0];
+
+          // Duck Typing.
+          expect(typeof ConfigService).toBe("function");
+          expect(typeof ConfigService.prototype.selectAsync).toBe("function");
+        });
+    });
+
+    it("should be able to create a configuration service instance given an environment", function() {
+
+      return localRequire.promise(["pentaho/config/impl/Service"])
+        .then(function(deps) {
+          var ConfigurationService = deps[0];
+
+          var configurationService = new ConfigurationService({application: "1"});
+        });
+    });
+
+    it("should be able to add a rule and select it back", function() {
+
+      return localRequire.promise(["pentaho/config/impl/Service"])
+        .then(function(deps) {
+          var ConfigurationService = deps[0];
+
+          var rule1 = {
+            select: {module: "A", user: "1", theme: "1", locale: "1", application: "1"},
+            apply: {foo: "bar"}
+          };
+
+          var configurationService = new ConfigurationService({application: "1"});
+          configurationService.add({rules: [rule1]});
+
+          return configurationService.selectAsync("A");
+        })
+        .then(function(finalConfig) {
+          expect(finalConfig).toEqual({foo: "bar"});
+        });
+    });
+  });
+});


### PR DESCRIPTION
Must be merged together with: https://github.com/webdetails/cgg/pull/158.

@himanshu6201, @varuntangirala, @NJtwentyone please review.