### PR TITLE
[SP-6215] - Backport of PIR-1499 - Category name not appearing in Available Fields using 'Find' after adding column within it to canvas or filter (9.3 Suite)

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/FieldList.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/FieldList.js
@@ -626,7 +626,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
       if (groupHeader != nodeGroupHeader) {
         groupHeader = nodeGroupHeader;
         showGroup = false;
-        if (groupHeader) {
+        if (groupHeader && node.id) {
           domClass.add(groupHeader, "hidden");
           domClass.remove(groupHeader, "categoryNodeFirst");
           domClass.remove(groupHeader, "categoryNodeNotFirst");


### PR DESCRIPTION
@smmribeiro 
@bcostahitachivantara 
@renato-s 