### PR TITLE
[BACKLOG-36891] Fixed NPE when a11y utilities are given null elements

### DIFF
--- a/impl/client/src/main/javascript/web/util/_a11y.js
+++ b/impl/client/src/main/javascript/web/util/_a11y.js
@@ -42,13 +42,10 @@ define(function () {
     elem.addEventListener('keydown', actionButtonKeyDownHandler);
     elem.addEventListener('keyup', actionButtonKeyUpHandler);
 
-    dispose.remove = dispose;
-    return dispose;
-
-    function dispose() {
+    return createDisposable(function dispose() {
       elem.removeEventListener('keydown', actionButtonKeyDownHandler);
       elem.removeEventListener('keyup', actionButtonKeyUpHandler);
-    }
+    });
 
     function actionButtonKeyDownHandler(event) {
       // The action button is activated by space on the keyup event, but the
@@ -84,12 +81,34 @@ define(function () {
     }
   }
 
+  function createDisposable(dispose) {
+    dispose.remove = dispose;
+
+    return dispose;
+  }
+
+  function createNullDisposable() {
+    return createDisposable(function nullDispose() {
+      // NOOP
+    });
+  }
+
   return {
     keyCodes: keyCodes,
+
     makeAccessibleActionButton: function (elem) {
+      if (elem == null) {
+        return createNullDisposable();
+      }
+
       return makeAccessibleActionButton(elem, false);
     },
+
     makeAccessibleToggleButton: function (elem, initialState) {
+      if (elem == null) {
+        return createNullDisposable();
+      }
+
       elem.setAttribute("aria-pressed", initialState);
       return makeAccessibleActionButton(elem, true)
     }


### PR DESCRIPTION
- Opting for ease of use of the utility by tolerating null elements being passed in

The changes in this story caused a regression (NPE at startup, impeding it) when Analyzer is used with options (e.g. http://localhost:8080/pentaho/api/repos/%3Apublic%3ASteel%20Wheels%3ACountry%20Performance%20(heat%20grid).xanalyzer/editor?disableFilterPanel=true). This also affects PDI/DET.

@pentaho/wcag, please, review.