### PR TITLE
[BACKLOG-37351] Change modules to be RequireJS first and to export to global variables later

### DIFF
--- a/impl/client/src/main/javascript/web/util/_dialog.js
+++ b/impl/client/src/main/javascript/web/util/_dialog.js
@@ -20,23 +20,19 @@
  * Portions of this file are based on jQuery UI, v1.13.2
  */
 
-var pho = pho || {};
-if (pho.util == null) {
-  pho.util = {};
-}
-
-(function() {
+/* Need module name as this file is loaded first as a static resource by common-ui. */
+define("common-ui/util/_dialog", [
+  "./_focus",
+  "../jquery-clean"
+], function(focusUtil, $) {
   "use strict";
-
-  /** @type {jQuery} */
-  var jQueryLocal = pho.util._focus.jQuery;
 
   var KeyCodes = {
     tab: 9
   };
   var Selectors = {
     autoFocus: "[autofocus]",
-    tabbable: pho.util._focus.Selectors.tabbable
+    tabbable: focusUtil.Selectors.tabbable
   };
   var RestoreFocusModes = {
     off: 1,
@@ -70,7 +66,7 @@ if (pho.util == null) {
    * @param {Element} dialog - The dialog element.
    */
   function DialogContext(dialog) {
-    this._$dialog = jQueryLocal(dialog);
+    this._$dialog = $(dialog);
     this.setContent(null);
     this.setButtons(null);
   }
@@ -78,12 +74,12 @@ if (pho.util == null) {
   function querySection(section, selector) {
     if(Array.isArray(section)) {
       // Filter given elements.
-      return jQueryLocal(section).filter(selector);
+      return $(section).filter(selector);
     }
 
     // The section's root element or a jQuery of it.
     // Filter descendants.
-    return jQueryLocal(section).find(selector);
+    return $(section).find(selector);
   }
 
   Object.assign(DialogContext.prototype, /** @lends pho.util.DialogContext# */{
@@ -191,7 +187,7 @@ if (pho.util == null) {
       } else {
         // An Element. Can be from another frame, so cannot reliably use instanceof.
         this._restoreFocusMode = RestoreFocusModes.fixed;
-        this._$restoreFocus = jQueryLocal(restoreFocus);
+        this._$restoreFocus = $(restoreFocus);
       }
 
       return this;
@@ -216,7 +212,7 @@ if (pho.util == null) {
 
       if(this._restoreFocusMode === RestoreFocusModes.auto) {
         var activeElement = this._getActiveElement();
-        this._$restoreFocus = activeElement && jQueryLocal(activeElement);
+        this._$restoreFocus = activeElement && $(activeElement);
       }
 
       if(this._doesTrapFocus) {
@@ -344,7 +340,7 @@ if (pho.util == null) {
 
     _contains: function(elem) {
       var dialog = this.getElement();
-      return elem === dialog || jQueryLocal.contains(dialog, elem);
+      return elem === dialog || $.contains(dialog, elem);
     },
 
     _onTrapFocusKeyDown: function(event) {
@@ -385,7 +381,7 @@ if (pho.util == null) {
   });
   // endregion
 
-  pho.util._dialog = {
+  return {
     /**
      * Creates a dialog context for a given dialog element.
      *
@@ -404,8 +400,14 @@ if (pho.util == null) {
      */
     getOpen: getOpenDialogContext
   };
-})();
+});
 
-define("common-ui/util/_dialog", function() {
-  return pho.util._dialog;
+// Create global reference for non-amd users.
+var pho = pho || {};
+if (pho.util == null) {
+  pho.util = {};
+}
+
+require(["common-ui/util/_dialog"], function(dialogUtil) {
+  pho.util._dialog = dialogUtil;
 });

--- a/impl/client/src/main/javascript/web/util/_focus.js
+++ b/impl/client/src/main/javascript/web/util/_focus.js
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-/* globals pho */
-
 /*
  * Portions of this file are based on jQuery UI, v1.13.2
  */
 
-var pho = pho || {};
-if (pho.util == null) {
-  pho.util = {};
-}
-
-(function() {
+/* Need module name as this file is loaded first as a static resource by common-ui. */
+define("common-ui/util/_focus", [
+  "../jquery-clean"
+], function($) {
   "use strict";
-
-  // Guard against later replacement of the global jQuery by another instance
-  // which would not have the below registered pseudo-selectors.
-  var jQueryLocal = $;
 
   // region Extends jQuery with tabbable and focusable.
   // Adapted from https://github.com/jquery/jquery-ui/blob/1.13.2/ui/focusable.js and ./tabbable.js
@@ -43,7 +35,7 @@ if (pho.util == null) {
         return false;
       }
 
-      var $img = jQueryLocal("img[usemap='#" + mapName + "']");
+      var $img = $("img[usemap='#" + mapName + "']");
       return $img.length > 0 && $img.is(":visible");
     }
 
@@ -56,7 +48,7 @@ if (pho.util == null) {
         // However, controls within the fieldset's legend do not get disabled.
         // Since controls generally aren't placed inside legends, we skip
         // this portion of the check.
-        var $fieldset = jQueryLocal(elem).closest("fieldset")[0];
+        var $fieldset = $(elem).closest("fieldset")[0];
         if($fieldset) {
           focusableIfVisible = !$fieldset.disabled;
         }
@@ -67,16 +59,16 @@ if (pho.util == null) {
       focusableIfVisible = hasTabindex;
     }
 
-    var $elem = jQueryLocal(elem);
+    var $elem = $(elem);
     return focusableIfVisible && $elem.is(":visible") && $elem.css("visibility") === "visible";
   }
 
-  jQueryLocal.extend(jQueryLocal.expr.pseudos, {
+  $.extend($.expr.pseudos, {
     "pen-focusable": function(element) {
-      return isFocusable(element, jQueryLocal.attr(element, "tabindex") != null);
+      return isFocusable(element, $.attr(element, "tabindex") != null);
     },
     "pen-tabbable": function(element) {
-      var tabIndex = jQueryLocal.attr(element, "tabindex");
+      var tabIndex = $.attr(element, "tabindex");
       var hasTabindex = tabIndex != null;
       return (!hasTabindex || tabIndex >= 0) && isFocusable(element, hasTabindex);
     }
@@ -120,15 +112,17 @@ if (pho.util == null) {
   /**
    * Contains utilities for dealing with focus.
    * @namespace
+   * @name common-ui.util._focus
+   * @amd common-ui/util/_focus
    * @private
    */
-  pho.util._focus = {
+  return {
     /**
      * Gets a jQuery instance which is ensured to have the custom pseudo-selectors,
      * `:pen-tabbable` and `:pen-focusable`, registered.
-     * @type {jQuery}
+     * @type {$}
      */
-    jQuery: jQueryLocal,
+    jQuery: $,
 
     Selectors: Selectors,
 
@@ -143,7 +137,7 @@ if (pho.util == null) {
      */
     tabbables: function(root) {
       return expandSelection(root || document.body, function(elem) {
-        return jQueryLocal(Selectors.tabbable, elem);
+        return $(Selectors.tabbable, elem);
       });
     },
 
@@ -189,8 +183,14 @@ if (pho.util == null) {
       return tabbables[index - 1];
     }
   };
-})();
+});
 
-define("common-ui/util/_focus", function() {
-  return pho.util._focus;
+// Create global reference for non-amd users.
+var pho = pho || {};
+if (pho.util == null) {
+  pho.util = {};
+}
+
+require(["common-ui/util/_focus"], function(focusUtil) {
+  pho.util._focus = focusUtil;
 });


### PR DESCRIPTION
@pentaho/wcag, please, review.

[BACKLOG-37351](https://hv-eng.atlassian.net/browse/BACKLOG-37351)

The problem occurred because, in the unit test environment, jQuery is not loaded before the `common-ui/util/_focus` and `common-ui/util/_dialog` scripts. In this environment, these are loaded like any other RequireJS modules, however, the scripts are not regular RequireJS modules and do not declare the dependency on jQuery. In the server, they are loaded instead as static resources, always after jQuery is loaded, by `webcontext.js` (in the `global` context), which is one of the first things to be included by any HTML page (Mantle.jsp, Analyzer, PDD, ...).

- Using the same dual Global & RequireJS module pattern as `common-ui/util/URLEncoder`.
- _In principle_, the global variables get defined before any use.
- The RequireJS modules start "loading" when the scripts are loaded by webcontext.js, and the corresponding global variables will be available only when the RequireJS modules load.
- The first known use of the corresponding global variables is by `MantleLoginEntryPoint`, which eagerly creates the `MantleLoginDialog`, which then uses `pho.util._dialog`. I believe that this always occurs many event loop turns after the dependencies are made globally available (and if we find an issue here, we could easily instead lazily create the login dialog).
- There appears to be no easy way for a GWT module to depend on a RequireJS module and to incorporate that within the GWT module loading itself (e.g. loading of essential i18n resources is typically done on `EntryPoint#onModuleLoad()` and it has to be the application to specially handle the additional wait). Ideally, we'd be able to load the modules `common-ui/util/_focus` and `common-ui/util/_dialog` within the scope of `WidgetModule` (an `EntryPoint`), where the classes `ElementUtils` and `DialogBox` which make use of the latter live. Because that does not seem to be possible, in the past, we've resorted to the use of these dual module format scripts and on the empirically proven availability of the resources. IMO, a good solution until proven otherwise (or given enough time/human resources to solve the issue at a deeper level, somehow).

Related PR for `master` branch: https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1639

[BACKLOG-37351]: https://hv-eng.atlassian.net/browse/BACKLOG-37351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ