### PR TITLE
[BACKLOG-38174] Restoring focus after deleting selected data source

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/datasourceselect.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/datasourceselect.js
@@ -200,7 +200,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
             this.msgBox.callbacks = [
               lang.hitch(this, this.deleteDatasource2),
               lang.hitch(this, function () {
-                this.msgBox.hide()
+                this.msgBox.hide();
               })
             ];
 
@@ -210,7 +210,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
 
 
         deleteDatasource2: function () {
-
+          this.msgBox.popup.setDialogOpener(this.adddatasourceimg.buttonImg);
           this.msgBox.hide();
 
           var callbacks = {


### PR DESCRIPTION
 @pentaho/wcag Please review for https://hv-eng.atlassian.net/browse/BACKLOG-38174 .

the msgBox in  `deleteDatasource2` closes after confirming the deletion operation. The edit button is disabled after selected model is deleted.  Setting the add button to be the dialogOpener for msgBox (in this case), so that focus doesn't go to disabled edit button.