### PR TITLE
[BACKLOG-37873] Hide HostDialog's close button by default

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/angularjs/themes/styles.css
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/angularjs/themes/styles.css
@@ -4,6 +4,11 @@
   overflow-y: auto;
 }
 
+/* Hide the close button, by default. Override to enable for specific dialogs. */
+.pentaho-angularjs-host-dialog .dijitDialogCloseIcon {
+  display: none;
+}
+
 .pentaho-angularjs-host-dialog > * > .dijitDialogPaneContent {
   /* Dijit sets these upon viewport resize */
   width: unset !important;


### PR DESCRIPTION
Story/Task: [BACKLOG-38656](https://hv-eng.atlassian.net/browse/BACKLOG-38656)

/cc @pentaho/hoth


- Hidden by default via CSS
- Still preserves ability to close via ESC key

[BACKLOG-38656]: https://hv-eng.atlassian.net/browse/BACKLOG-38656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ