### PR TITLE
[BACKLOG-37873] Styled AngularJS HostDialog's modal backdrop/glasspane

### DIFF
--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/angularjs/HostDialog.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/angularjs/HostDialog.js
@@ -6,11 +6,15 @@ define([
   "common-ui/angularjs",
   "./hostDialogModule",
   "dojo/text!./HostDialog.html",
+  "../Overrides",
   "pentaho/shim/es6-promise",
   "css!./themes/styles.css"
 ], function(declare, Dialog, angularJs, hostDialogModule, templateHtml) {
 
   // "use strict";
+
+  // The pentaho/common/Overrides is needed so that the dialog's modal underlay/backdrop uses the Pentaho
+  // glasspane CSS class and associated color.
 
   /**
    * @name dijit.Dialog


### PR DESCRIPTION
Story/Task: [BACKLOG-38649](https://hv-eng.atlassian.net/browse/BACKLOG-38649)

/cc @pentaho/hoth


- Makes sure to override `dijit/DialogUnderlay` to use the Pentaho `glasspane` class



[BACKLOG-38649]: https://hv-eng.atlassian.net/browse/BACKLOG-38649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ