### PR TITLE
[BACKLOG-37873][BACKLOG-38655] Changed `themes.xml` to declare responsive themes

### DIFF
--- a/assemblies/platform-plugin/src/main/resources/themes.xml
+++ b/assemblies/platform-plugin/src/main/resources/themes.xml
@@ -4,15 +4,18 @@
     <file>globalOnyx.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </onyx>
-  <ruby display-name="Ruby" system="true">
+  <ruby display-name="Ruby" system="true" responsive="true">
+    <file>../base.css</file>
     <file>globalRuby.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </ruby>
   <crystal display-name="Crystal" system="true">
+    <file>../base.css</file>
     <file>globalCrystal.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </crystal>
   <sapphire display-name="Sapphire" system="true">
+    <file>../base.css</file>
     <file>globalSapphire.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </sapphire>


### PR DESCRIPTION
- Also, added the new shared `base.css` stylesheet, including rules for basic responsive primitives, to supported themes

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/41

/cc @pentaho/hoth