### PR TITLE
[BACKLOG-39139] Fix css overflow handling to prevent content from being

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/pentaho-prompting.css
+++ b/impl/client/src/main/javascript/web/prompting/pentaho-prompting.css
@@ -1,6 +1,5 @@
 div.prompt-panel {
   padding: 4px 0 0 8px;
-  overflow: auto;
 }
 
 div.prompt-panel .pentaho-toggle-button-container {


### PR DESCRIPTION
cut off when rendered in an iframe.