### PR TITLE
[BACKLOG-39139] Leave original default overflow in place for

### DIFF
--- a/impl/client/src/main/javascript/web/prompting/pentaho-prompting.css
+++ b/impl/client/src/main/javascript/web/prompting/pentaho-prompting.css
@@ -1,5 +1,6 @@
 div.prompt-panel {
   padding: 4px 0 0 8px;
+  overflow: var( --var-prompt-panel-overflow, auto );
 }
 
 div.prompt-panel .pentaho-toggle-button-container {


### PR DESCRIPTION
.prompt-panel