### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with sp…

### DIFF
--- a/impl/client/src/main/javascript/web/util/URLEncoder.js
+++ b/impl/client/src/main/javascript/web/util/URLEncoder.js
@@ -114,6 +114,16 @@ define("common-ui/util/URLEncoder", [], function() {
       .replace(new RegExp("\\t", "g"), ":");
   };
 
+  Encoder.encodeGenericFilePath = function (str) {
+
+    "use strict";
+
+    return String(str)
+        .replaceAll("~", "\t")
+        .replaceAll(":", "~")
+        .replaceAll("/", ":");
+  }
+  
   // Return encoder for AMD use.
   return Encoder;
 

--- a/impl/client/src/test/javascript/util/URLEncoder.spec.js
+++ b/impl/client/src/test/javascript/util/URLEncoder.spec.js
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2014 - 2024 Hitachi Vantara. All rights reserved.
  */
 
 define(["common-ui/util/URLEncoder"], function(Encoder) {
@@ -51,6 +51,10 @@ define(["common-ui/util/URLEncoder"], function(Encoder) {
 
     it("should handle no args and no queryObjs", function() {
       expect(Encoder.encode("http://www.foo.com/")).toBe("http://www.foo.com/");
+    });
+
+    it("should encode generic file path characters", function() {
+      expect(Encoder.encodeGenericFilePath("/home/Ab`~!@#$%^&()_+{}<>?'=-yZ:")).toBe(":home:Ab`\t!@#$%^&()_+{}<>?'=-yZ~");
     });
   });
 });


### PR DESCRIPTION
…ecial characteres (that used to work before)

- Add new en/decode functions for generic file paths to address handling of "~" in file paths

Related PRs (including this one), to be merged together:
1. https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1762
2. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1032
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/164
4. https://github.com/pentaho/pentaho-platform/pull/5583