### PR TITLE
fix: event listener of 'change:init' failed [BACKLOG-40956]

### DIFF
--- a/impl/client/src/main/config/javascript/build.js
+++ b/impl/client/src/main/config/javascript/build.js
@@ -106,7 +106,26 @@
     const { minify } = require.nodeRequire("uglify-js");
     const { code, error } = minify(contents, {
       output: {
+        /** @default true */
         beautify: false
+      },
+
+      /*
+        Overriding these properties to match 'uglify-js2' default values.
+        The properties new default values were breaking the code functionality.
+      */
+      compress: {
+        /** @default true */
+        collapse_vars: false,
+
+        /** @default false */
+        keep_fargs: true,
+
+        /** @default "strict" */
+        pure_getters: false,
+
+        /** @default true */
+        reduce_vars: false,
       }
     });
 


### PR DESCRIPTION
In the new version of uglify-js some default values for the 'compress' options changed and cause loss of functionality in our code.

 - [uglify-js v2 compress options](https://www.npmjs.com/package/uglify-js2#compressor-options)
 - [uglify-js v3 compress options](https://www.npmjs.com/package/uglify-js#compress-options)

@pentaho/millenniumfalcon @dcleao please review