### PR TITLE
fix: MessageBox usage with html in title and message [BACKLOG-40907]

### DIFF
--- a/impl/client/pom.xml
+++ b/impl/client/pom.xml
@@ -19,7 +19,7 @@
     for each of the constituents (e.g. vizapi, prompting) of the current artifact.</description>
 
   <properties>
-    <js.project.list>dojo-release,prantlf__requirejs,jquery,jquery-i18n-properties,pentaho-cdf-js,angular,angular-animate,angular-i18n,uirouter__core,uirouter__angularjs,echarts</js.project.list>
+    <js.project.list>dojo-release,prantlf__requirejs,jquery,jquery-i18n-properties,pentaho-cdf-js,angular,angular-animate,angular-i18n,uirouter__core,uirouter__angularjs,echarts,dompurify</js.project.list>
     <build.javascriptReportDirectory>target/js-reports</build.javascriptReportDirectory>
 
     <docjs.config.file>jsdoc-vizapi.json</docjs.config.file>
@@ -87,6 +87,10 @@
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>uirouter__angularjs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>dompurify</artifactId>
     </dependency>
   </dependencies>
 

--- a/impl/client/src/main/assembly/dependencies-js-assembly.xml
+++ b/impl/client/src/main/assembly/dependencies-js-assembly.xml
@@ -62,6 +62,20 @@
       </includes>
       <outputDirectory>echarts</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>${webjars.target.directory}/dompurify/${dompurify.version}/dist</directory>
+      <includes>
+        <include>purify.js</include>
+      </includes>
+      <outputDirectory>dompurify</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${webjars.target.directory}/dompurify/${dompurify.version}</directory>
+      <includes>
+        <include>LICENSE*</include>
+      </includes>
+      <outputDirectory>dompurify</outputDirectory>
+    </fileSet>
 
     <fileSet>
       <directory>${build.dependenciesDirectory}/dojo-release-${dojo.version}-src</directory>

--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
@@ -21,11 +21,11 @@ define([
   "dojo/dom-class",
   "dojo/on",
   "dojo/query",
-  "dojox/html/entities",
+  "common-ui/dompurify",
   "pentaho/common/button",
   "pentaho/common/Dialog",
   "dojo/text!pentaho/common/MessageBox.html",
-], (declare, _WidgetBase, _Templated, domClass, on, query, htmlEntities, button, Dialog, templateStr) =>
+], (declare, _WidgetBase, _Templated, domClass, on, query, DOMPurify, button, Dialog, templateStr) =>
   declare("pentaho.common.MessageBox", [Dialog], {
     buttons: ["btn1", "btn2", "btn3"],
     messageType: null, // Options are null, ERROR, WARN, INFO
@@ -33,7 +33,7 @@ define([
     responsiveClasses: "dw-sm",
 
     setTitle(title) {
-      this.titleNode.innerHTML = htmlEntities.encode(title);
+      this.titleNode.innerHTML = DOMPurify.sanitize(title);
     },
 
     postCreate() {
@@ -58,7 +58,7 @@ define([
     },
 
     setMessage(message) {
-      this.messagelbl.innerHTML = htmlEntities.encode(message);
+      this.messagelbl.innerHTML = DOMPurify.sanitize(message);
     },
 
     setButtons(buttons) {
@@ -70,7 +70,7 @@ define([
         if (buttonNode) {
           if (i < this.buttons.length) {
             const { [i]: buttonText } = this.buttons;
-            buttonNode.innerHTML = htmlEntities.encode(buttonText);
+            buttonNode.innerHTML = DOMPurify.sanitize(buttonText);
 
             domClass.remove(buttonNode, "hidden");
           } else {

--- a/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
+++ b/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
@@ -212,6 +212,7 @@
   // endregion
 
   requirePaths["common-ui/echarts"] = basePath + "/echarts/echarts";
+  requirePaths["common-ui/dompurify"] = basePath + "/dompurify/purify";
 
   // region Bundled 3rd party libs
   requirePaths["common-ui/jquery"] = basePath + "/jquery/jquery.conflict";

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <jquery-i18n-properties.version>1.0.9</jquery-i18n-properties.version>
     <pentaho-cdf-plugin.version>10.2.0.0-SNAPSHOT</pentaho-cdf-plugin.version>
     <echarts.version>5.4.3</echarts.version>
+    <dompurify.version>3.1.5</dompurify.version>
     <!-- Removed due to custom changes in the current common-ui version -->
     <!-- (mainly the exporting of the Handlebars global variable) -->
     <!--<handlebars.version>4.0.5</handlebars.version>-->
@@ -97,6 +98,11 @@
         <groupId>org.webjars.npm</groupId>
         <artifactId>echarts</artifactId>
         <version>${echarts.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>dompurify</artifactId>
+        <version>${dompurify.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
instead of blindly encoding all html to prevent xss attacks, that caused the regression by encoding valid html used for formatting, will use [DOMPurify](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page#html_sanitization) to only remove harmful html.

@pentaho/millenniumfalcon please review
cc: @peterrinehart