### PR TITLE
[SP-6583] Backport of PPP-5061 - Sanitize messages and title in message box (9.3 Suite)

### DIFF
--- a/impl/client/pom.xml
+++ b/impl/client/pom.xml
@@ -19,7 +19,7 @@
     for each of the constituents (e.g. vizapi, prompting) of the current artifact.</description>
 
   <properties>
-    <js.project.list>dojo-release,requirejs,jquery,jquery-i18n-properties,pentaho-cdf-js</js.project.list>
+    <js.project.list>dojo-release,requirejs,jquery,jquery-i18n-properties,pentaho-cdf-js,dompurify</js.project.list>
     <build.javascriptReportDirectory>target/js-reports</build.javascriptReportDirectory>
 
     <docjs.config.file>jsdoc-vizapi.json</docjs.config.file>
@@ -60,6 +60,10 @@
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>requirejs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>dompurify</artifactId>
     </dependency>
   </dependencies>
 

--- a/impl/client/src/main/assembly/dependencies-js-assembly.xml
+++ b/impl/client/src/main/assembly/dependencies-js-assembly.xml
@@ -62,6 +62,20 @@
       </excludes>
     </fileSet>
 
+    <fileSet>
+      <directory>${webjars.target.directory}/dompurify/${dompurify.version}/dist</directory>
+      <includes>
+        <include>purify.js</include>
+      </includes>
+      <outputDirectory>dompurify</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${webjars.target.directory}/dompurify/${dompurify.version}</directory>
+      <includes>
+        <include>LICENSE*</include>
+      </includes>
+      <outputDirectory>dompurify</outputDirectory>
+    </fileSet>
   </fileSets>
 
   <files>

--- a/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
+++ b/impl/client/src/main/javascript/web/dojo/pentaho/common/MessageBox.js
@@ -1,29 +1,29 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*/
-define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on", "dojo/query",'pentaho/common/button'
-  ,'pentaho/common/Dialog', "dojo/dom-class", "dojo/text!pentaho/common/MessageBox.html"],
-    function(declare, _WidgetBase, _Templated, on, query, button, Dialog, domClass, templateStr){
+ * Copyright 2010 - 2024 Hitachi Vantara. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on", "dojo/query",'pentaho/common/button',
+    'pentaho/common/Dialog', "dojo/dom-class", "common-ui/dompurify", "dojo/text!pentaho/common/MessageBox.html"],
+    function(declare, _WidgetBase, _Templated, on, query, button, Dialog, domClass, DOMPurify, templateStr){
       return declare("pentaho.common.MessageBox", [Dialog],
      {
         buttons: ['btn1','btn2','btn3'],
         messageType: null,                         // options are null, ERROR, WARN, INFO
 
         setTitle: function(title) {
-            this.titleNode.innerHTML = title;
+            this.titleNode.innerHTML = DOMPurify.sanitize(title);
         },
 
         postCreate: function() {
@@ -48,17 +48,17 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
         },
 
         setMessage: function(message) {
-            this.messagelbl.innerHTML = message;
+            this.messagelbl.innerHTML = DOMPurify.sanitize(message);
         },
 
         setButtons: function(buttons) {
-        
+
             this.buttons = buttons;
             for(var i=0; i<3; i++) {
                 var button = query("button"+i, this.popup.domNode)
                 if(button) {
                     if(i<this.buttons.length) {
-                        button.innerHTML = this.buttons[i];
+                        button.innerHTML = DOMPurify.sanitize(this.buttons[i]);
                         domClass.remove(button, 'hidden');
                     } else {
                         domClass.add(button, 'hidden');
@@ -68,7 +68,7 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_Templated", "dojo/on"
         },
 
         templateString: templateStr
-           
+
       }
 );
 });

--- a/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
+++ b/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
@@ -203,6 +203,8 @@
   requirePaths["dojo/request/default"] = dojoOverrides + "dojo/request/default";
   // endregion
 
+  requirePaths["common-ui/dompurify"] = basePath + "/dompurify/purify";
+
   // region Bundled 3rd party libs
   requirePaths["common-ui/jquery"] = basePath + "/jquery/jquery.conflict";
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <dojo.version>1.9.2</dojo.version>
     <jquery-i18n-properties.version>1.0.9</jquery-i18n-properties.version>
     <pentaho-cdf-plugin.version>9.3.0.0-SNAPSHOT</pentaho-cdf-plugin.version>
+    <dompurify.version>2.5.6</dompurify.version>
     <!-- Removed due to custom changes in the current common-ui version -->
     <!-- (mainly the exporting of the Handlebars global variable) -->
     <!--<handlebars.version>4.0.5</handlebars.version>-->
@@ -63,6 +64,11 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>dompurify</artifactId>
+        <version>${dompurify.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

Original PRs:
 - [PPP-5061](https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1769)
 - [BACKLOG-40907](https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1776)
 
Didn't include the **lint** done in the `PPP-5061` PR because PhantomJS doesn't support the modern javascript syntax.
 - that is also why for this backport the version of `dompurify` was downgraded from `3.1.5` to `2.5.6`

Need to include the `BACKLOG-40907` PR as the fix in `PPP-5061` broke some plugins behavior

[PPP-5061]: https://hv-eng.atlassian.net/browse/PPP-5061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-40907]: https://hv-eng.atlassian.net/browse/BACKLOG-40907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ