### PR TITLE
[ANALYZER-4145] - Multiselect feature for Analyzer Report Filter no longer requires holding CTLR key

### DIFF
--- a/impl/client/src/main/javascript/web/util/_a11y.js
+++ b/impl/client/src/main/javascript/web/util/_a11y.js
@@ -128,6 +128,12 @@ define("common-ui/util/_a11y", ["./_focus"], function (focusUtil) {
         return;
       }
 
+      if (!evt.ctrlKey) {
+        getSelectedOptions().forEach(option => {
+          toggleSelected(option)
+        });
+      }
+
       setActiveOption(evt.target);
       toggleSelected(evt.target);
       scrollActiveOptionIntoView();


### PR DESCRIPTION
The issue relates to this dialog: https://github.com/pentaho/pentaho-analyzer/blob/d350af40eb9a193670940509aedf194c25a92ff8/client/src/main/javascript/scripts/report/cv_rptFilterDlg.js

If there are any concerns about this change affecting other components elsewhere in Pentaho, I did search for that problem, and found out that this accessible listbox (the element affected by this change) is only used in the dialog mentioned above.

@pentaho/tatooine_dev 