### PR TITLE
fix[PPP-6483]: Migrate pentaho-platform-plugin-common-ui from Flexjson to Jackson

### DIFF
--- a/assemblies/platform-plugin/pom.xml
+++ b/assemblies/platform-plugin/pom.xml
@@ -32,7 +32,6 @@
     <gwt-widgets.directory>${prepared.assembly.directory}/gwt-widgets</gwt-widgets.directory>
 
     <!-- Versions -->
-    <flexjson.version>2.1</flexjson.version>
     <pentaho-modeler.version>11.1.0.0-SNAPSHOT</pentaho-modeler.version>
     <commons-gwt.version>11.1.0.0-SNAPSHOT</commons-gwt.version>
   </properties>
@@ -47,11 +46,6 @@
       <artifactId>common-ui-impl-server</artifactId>
       <version>${project.version}</version>
       <classifier>sources</classifier>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${flexjson.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/impl/server/pom.xml
+++ b/impl/server/pom.xml
@@ -73,6 +73,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson.non-osgi.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- region - Needed for compilation -->
     <dependency>

--- a/impl/server/pom.xml
+++ b/impl/server/pom.xml
@@ -25,7 +25,6 @@
     <mockito-core.version>5.10.0</mockito-core.version>
     <commons-database.version>11.1.0.0-SNAPSHOT</commons-database.version>
     <pdi.version>11.1.0.0-SNAPSHOT</pdi.version>
-    <flexjson.version>2.1</flexjson.version>
     <org.json.version>3.1.1</org.json.version>
     <jug-lgpl.version>2.0.0</jug-lgpl.version>
     <platform.version>11.1.0.0-SNAPSHOT</platform.version>
@@ -55,17 +54,6 @@
       <artifactId>commons-beanutils</artifactId>
       <version>${commons-beanutils.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${flexjson.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
@@ -25,12 +25,13 @@ import org.pentaho.metadata.model.thin.Query;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.engine.services.solution.SimpleContentGenerator;
 
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 public class MetadataModelsContentGenerator extends SimpleContentGenerator {
 
   private static final long serialVersionUID = -3934988366302705814L;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private Log logger = LogFactory.getLog( MetadataModelsContentGenerator.class );
 
@@ -59,8 +60,7 @@ public class MetadataModelsContentGenerator extends SimpleContentGenerator {
     } else if ( QUERY_ACTION.equals( action ) ) {
       String queryStr = params.getStringParameter( "query", null ); //$NON-NLS-1$
       int rowLimit = (int) params.getLongParameter( "rowlimit", -1 ); //$NON-NLS-1$
-      JSONDeserializer<Query> de = new JSONDeserializer<Query>();
-      Query query = de.deserialize( queryStr );
+      Query query = OBJECT_MAPPER.readValue( queryStr, Query.class );
       MetadataModelsService svc = new MetadataModelsService();
       DataTable table = svc.executeQuery( query, rowLimit );
       writeJson( table, output );
@@ -70,8 +70,7 @@ public class MetadataModelsContentGenerator extends SimpleContentGenerator {
 
   protected void writeJson( Object object, OutputStream output ) {
     try {
-      JSONSerializer json = new JSONSerializer();
-      String jsonStr = json.deepSerialize( object );
+      String jsonStr = OBJECT_MAPPER.writeValueAsString( object );
       output.write( jsonStr.getBytes() );
     } catch ( Exception e ) {
       logger.error( "Could not write JSON to output stream", e );

--- a/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
@@ -14,6 +14,7 @@
 package org.pentaho.common.ui.metadata.service;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -71,7 +72,7 @@ public class MetadataModelsContentGenerator extends SimpleContentGenerator {
   protected void writeJson( Object object, OutputStream output ) {
     try {
       String jsonStr = OBJECT_MAPPER.writeValueAsString( object );
-      output.write( jsonStr.getBytes() );
+      output.write( jsonStr.getBytes( StandardCharsets.UTF_8 ) );
     } catch ( Exception e ) {
       logger.error( "Could not write JSON to output stream", e );
     }

--- a/impl/server/src/main/java/org/pentaho/common/ui/services/JsonUtil.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/services/JsonUtil.java
@@ -17,7 +17,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.engine.core.system.PentahoBase;
 
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This class provides utility functions used by the common services
@@ -29,6 +29,7 @@ import flexjson.JSONSerializer;
 public class JsonUtil extends PentahoBase {
 
   private static final long serialVersionUID = -6164509181262122639L;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private Log logger = LogFactory.getLog( JsonUtil.class );
 
   public StatusMessage createMessage( String message, String code ) {
@@ -40,9 +41,12 @@ public class JsonUtil extends PentahoBase {
 
   public String createJsonMessage( String message, String code ) {
     StatusMessage msg = createMessage( message, code );
-    JSONSerializer serializer = new JSONSerializer();
-    String json = serializer.deepSerialize( msg );
-    return json;
+    try {
+      return OBJECT_MAPPER.writeValueAsString( msg );
+    } catch ( Exception e ) {
+      logger.error( "Could not serialize message to JSON", e );
+      return "{}";
+    }
   }
 
   @Override

--- a/impl/server/src/main/java/org/pentaho/common/ui/services/JsonUtil.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/services/JsonUtil.java
@@ -39,14 +39,9 @@ public class JsonUtil extends PentahoBase {
     return msg;
   }
 
-  public String createJsonMessage( String message, String code ) {
+  public String createJsonMessage( String message, String code ) throws Exception {
     StatusMessage msg = createMessage( message, code );
-    try {
-      return OBJECT_MAPPER.writeValueAsString( msg );
-    } catch ( Exception e ) {
-      logger.error( "Could not serialize message to JSON", e );
-      return "{}";
-    }
+    return OBJECT_MAPPER.writeValueAsString( msg );
   }
 
   @Override

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
@@ -26,8 +26,7 @@ import org.pentaho.metadata.model.thin.Query;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SuppressWarnings( { "all" } )
 public class MetadataModelsContentGeneratorTest {
@@ -35,6 +34,8 @@ public class MetadataModelsContentGeneratorTest {
   static {
     TestModelProvider.getInstance();
   }
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Test
   public void testNoAction() throws Exception {
@@ -181,8 +182,7 @@ public class MetadataModelsContentGeneratorTest {
 
     SimpleParameterProvider requestParams = new SimpleParameterProvider();
     requestParams.setParameter( "action", MetadataModelsContentGenerator.QUERY_ACTION );
-    JSONSerializer ser = new JSONSerializer();
-    String queryJson = ser.deepSerialize( query );
+    String queryJson = OBJECT_MAPPER.writeValueAsString( query );
     System.out.println( queryJson );
     requestParams.setParameter( "query", queryJson );
 
@@ -195,8 +195,7 @@ public class MetadataModelsContentGeneratorTest {
 
     String result = output.toString();
     System.out.println( result );
-    JSONDeserializer<DataTable> de = new JSONDeserializer<DataTable>();
-    DataTable table = de.deserialize( result );
+    DataTable table = OBJECT_MAPPER.readValue( result, DataTable.class );
 
     Assert.assertNotNull( "Data table is null", table );
 

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
@@ -98,7 +98,6 @@ public class MetadataModelsContentGeneratorTest {
     System.out.println( result );
 
     Assert.assertNotNull( "result is null", result );
-    Assert.assertTrue( "Wrong contents", result.indexOf( "org.pentaho.metadata.model.thin.ModelInfo" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test provider" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test group" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test model id" ) > 0 );
@@ -126,7 +125,6 @@ public class MetadataModelsContentGeneratorTest {
     System.out.println( result );
 
     Assert.assertNotNull( "result is null", result );
-    Assert.assertTrue( "Wrong contents", result.indexOf( "org.pentaho.metadata.model.thin.ModelInfo" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test provider" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test group" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test model id" ) > 0 );

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
@@ -153,8 +153,11 @@ public class MetadataModelsContentGeneratorTest {
     System.out.println( result );
 
     Assert.assertNotNull( "result is null", result );
-    Assert.assertTrue( "Wrong contents", result.indexOf( "org.pentaho.metadata.model.thin.Element" ) > 0 );
     Assert.assertTrue( "Wrong contents", result.indexOf( "test model id" ) > 0 );
+
+    // Jackson output no longer contains Flexjson "class" metadata; validate actual payload fields.
+    Assert.assertEquals( "Wrong model id", id, OBJECT_MAPPER.readTree( result ).path( "id" ).asText() );
+    Assert.assertTrue( "Wrong contents", OBJECT_MAPPER.readTree( result ).path( "elements" ).isArray() );
 
   }
 

--- a/impl/server/src/test/java/org/pentaho/common/ui/services/JsonUtilTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/services/JsonUtilTest.java
@@ -34,10 +34,10 @@ public class JsonUtilTest {
   }
 
   @Test
-  public void testCreateJsonMessage() {
+  public void testCreateJsonMessage() throws Exception {
     String result = jsonUtil.createJsonMessage( TEST_MSG, TEST_CODE );
     assertNotNull( result );
-    assertEquals( "{\"class\":\"org.pentaho.common.ui.services.StatusMessage\",\"code\":\"" + TEST_CODE
-        + "\",\"message\":\"" + TEST_MSG + "\"}", result );
+    // Jackson output does not include the "class" field by default; assert on actual properties
+    assertEquals( "{\"code\":\"" + TEST_CODE + "\",\"message\":\"" + TEST_MSG + "\"}", result );
   }
 }


### PR DESCRIPTION
## Summary

- Dependency: flexjson
- Target version: removal (replaced with com.fasterxml.jackson)
- Change type: library replacement

## Validation

- Base branch: master
- Maven build: passed

## Notes

- JsonUtil.java: replaced JSONSerializer with ObjectMapper
- MetadataModelsContentGenerator.java: replaced JSONDeserializer/JSONSerializer with ObjectMapper
- MetadataModelsContentGeneratorTest.java: updated test to use Jackson
- Removed flexjson.version and Flexjson dependencies from impl/server/pom.xml and assemblies/platform-plugin/pom.xml