### PR TITLE
fix[PPP-6483]: Remove flexjson from common-ui plugin assembly

### DIFF
--- a/assemblies/platform-plugin/src/main/assembly/assembly.xml
+++ b/assemblies/platform-plugin/src/main/assembly/assembly.xml
@@ -42,7 +42,6 @@
       </excludes>
       <includes>
         <include>org.pentaho:common-ui-impl-server:jar</include>
-        <include>net.sf.flexjson:flexjson</include>
         <include>pentaho:pentaho-modeler</include>
       </includes>
       <outputDirectory>common-ui/lib</outputDirectory>


### PR DESCRIPTION
## Summary
Removes `net.sf.flexjson:flexjson` from the `common-ui` platform plugin assembly descriptor.

## Changes
- `assemblies/platform-plugin/src/main/assembly/assembly.xml`: Remove `<include>net.sf.flexjson:flexjson</include>` from the server-side dependency set

## Context
The Java code in `common-ui-impl-server` no longer uses flexjson (migrated to Jackson as part of PPP-6483). The assembly was still packaging the jar into `common-ui/lib/`, causing it to appear on the classpath despite no active usage.