### PR TITLE
CVE fix: handlebars 4.7.7 -> 4.7.9 (CVE-2026-33916/33937/33938/33939/33940/33941)

### DIFF
--- a/assemblies/webpackage/src/main/resources-filtered/common-ui/package.json
+++ b/assemblies/webpackage/src/main/resources-filtered/common-ui/package.json
@@ -70,7 +70,7 @@
 
     "common-ui/jquery": "/jquery/jquery.conflict",
     "common-ui/jquery-clean": "/jquery/jquery",
-    "common-ui/handlebars": "/handlebars/handlebars-v4.7.7",
+    "common-ui/handlebars": "/handlebars/handlebars-v4.7.9",
     "common-ui/jquery-i18n": "/jquery/jquery.i18n.properties-min",
     "common-ui/jquery-pentaho-i18n": "/jquery/jquery.i18n.properties.supported.languages",
     "common-ui/bootstrap": "/bootstrap/bootstrap",

--- a/impl/client/src/main/javascript/web/handlebars/handlebars-v4.7.9.js
+++ b/impl/client/src/main/javascript/web/handlebars/handlebars-v4.7.9.js
@@ -1,7 +1,7 @@
 /**!
 
  @license
- handlebars v4.7.7
+ handlebars v4.7.9
 
 Copyright (C) 2011-2019 by Yehuda Katz
 
@@ -92,23 +92,23 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	// Compiler imports
 
-	var _handlebarsCompilerAst = __webpack_require__(45);
+	var _handlebarsCompilerAst = __webpack_require__(83);
 
 	var _handlebarsCompilerAst2 = _interopRequireDefault(_handlebarsCompilerAst);
 
-	var _handlebarsCompilerBase = __webpack_require__(46);
+	var _handlebarsCompilerBase = __webpack_require__(84);
 
-	var _handlebarsCompilerCompiler = __webpack_require__(51);
+	var _handlebarsCompilerCompiler = __webpack_require__(89);
 
-	var _handlebarsCompilerJavascriptCompiler = __webpack_require__(52);
+	var _handlebarsCompilerJavascriptCompiler = __webpack_require__(90);
 
 	var _handlebarsCompilerJavascriptCompiler2 = _interopRequireDefault(_handlebarsCompilerJavascriptCompiler);
 
-	var _handlebarsCompilerVisitor = __webpack_require__(49);
+	var _handlebarsCompilerVisitor = __webpack_require__(87);
 
 	var _handlebarsCompilerVisitor2 = _interopRequireDefault(_handlebarsCompilerVisitor);
 
-	var _handlebarsNoConflict = __webpack_require__(44);
+	var _handlebarsNoConflict = __webpack_require__(82);
 
 	var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict);
 
@@ -178,7 +178,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	// Each of these augment the Handlebars object. No need to setup here.
 	// (This is done to easily share code between commonjs and browse envs)
 
-	var _handlebarsSafeString = __webpack_require__(37);
+	var _handlebarsSafeString = __webpack_require__(76);
 
 	var _handlebarsSafeString2 = _interopRequireDefault(_handlebarsSafeString);
 
@@ -190,11 +190,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var Utils = _interopRequireWildcard(_handlebarsUtils);
 
-	var _handlebarsRuntime = __webpack_require__(38);
+	var _handlebarsRuntime = __webpack_require__(77);
 
 	var runtime = _interopRequireWildcard(_handlebarsRuntime);
 
-	var _handlebarsNoConflict = __webpack_require__(44);
+	var _handlebarsNoConflict = __webpack_require__(82);
 
 	var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict);
 
@@ -270,15 +270,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _helpers = __webpack_require__(10);
 
-	var _decorators = __webpack_require__(30);
+	var _decorators = __webpack_require__(70);
 
-	var _logger = __webpack_require__(32);
+	var _logger = __webpack_require__(72);
 
 	var _logger2 = _interopRequireDefault(_logger);
 
-	var _internalProtoAccess = __webpack_require__(33);
+	var _internalProtoAccess = __webpack_require__(73);
 
-	var VERSION = '4.7.7';
+	var VERSION = '4.7.9';
 	exports.VERSION = VERSION;
 	var COMPILER_REVISION = 8;
 	exports.COMPILER_REVISION = COMPILER_REVISION;
@@ -621,23 +621,23 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _helpersEach2 = _interopRequireDefault(_helpersEach);
 
-	var _helpersHelperMissing = __webpack_require__(25);
+	var _helpersHelperMissing = __webpack_require__(65);
 
 	var _helpersHelperMissing2 = _interopRequireDefault(_helpersHelperMissing);
 
-	var _helpersIf = __webpack_require__(26);
+	var _helpersIf = __webpack_require__(66);
 
 	var _helpersIf2 = _interopRequireDefault(_helpersIf);
 
-	var _helpersLog = __webpack_require__(27);
+	var _helpersLog = __webpack_require__(67);
 
 	var _helpersLog2 = _interopRequireDefault(_helpersLog);
 
-	var _helpersLookup = __webpack_require__(28);
+	var _helpersLookup = __webpack_require__(68);
 
 	var _helpersLookup2 = _interopRequireDefault(_helpersLookup);
 
-	var _helpersWith = __webpack_require__(29);
+	var _helpersWith = __webpack_require__(69);
 
 	var _helpersWith2 = _interopRequireDefault(_helpersWith);
 
@@ -655,7 +655,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (instance.helpers[helperName]) {
 	    instance.hooks[helperName] = instance.helpers[helperName];
 	    if (!keepHelper) {
-	      delete instance.helpers[helperName];
+	      // Using delete is slow
+	      instance.helpers[helperName] = undefined;
 	    }
 	  }
 	}
@@ -707,9 +708,15 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 12 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
+	'use strict';
 
-	var _Object$keys = __webpack_require__(13)['default'];
+	var _Symbol = __webpack_require__(13)['default'];
+
+	var _Symbol$iterator = __webpack_require__(43)['default'];
+
+	var _getIterator = __webpack_require__(55)['default'];
+
+	var _Object$keys = __webpack_require__(60)['default'];
 
 	var _interopRequireDefault = __webpack_require__(1)['default'];
 
@@ -771,9 +778,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	            execIteration(i, i, i === context.length - 1);
 	          }
 	        }
-	      } else if (global.Symbol && context[global.Symbol.iterator]) {
+	      } else if (typeof _Symbol === 'function' && context[_Symbol$iterator]) {
 	        var newContext = [];
-	        var iterator = context[global.Symbol.iterator]();
+	        var iterator = _getIterator(context);
 	        for (var it = iterator.next(); !it.done; it = iterator.next()) {
 	          newContext.push(it.value);
 	        }
@@ -811,7 +818,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	module.exports = exports['default'];
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }),
 /* 13 */
@@ -824,61 +830,285 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ (function(module, exports, __webpack_require__) {
 
 	__webpack_require__(15);
-	module.exports = __webpack_require__(21).Object.keys;
+	__webpack_require__(42);
+	module.exports = __webpack_require__(21).Symbol;
 
 /***/ }),
 /* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	// 19.1.2.14 Object.keys(O)
-	var toObject = __webpack_require__(16);
+	'use strict';
+	// ECMAScript 6 symbols shim
+	var $              = __webpack_require__(9)
+	  , global         = __webpack_require__(16)
+	  , has            = __webpack_require__(17)
+	  , DESCRIPTORS    = __webpack_require__(18)
+	  , $export        = __webpack_require__(20)
+	  , redefine       = __webpack_require__(24)
+	  , $fails         = __webpack_require__(19)
+	  , shared         = __webpack_require__(27)
+	  , setToStringTag = __webpack_require__(28)
+	  , uid            = __webpack_require__(30)
+	  , wks            = __webpack_require__(29)
+	  , keyOf          = __webpack_require__(31)
+	  , $names         = __webpack_require__(36)
+	  , enumKeys       = __webpack_require__(37)
+	  , isArray        = __webpack_require__(38)
+	  , anObject       = __webpack_require__(39)
+	  , toIObject      = __webpack_require__(32)
+	  , createDesc     = __webpack_require__(26)
+	  , getDesc        = $.getDesc
+	  , setDesc        = $.setDesc
+	  , _create        = $.create
+	  , getNames       = $names.get
+	  , $Symbol        = global.Symbol
+	  , $JSON          = global.JSON
+	  , _stringify     = $JSON && $JSON.stringify
+	  , setter         = false
+	  , HIDDEN         = wks('_hidden')
+	  , isEnum         = $.isEnum
+	  , SymbolRegistry = shared('symbol-registry')
+	  , AllSymbols     = shared('symbols')
+	  , useNative      = typeof $Symbol == 'function'
+	  , ObjectProto    = Object.prototype;
 
-	__webpack_require__(18)('keys', function($keys){
-	  return function keys(it){
-	    return $keys(toObject(it));
+	// fallback for old Android, https://code.google.com/p/v8/issues/detail?id=687
+	var setSymbolDesc = DESCRIPTORS && $fails(function(){
+	  return _create(setDesc({}, 'a', {
+	    get: function(){ return setDesc(this, 'a', {value: 7}).a; }
+	  })).a != 7;
+	}) ? function(it, key, D){
+	  var protoDesc = getDesc(ObjectProto, key);
+	  if(protoDesc)delete ObjectProto[key];
+	  setDesc(it, key, D);
+	  if(protoDesc && it !== ObjectProto)setDesc(ObjectProto, key, protoDesc);
+	} : setDesc;
+
+	var wrap = function(tag){
+	  var sym = AllSymbols[tag] = _create($Symbol.prototype);
+	  sym._k = tag;
+	  DESCRIPTORS && setter && setSymbolDesc(ObjectProto, tag, {
+	    configurable: true,
+	    set: function(value){
+	      if(has(this, HIDDEN) && has(this[HIDDEN], tag))this[HIDDEN][tag] = false;
+	      setSymbolDesc(this, tag, createDesc(1, value));
+	    }
+	  });
+	  return sym;
+	};
+
+	var isSymbol = function(it){
+	  return typeof it == 'symbol';
+	};
+
+	var $defineProperty = function defineProperty(it, key, D){
+	  if(D && has(AllSymbols, key)){
+	    if(!D.enumerable){
+	      if(!has(it, HIDDEN))setDesc(it, HIDDEN, createDesc(1, {}));
+	      it[HIDDEN][key] = true;
+	    } else {
+	      if(has(it, HIDDEN) && it[HIDDEN][key])it[HIDDEN][key] = false;
+	      D = _create(D, {enumerable: createDesc(0, false)});
+	    } return setSymbolDesc(it, key, D);
+	  } return setDesc(it, key, D);
+	};
+	var $defineProperties = function defineProperties(it, P){
+	  anObject(it);
+	  var keys = enumKeys(P = toIObject(P))
+	    , i    = 0
+	    , l = keys.length
+	    , key;
+	  while(l > i)$defineProperty(it, key = keys[i++], P[key]);
+	  return it;
+	};
+	var $create = function create(it, P){
+	  return P === undefined ? _create(it) : $defineProperties(_create(it), P);
+	};
+	var $propertyIsEnumerable = function propertyIsEnumerable(key){
+	  var E = isEnum.call(this, key);
+	  return E || !has(this, key) || !has(AllSymbols, key) || has(this, HIDDEN) && this[HIDDEN][key]
+	    ? E : true;
+	};
+	var $getOwnPropertyDescriptor = function getOwnPropertyDescriptor(it, key){
+	  var D = getDesc(it = toIObject(it), key);
+	  if(D && has(AllSymbols, key) && !(has(it, HIDDEN) && it[HIDDEN][key]))D.enumerable = true;
+	  return D;
+	};
+	var $getOwnPropertyNames = function getOwnPropertyNames(it){
+	  var names  = getNames(toIObject(it))
+	    , result = []
+	    , i      = 0
+	    , key;
+	  while(names.length > i)if(!has(AllSymbols, key = names[i++]) && key != HIDDEN)result.push(key);
+	  return result;
+	};
+	var $getOwnPropertySymbols = function getOwnPropertySymbols(it){
+	  var names  = getNames(toIObject(it))
+	    , result = []
+	    , i      = 0
+	    , key;
+	  while(names.length > i)if(has(AllSymbols, key = names[i++]))result.push(AllSymbols[key]);
+	  return result;
+	};
+	var $stringify = function stringify(it){
+	  if(it === undefined || isSymbol(it))return; // IE8 returns string on undefined
+	  var args = [it]
+	    , i    = 1
+	    , $$   = arguments
+	    , replacer, $replacer;
+	  while($$.length > i)args.push($$[i++]);
+	  replacer = args[1];
+	  if(typeof replacer == 'function')$replacer = replacer;
+	  if($replacer || !isArray(replacer))replacer = function(key, value){
+	    if($replacer)value = $replacer.call(this, key, value);
+	    if(!isSymbol(value))return value;
 	  };
+	  args[1] = replacer;
+	  return _stringify.apply($JSON, args);
+	};
+	var buggyJSON = $fails(function(){
+	  var S = $Symbol();
+	  // MS Edge converts symbol values to JSON as {}
+	  // WebKit converts symbol values to JSON as null
+	  // V8 throws on boxed symbols
+	  return _stringify([S]) != '[null]' || _stringify({a: S}) != '{}' || _stringify(Object(S)) != '{}';
 	});
+
+	// 19.4.1.1 Symbol([description])
+	if(!useNative){
+	  $Symbol = function Symbol(){
+	    if(isSymbol(this))throw TypeError('Symbol is not a constructor');
+	    return wrap(uid(arguments.length > 0 ? arguments[0] : undefined));
+	  };
+	  redefine($Symbol.prototype, 'toString', function toString(){
+	    return this._k;
+	  });
+
+	  isSymbol = function(it){
+	    return it instanceof $Symbol;
+	  };
+
+	  $.create     = $create;
+	  $.isEnum     = $propertyIsEnumerable;
+	  $.getDesc    = $getOwnPropertyDescriptor;
+	  $.setDesc    = $defineProperty;
+	  $.setDescs   = $defineProperties;
+	  $.getNames   = $names.get = $getOwnPropertyNames;
+	  $.getSymbols = $getOwnPropertySymbols;
+
+	  if(DESCRIPTORS && !__webpack_require__(41)){
+	    redefine(ObjectProto, 'propertyIsEnumerable', $propertyIsEnumerable, true);
+	  }
+	}
+
+	var symbolStatics = {
+	  // 19.4.2.1 Symbol.for(key)
+	  'for': function(key){
+	    return has(SymbolRegistry, key += '')
+	      ? SymbolRegistry[key]
+	      : SymbolRegistry[key] = $Symbol(key);
+	  },
+	  // 19.4.2.5 Symbol.keyFor(sym)
+	  keyFor: function keyFor(key){
+	    return keyOf(SymbolRegistry, key);
+	  },
+	  useSetter: function(){ setter = true; },
+	  useSimple: function(){ setter = false; }
+	};
+	// 19.4.2.2 Symbol.hasInstance
+	// 19.4.2.3 Symbol.isConcatSpreadable
+	// 19.4.2.4 Symbol.iterator
+	// 19.4.2.6 Symbol.match
+	// 19.4.2.8 Symbol.replace
+	// 19.4.2.9 Symbol.search
+	// 19.4.2.10 Symbol.species
+	// 19.4.2.11 Symbol.split
+	// 19.4.2.12 Symbol.toPrimitive
+	// 19.4.2.13 Symbol.toStringTag
+	// 19.4.2.14 Symbol.unscopables
+	$.each.call((
+	  'hasInstance,isConcatSpreadable,iterator,match,replace,search,' +
+	  'species,split,toPrimitive,toStringTag,unscopables'
+	).split(','), function(it){
+	  var sym = wks(it);
+	  symbolStatics[it] = useNative ? sym : wrap(sym);
+	});
+
+	setter = true;
+
+	$export($export.G + $export.W, {Symbol: $Symbol});
+
+	$export($export.S, 'Symbol', symbolStatics);
+
+	$export($export.S + $export.F * !useNative, 'Object', {
+	  // 19.1.2.2 Object.create(O [, Properties])
+	  create: $create,
+	  // 19.1.2.4 Object.defineProperty(O, P, Attributes)
+	  defineProperty: $defineProperty,
+	  // 19.1.2.3 Object.defineProperties(O, Properties)
+	  defineProperties: $defineProperties,
+	  // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
+	  getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
+	  // 19.1.2.7 Object.getOwnPropertyNames(O)
+	  getOwnPropertyNames: $getOwnPropertyNames,
+	  // 19.1.2.8 Object.getOwnPropertySymbols(O)
+	  getOwnPropertySymbols: $getOwnPropertySymbols
+	});
+
+	// 24.3.2 JSON.stringify(value [, replacer [, space]])
+	$JSON && $export($export.S + $export.F * (!useNative || buggyJSON), 'JSON', {stringify: $stringify});
+
+	// 19.4.3.5 Symbol.prototype[@@toStringTag]
+	setToStringTag($Symbol, 'Symbol');
+	// 20.2.1.9 Math[@@toStringTag]
+	setToStringTag(Math, 'Math', true);
+	// 24.3.3 JSON[@@toStringTag]
+	setToStringTag(global.JSON, 'JSON', true);
 
 /***/ }),
 /* 16 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-	// 7.1.13 ToObject(argument)
-	var defined = __webpack_require__(17);
-	module.exports = function(it){
-	  return Object(defined(it));
-	};
+	// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+	var global = module.exports = typeof window != 'undefined' && window.Math == Math
+	  ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
+	if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
 
 /***/ }),
 /* 17 */
 /***/ (function(module, exports) {
 
-	// 7.2.1 RequireObjectCoercible(argument)
-	module.exports = function(it){
-	  if(it == undefined)throw TypeError("Can't call method on  " + it);
-	  return it;
+	var hasOwnProperty = {}.hasOwnProperty;
+	module.exports = function(it, key){
+	  return hasOwnProperty.call(it, key);
 	};
 
 /***/ }),
 /* 18 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	// most Object methods by ES6 should accept primitives
-	var $export = __webpack_require__(19)
-	  , core    = __webpack_require__(21)
-	  , fails   = __webpack_require__(24);
-	module.exports = function(KEY, exec){
-	  var fn  = (core.Object || {})[KEY] || Object[KEY]
-	    , exp = {};
-	  exp[KEY] = exec(fn);
-	  $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
-	};
+	// Thank's IE8 for his funny defineProperty
+	module.exports = !__webpack_require__(19)(function(){
+	  return Object.defineProperty({}, 'a', {get: function(){ return 7; }}).a != 7;
+	});
 
 /***/ }),
 /* 19 */
+/***/ (function(module, exports) {
+
+	module.exports = function(exec){
+	  try {
+	    return !!exec();
+	  } catch(e){
+	    return true;
+	  }
+	};
+
+/***/ }),
+/* 20 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var global    = __webpack_require__(20)
+	var global    = __webpack_require__(16)
 	  , core      = __webpack_require__(21)
 	  , ctx       = __webpack_require__(22)
 	  , PROTOTYPE = 'prototype';
@@ -926,15 +1156,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = $export;
 
 /***/ }),
-/* 20 */
-/***/ (function(module, exports) {
-
-	// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
-	var global = module.exports = typeof window != 'undefined' && window.Math == Math
-	  ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
-	if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
-
-/***/ }),
 /* 21 */
 /***/ (function(module, exports) {
 
@@ -977,18 +1198,559 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ }),
 /* 24 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = function(exec){
-	  try {
-	    return !!exec();
-	  } catch(e){
-	    return true;
-	  }
-	};
+	module.exports = __webpack_require__(25);
 
 /***/ }),
 /* 25 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var $          = __webpack_require__(9)
+	  , createDesc = __webpack_require__(26);
+	module.exports = __webpack_require__(18) ? function(object, key, value){
+	  return $.setDesc(object, key, createDesc(1, value));
+	} : function(object, key, value){
+	  object[key] = value;
+	  return object;
+	};
+
+/***/ }),
+/* 26 */
+/***/ (function(module, exports) {
+
+	module.exports = function(bitmap, value){
+	  return {
+	    enumerable  : !(bitmap & 1),
+	    configurable: !(bitmap & 2),
+	    writable    : !(bitmap & 4),
+	    value       : value
+	  };
+	};
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var global = __webpack_require__(16)
+	  , SHARED = '__core-js_shared__'
+	  , store  = global[SHARED] || (global[SHARED] = {});
+	module.exports = function(key){
+	  return store[key] || (store[key] = {});
+	};
+
+/***/ }),
+/* 28 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var def = __webpack_require__(9).setDesc
+	  , has = __webpack_require__(17)
+	  , TAG = __webpack_require__(29)('toStringTag');
+
+	module.exports = function(it, tag, stat){
+	  if(it && !has(it = stat ? it : it.prototype, TAG))def(it, TAG, {configurable: true, value: tag});
+	};
+
+/***/ }),
+/* 29 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var store  = __webpack_require__(27)('wks')
+	  , uid    = __webpack_require__(30)
+	  , Symbol = __webpack_require__(16).Symbol;
+	module.exports = function(name){
+	  return store[name] || (store[name] =
+	    Symbol && Symbol[name] || (Symbol || uid)('Symbol.' + name));
+	};
+
+/***/ }),
+/* 30 */
+/***/ (function(module, exports) {
+
+	var id = 0
+	  , px = Math.random();
+	module.exports = function(key){
+	  return 'Symbol('.concat(key === undefined ? '' : key, ')_', (++id + px).toString(36));
+	};
+
+/***/ }),
+/* 31 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var $         = __webpack_require__(9)
+	  , toIObject = __webpack_require__(32);
+	module.exports = function(object, el){
+	  var O      = toIObject(object)
+	    , keys   = $.getKeys(O)
+	    , length = keys.length
+	    , index  = 0
+	    , key;
+	  while(length > index)if(O[key = keys[index++]] === el)return key;
+	};
+
+/***/ }),
+/* 32 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// to indexed object, toObject with fallback for non-array-like ES3 strings
+	var IObject = __webpack_require__(33)
+	  , defined = __webpack_require__(35);
+	module.exports = function(it){
+	  return IObject(defined(it));
+	};
+
+/***/ }),
+/* 33 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// fallback for non-array-like ES3 and non-enumerable old V8 strings
+	var cof = __webpack_require__(34);
+	module.exports = Object('z').propertyIsEnumerable(0) ? Object : function(it){
+	  return cof(it) == 'String' ? it.split('') : Object(it);
+	};
+
+/***/ }),
+/* 34 */
+/***/ (function(module, exports) {
+
+	var toString = {}.toString;
+
+	module.exports = function(it){
+	  return toString.call(it).slice(8, -1);
+	};
+
+/***/ }),
+/* 35 */
+/***/ (function(module, exports) {
+
+	// 7.2.1 RequireObjectCoercible(argument)
+	module.exports = function(it){
+	  if(it == undefined)throw TypeError("Can't call method on  " + it);
+	  return it;
+	};
+
+/***/ }),
+/* 36 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
+	var toIObject = __webpack_require__(32)
+	  , getNames  = __webpack_require__(9).getNames
+	  , toString  = {}.toString;
+
+	var windowNames = typeof window == 'object' && Object.getOwnPropertyNames
+	  ? Object.getOwnPropertyNames(window) : [];
+
+	var getWindowNames = function(it){
+	  try {
+	    return getNames(it);
+	  } catch(e){
+	    return windowNames.slice();
+	  }
+	};
+
+	module.exports.get = function getOwnPropertyNames(it){
+	  if(windowNames && toString.call(it) == '[object Window]')return getWindowNames(it);
+	  return getNames(toIObject(it));
+	};
+
+/***/ }),
+/* 37 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// all enumerable object keys, includes symbols
+	var $ = __webpack_require__(9);
+	module.exports = function(it){
+	  var keys       = $.getKeys(it)
+	    , getSymbols = $.getSymbols;
+	  if(getSymbols){
+	    var symbols = getSymbols(it)
+	      , isEnum  = $.isEnum
+	      , i       = 0
+	      , key;
+	    while(symbols.length > i)if(isEnum.call(it, key = symbols[i++]))keys.push(key);
+	  }
+	  return keys;
+	};
+
+/***/ }),
+/* 38 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// 7.2.2 IsArray(argument)
+	var cof = __webpack_require__(34);
+	module.exports = Array.isArray || function(arg){
+	  return cof(arg) == 'Array';
+	};
+
+/***/ }),
+/* 39 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var isObject = __webpack_require__(40);
+	module.exports = function(it){
+	  if(!isObject(it))throw TypeError(it + ' is not an object!');
+	  return it;
+	};
+
+/***/ }),
+/* 40 */
+/***/ (function(module, exports) {
+
+	module.exports = function(it){
+	  return typeof it === 'object' ? it !== null : typeof it === 'function';
+	};
+
+/***/ }),
+/* 41 */
+/***/ (function(module, exports) {
+
+	module.exports = true;
+
+/***/ }),
+/* 42 */
+/***/ (function(module, exports) {
+
+	
+
+/***/ }),
+/* 43 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	module.exports = { "default": __webpack_require__(44), __esModule: true };
+
+/***/ }),
+/* 44 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	__webpack_require__(45);
+	__webpack_require__(51);
+	module.exports = __webpack_require__(29)('iterator');
+
+/***/ }),
+/* 45 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var $at  = __webpack_require__(46)(true);
+
+	// 21.1.3.27 String.prototype[@@iterator]()
+	__webpack_require__(48)(String, 'String', function(iterated){
+	  this._t = String(iterated); // target
+	  this._i = 0;                // next index
+	// 21.1.5.2.1 %StringIteratorPrototype%.next()
+	}, function(){
+	  var O     = this._t
+	    , index = this._i
+	    , point;
+	  if(index >= O.length)return {value: undefined, done: true};
+	  point = $at(O, index);
+	  this._i += point.length;
+	  return {value: point, done: false};
+	});
+
+/***/ }),
+/* 46 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var toInteger = __webpack_require__(47)
+	  , defined   = __webpack_require__(35);
+	// true  -> String#at
+	// false -> String#codePointAt
+	module.exports = function(TO_STRING){
+	  return function(that, pos){
+	    var s = String(defined(that))
+	      , i = toInteger(pos)
+	      , l = s.length
+	      , a, b;
+	    if(i < 0 || i >= l)return TO_STRING ? '' : undefined;
+	    a = s.charCodeAt(i);
+	    return a < 0xd800 || a > 0xdbff || i + 1 === l || (b = s.charCodeAt(i + 1)) < 0xdc00 || b > 0xdfff
+	      ? TO_STRING ? s.charAt(i) : a
+	      : TO_STRING ? s.slice(i, i + 2) : (a - 0xd800 << 10) + (b - 0xdc00) + 0x10000;
+	  };
+	};
+
+/***/ }),
+/* 47 */
+/***/ (function(module, exports) {
+
+	// 7.1.4 ToInteger
+	var ceil  = Math.ceil
+	  , floor = Math.floor;
+	module.exports = function(it){
+	  return isNaN(it = +it) ? 0 : (it > 0 ? floor : ceil)(it);
+	};
+
+/***/ }),
+/* 48 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var LIBRARY        = __webpack_require__(41)
+	  , $export        = __webpack_require__(20)
+	  , redefine       = __webpack_require__(24)
+	  , hide           = __webpack_require__(25)
+	  , has            = __webpack_require__(17)
+	  , Iterators      = __webpack_require__(49)
+	  , $iterCreate    = __webpack_require__(50)
+	  , setToStringTag = __webpack_require__(28)
+	  , getProto       = __webpack_require__(9).getProto
+	  , ITERATOR       = __webpack_require__(29)('iterator')
+	  , BUGGY          = !([].keys && 'next' in [].keys()) // Safari has buggy iterators w/o `next`
+	  , FF_ITERATOR    = '@@iterator'
+	  , KEYS           = 'keys'
+	  , VALUES         = 'values';
+
+	var returnThis = function(){ return this; };
+
+	module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED){
+	  $iterCreate(Constructor, NAME, next);
+	  var getMethod = function(kind){
+	    if(!BUGGY && kind in proto)return proto[kind];
+	    switch(kind){
+	      case KEYS: return function keys(){ return new Constructor(this, kind); };
+	      case VALUES: return function values(){ return new Constructor(this, kind); };
+	    } return function entries(){ return new Constructor(this, kind); };
+	  };
+	  var TAG        = NAME + ' Iterator'
+	    , DEF_VALUES = DEFAULT == VALUES
+	    , VALUES_BUG = false
+	    , proto      = Base.prototype
+	    , $native    = proto[ITERATOR] || proto[FF_ITERATOR] || DEFAULT && proto[DEFAULT]
+	    , $default   = $native || getMethod(DEFAULT)
+	    , methods, key;
+	  // Fix native
+	  if($native){
+	    var IteratorPrototype = getProto($default.call(new Base));
+	    // Set @@toStringTag to native iterators
+	    setToStringTag(IteratorPrototype, TAG, true);
+	    // FF fix
+	    if(!LIBRARY && has(proto, FF_ITERATOR))hide(IteratorPrototype, ITERATOR, returnThis);
+	    // fix Array#{values, @@iterator}.name in V8 / FF
+	    if(DEF_VALUES && $native.name !== VALUES){
+	      VALUES_BUG = true;
+	      $default = function values(){ return $native.call(this); };
+	    }
+	  }
+	  // Define iterator
+	  if((!LIBRARY || FORCED) && (BUGGY || VALUES_BUG || !proto[ITERATOR])){
+	    hide(proto, ITERATOR, $default);
+	  }
+	  // Plug for library
+	  Iterators[NAME] = $default;
+	  Iterators[TAG]  = returnThis;
+	  if(DEFAULT){
+	    methods = {
+	      values:  DEF_VALUES  ? $default : getMethod(VALUES),
+	      keys:    IS_SET      ? $default : getMethod(KEYS),
+	      entries: !DEF_VALUES ? $default : getMethod('entries')
+	    };
+	    if(FORCED)for(key in methods){
+	      if(!(key in proto))redefine(proto, key, methods[key]);
+	    } else $export($export.P + $export.F * (BUGGY || VALUES_BUG), NAME, methods);
+	  }
+	  return methods;
+	};
+
+/***/ }),
+/* 49 */
+/***/ (function(module, exports) {
+
+	module.exports = {};
+
+/***/ }),
+/* 50 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var $              = __webpack_require__(9)
+	  , descriptor     = __webpack_require__(26)
+	  , setToStringTag = __webpack_require__(28)
+	  , IteratorPrototype = {};
+
+	// 25.1.2.1.1 %IteratorPrototype%[@@iterator]()
+	__webpack_require__(25)(IteratorPrototype, __webpack_require__(29)('iterator'), function(){ return this; });
+
+	module.exports = function(Constructor, NAME, next){
+	  Constructor.prototype = $.create(IteratorPrototype, {next: descriptor(1, next)});
+	  setToStringTag(Constructor, NAME + ' Iterator');
+	};
+
+/***/ }),
+/* 51 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	__webpack_require__(52);
+	var Iterators = __webpack_require__(49);
+	Iterators.NodeList = Iterators.HTMLCollection = Iterators.Array;
+
+/***/ }),
+/* 52 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var addToUnscopables = __webpack_require__(53)
+	  , step             = __webpack_require__(54)
+	  , Iterators        = __webpack_require__(49)
+	  , toIObject        = __webpack_require__(32);
+
+	// 22.1.3.4 Array.prototype.entries()
+	// 22.1.3.13 Array.prototype.keys()
+	// 22.1.3.29 Array.prototype.values()
+	// 22.1.3.30 Array.prototype[@@iterator]()
+	module.exports = __webpack_require__(48)(Array, 'Array', function(iterated, kind){
+	  this._t = toIObject(iterated); // target
+	  this._i = 0;                   // next index
+	  this._k = kind;                // kind
+	// 22.1.5.2.1 %ArrayIteratorPrototype%.next()
+	}, function(){
+	  var O     = this._t
+	    , kind  = this._k
+	    , index = this._i++;
+	  if(!O || index >= O.length){
+	    this._t = undefined;
+	    return step(1);
+	  }
+	  if(kind == 'keys'  )return step(0, index);
+	  if(kind == 'values')return step(0, O[index]);
+	  return step(0, [index, O[index]]);
+	}, 'values');
+
+	// argumentsList[@@iterator] is %ArrayProto_values% (9.4.4.6, 9.4.4.7)
+	Iterators.Arguments = Iterators.Array;
+
+	addToUnscopables('keys');
+	addToUnscopables('values');
+	addToUnscopables('entries');
+
+/***/ }),
+/* 53 */
+/***/ (function(module, exports) {
+
+	module.exports = function(){ /* empty */ };
+
+/***/ }),
+/* 54 */
+/***/ (function(module, exports) {
+
+	module.exports = function(done, value){
+	  return {value: value, done: !!done};
+	};
+
+/***/ }),
+/* 55 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	module.exports = { "default": __webpack_require__(56), __esModule: true };
+
+/***/ }),
+/* 56 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	__webpack_require__(51);
+	__webpack_require__(45);
+	module.exports = __webpack_require__(57);
+
+/***/ }),
+/* 57 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var anObject = __webpack_require__(39)
+	  , get      = __webpack_require__(58);
+	module.exports = __webpack_require__(21).getIterator = function(it){
+	  var iterFn = get(it);
+	  if(typeof iterFn != 'function')throw TypeError(it + ' is not iterable!');
+	  return anObject(iterFn.call(it));
+	};
+
+/***/ }),
+/* 58 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	var classof   = __webpack_require__(59)
+	  , ITERATOR  = __webpack_require__(29)('iterator')
+	  , Iterators = __webpack_require__(49);
+	module.exports = __webpack_require__(21).getIteratorMethod = function(it){
+	  if(it != undefined)return it[ITERATOR]
+	    || it['@@iterator']
+	    || Iterators[classof(it)];
+	};
+
+/***/ }),
+/* 59 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// getting tag from 19.1.3.6 Object.prototype.toString()
+	var cof = __webpack_require__(34)
+	  , TAG = __webpack_require__(29)('toStringTag')
+	  // ES3 wrong here
+	  , ARG = cof(function(){ return arguments; }()) == 'Arguments';
+
+	module.exports = function(it){
+	  var O, T, B;
+	  return it === undefined ? 'Undefined' : it === null ? 'Null'
+	    // @@toStringTag case
+	    : typeof (T = (O = Object(it))[TAG]) == 'string' ? T
+	    // builtinTag case
+	    : ARG ? cof(O)
+	    // ES3 arguments fallback
+	    : (B = cof(O)) == 'Object' && typeof O.callee == 'function' ? 'Arguments' : B;
+	};
+
+/***/ }),
+/* 60 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	module.exports = { "default": __webpack_require__(61), __esModule: true };
+
+/***/ }),
+/* 61 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	__webpack_require__(62);
+	module.exports = __webpack_require__(21).Object.keys;
+
+/***/ }),
+/* 62 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// 19.1.2.14 Object.keys(O)
+	var toObject = __webpack_require__(63);
+
+	__webpack_require__(64)('keys', function($keys){
+	  return function keys(it){
+	    return $keys(toObject(it));
+	  };
+	});
+
+/***/ }),
+/* 63 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// 7.1.13 ToObject(argument)
+	var defined = __webpack_require__(35);
+	module.exports = function(it){
+	  return Object(defined(it));
+	};
+
+/***/ }),
+/* 64 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// most Object methods by ES6 should accept primitives
+	var $export = __webpack_require__(20)
+	  , core    = __webpack_require__(21)
+	  , fails   = __webpack_require__(19);
+	module.exports = function(KEY, exec){
+	  var fn  = (core.Object || {})[KEY] || Object[KEY]
+	    , exp = {};
+	  exp[KEY] = exec(fn);
+	  $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
+	};
+
+/***/ }),
+/* 65 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1016,7 +1778,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 26 */
+/* 66 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1065,7 +1827,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 27 */
+/* 67 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -1095,7 +1857,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 28 */
+/* 68 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -1115,7 +1877,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 29 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1161,7 +1923,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 30 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1171,7 +1933,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.__esModule = true;
 	exports.registerDefaultDecorators = registerDefaultDecorators;
 
-	var _decoratorsInline = __webpack_require__(31);
+	var _decoratorsInline = __webpack_require__(71);
 
 	var _decoratorsInline2 = _interopRequireDefault(_decoratorsInline);
 
@@ -1180,7 +1942,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 31 */
+/* 71 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1213,7 +1975,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 32 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1264,48 +2026,53 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 33 */
+/* 73 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _Object$create = __webpack_require__(34)['default'];
+	var _Object$create = __webpack_require__(74)['default'];
 
-	var _Object$keys = __webpack_require__(13)['default'];
+	var _Object$keys = __webpack_require__(60)['default'];
 
-	var _interopRequireWildcard = __webpack_require__(3)['default'];
+	var _interopRequireDefault = __webpack_require__(1)['default'];
 
 	exports.__esModule = true;
 	exports.createProtoAccessControl = createProtoAccessControl;
 	exports.resultIsAllowed = resultIsAllowed;
 	exports.resetLoggedProperties = resetLoggedProperties;
 
-	var _createNewLookupObject = __webpack_require__(36);
+	var _utils = __webpack_require__(5);
 
-	var _logger = __webpack_require__(32);
+	var _logger = __webpack_require__(72);
 
-	var logger = _interopRequireWildcard(_logger);
+	var _logger2 = _interopRequireDefault(_logger);
 
 	var loggedProperties = _Object$create(null);
 
 	function createProtoAccessControl(runtimeOptions) {
-	  var defaultMethodWhiteList = _Object$create(null);
-	  defaultMethodWhiteList['constructor'] = false;
-	  defaultMethodWhiteList['__defineGetter__'] = false;
-	  defaultMethodWhiteList['__defineSetter__'] = false;
-	  defaultMethodWhiteList['__lookupGetter__'] = false;
-
-	  var defaultPropertyWhiteList = _Object$create(null);
+	  // Create an object with "null"-prototype to avoid truthy results on
+	  // prototype properties.
+	  var propertyWhiteList = _Object$create(null);
 	  // eslint-disable-next-line no-proto
-	  defaultPropertyWhiteList['__proto__'] = false;
+	  propertyWhiteList['__proto__'] = false;
+	  _utils.extend(propertyWhiteList, runtimeOptions.allowedProtoProperties);
+
+	  var methodWhiteList = _Object$create(null);
+	  methodWhiteList['constructor'] = false;
+	  methodWhiteList['__defineGetter__'] = false;
+	  methodWhiteList['__defineSetter__'] = false;
+	  methodWhiteList['__lookupGetter__'] = false;
+	  methodWhiteList['__lookupSetter__'] = false;
+	  _utils.extend(methodWhiteList, runtimeOptions.allowedProtoMethods);
 
 	  return {
 	    properties: {
-	      whitelist: _createNewLookupObject.createNewLookupObject(defaultPropertyWhiteList, runtimeOptions.allowedProtoProperties),
+	      whitelist: propertyWhiteList,
 	      defaultValue: runtimeOptions.allowProtoPropertiesByDefault
 	    },
 	    methods: {
-	      whitelist: _createNewLookupObject.createNewLookupObject(defaultMethodWhiteList, runtimeOptions.allowedProtoMethods),
+	      whitelist: methodWhiteList,
 	      defaultValue: runtimeOptions.allowProtoMethodsByDefault
 	    }
 	  };
@@ -1333,7 +2100,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function logUnexpecedPropertyAccessOnce(propertyName) {
 	  if (loggedProperties[propertyName] !== true) {
 	    loggedProperties[propertyName] = true;
-	    logger.log('error', 'Handlebars: Access has been denied to resolve the property "' + propertyName + '" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details');
+	    _logger2['default'].log('error', 'Handlebars: Access has been denied to resolve the property "' + propertyName + '" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details');
 	  }
 	}
 
@@ -1344,13 +2111,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 34 */
+/* 74 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = { "default": __webpack_require__(35), __esModule: true };
+	module.exports = { "default": __webpack_require__(75), __esModule: true };
 
 /***/ }),
-/* 35 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var $ = __webpack_require__(9);
@@ -1359,35 +2126,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 36 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _Object$create = __webpack_require__(34)['default'];
-
-	exports.__esModule = true;
-	exports.createNewLookupObject = createNewLookupObject;
-
-	var _utils = __webpack_require__(5);
-
-	/**
-	 * Create a new object with "null"-prototype to avoid truthy results on prototype properties.
-	 * The resulting object can be used with "object[property]" to check if a property exists
-	 * @param {...object} sources a varargs parameter of source objects that will be merged
-	 * @returns {object}
-	 */
-
-	function createNewLookupObject() {
-	  for (var _len = arguments.length, sources = Array(_len), _key = 0; _key < _len; _key++) {
-	    sources[_key] = arguments[_key];
-	  }
-
-	  return _utils.extend.apply(undefined, [_Object$create(null)].concat(sources));
-	}
-
-/***/ }),
-/* 37 */
+/* 76 */
 /***/ (function(module, exports) {
 
 	// Build out our basic SafeString type
@@ -1406,14 +2145,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 38 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _Object$seal = __webpack_require__(39)['default'];
+	var _Object$seal = __webpack_require__(78)['default'];
 
-	var _Object$keys = __webpack_require__(13)['default'];
+	var _Object$keys = __webpack_require__(60)['default'];
 
 	var _interopRequireWildcard = __webpack_require__(3)['default'];
 
@@ -1439,9 +2178,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _helpers = __webpack_require__(10);
 
-	var _internalWrapHelper = __webpack_require__(43);
+	var _internalWrapHelper = __webpack_require__(81);
 
-	var _internalProtoAccess = __webpack_require__(33);
+	var _internalProtoAccess = __webpack_require__(73);
 
 	function checkRevision(compilerInfo) {
 	  var compilerRevision = compilerInfo && compilerInfo[0] || 1,
@@ -1488,16 +2227,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    partial = env.VM.resolvePartial.call(this, partial, context, options);
 
-	    var extendedOptions = Utils.extend({}, options, {
-	      hooks: this.hooks,
-	      protoAccessControl: this.protoAccessControl
-	    });
+	    options.hooks = this.hooks;
+	    options.protoAccessControl = this.protoAccessControl;
 
-	    var result = env.VM.invokePartial.call(this, partial, context, extendedOptions);
+	    var result = env.VM.invokePartial.call(this, partial, context, options);
 
 	    if (result == null && env.compile) {
 	      options.partials[options.name] = env.compile(partial, templateSpec.compilerOptions, env);
-	      result = options.partials[options.name](context, extendedOptions);
+	      result = options.partials[options.name](context, options);
 	    }
 	    if (result != null) {
 	      if (options.indent) {
@@ -1546,7 +2283,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      for (var i = 0; i < len; i++) {
 	        var result = depths[i] && container.lookupProperty(depths[i], name);
 	        if (result != null) {
-	          return depths[i][name];
+	          return result;
 	        }
 	      }
 	    },
@@ -1628,8 +2365,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  ret._setup = function (options) {
 	    if (!options.partial) {
-	      var mergedHelpers = Utils.extend({}, env.helpers, options.helpers);
-	      wrapHelpersToPassLookupProperty(mergedHelpers, container);
+	      var mergedHelpers = {};
+	      addHelpers(mergedHelpers, env.helpers, container);
+	      addHelpers(mergedHelpers, options.helpers, container);
 	      container.helpers = mergedHelpers;
 
 	      if (templateSpec.usePartial) {
@@ -1695,21 +2433,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	function resolvePartial(partial, context, options) {
 	  if (!partial) {
 	    if (options.name === '@partial-block') {
-	      partial = options.data['partial-block'];
+	      partial = lookupOwnProperty(options.data, 'partial-block');
 	    } else {
-	      partial = options.partials[options.name];
+	      partial = lookupOwnProperty(options.partials, options.name);
 	    }
 	  } else if (!partial.call && !options.name) {
 	    // This is a dynamic partial that returned a string
 	    options.name = partial;
-	    partial = options.partials[partial];
+	    partial = lookupOwnProperty(options.partials, partial);
 	  }
 	  return partial;
 	}
 
 	function invokePartial(partial, context, options) {
 	  // Use the current closure context to save the partial-block if this partial
-	  var currentPartialBlock = options.data && options.data['partial-block'];
+	  var currentPartialBlock = lookupOwnProperty(options.data, 'partial-block');
 	  options.partial = true;
 	  if (options.ids) {
 	    options.data.contextPath = options.ids[0] || options.data.contextPath;
@@ -1751,6 +2489,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return '';
 	}
 
+	function lookupOwnProperty(obj, name) {
+	  if (obj && Object.prototype.hasOwnProperty.call(obj, name)) {
+	    return obj[name];
+	  }
+	}
+
 	function initData(context, data) {
 	  if (!data || !('root' in data)) {
 	    data = data ? _base.createFrame(data) : {};
@@ -1768,9 +2512,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return prog;
 	}
 
-	function wrapHelpersToPassLookupProperty(mergedHelpers, container) {
-	  _Object$keys(mergedHelpers).forEach(function (helperName) {
-	    var helper = mergedHelpers[helperName];
+	function addHelpers(mergedHelpers, helpers, container) {
+	  if (!helpers) return;
+	  _Object$keys(helpers).forEach(function (helperName) {
+	    var helper = helpers[helperName];
 	    mergedHelpers[helperName] = passLookupPropertyOption(helper, container);
 	  });
 	}
@@ -1778,46 +2523,39 @@ return /******/ (function(modules) { // webpackBootstrap
 	function passLookupPropertyOption(helper, container) {
 	  var lookupProperty = container.lookupProperty;
 	  return _internalWrapHelper.wrapHelper(helper, function (options) {
-	    return Utils.extend({ lookupProperty: lookupProperty }, options);
+	    options.lookupProperty = lookupProperty;
+	    return options;
 	  });
 	}
 
 /***/ }),
-/* 39 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = { "default": __webpack_require__(40), __esModule: true };
+	module.exports = { "default": __webpack_require__(79), __esModule: true };
 
 /***/ }),
-/* 40 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	__webpack_require__(41);
+	__webpack_require__(80);
 	module.exports = __webpack_require__(21).Object.seal;
 
 /***/ }),
-/* 41 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// 19.1.2.17 Object.seal(O)
-	var isObject = __webpack_require__(42);
+	var isObject = __webpack_require__(40);
 
-	__webpack_require__(18)('seal', function($seal){
+	__webpack_require__(64)('seal', function($seal){
 	  return function seal(it){
 	    return $seal && isObject(it) ? $seal(it) : it;
 	  };
 	});
 
 /***/ }),
-/* 42 */
-/***/ (function(module, exports) {
-
-	module.exports = function(it){
-	  return typeof it === 'object' ? it !== null : typeof it === 'function';
-	};
-
-/***/ }),
-/* 43 */
+/* 81 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -1840,34 +2578,44 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 44 */
+/* 82 */
 /***/ (function(module, exports) {
 
-	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
+	/* global globalThis */
+	'use strict';
 
 	exports.__esModule = true;
 
 	exports['default'] = function (Handlebars) {
 	  /* istanbul ignore next */
-	  var root = typeof global !== 'undefined' ? global : window,
-	      $Handlebars = root.Handlebars;
+	  // https://mathiasbynens.be/notes/globalthis
+	  (function () {
+	    if (typeof globalThis === 'object') return;
+	    Object.prototype.__defineGetter__('__magic__', function () {
+	      return this;
+	    });
+	    __magic__.globalThis = __magic__; // eslint-disable-line no-undef
+	    delete Object.prototype.__magic__;
+	  })();
+
+	  var $Handlebars = globalThis.Handlebars;
+
 	  /* istanbul ignore next */
 	  Handlebars.noConflict = function () {
-	    if (root.Handlebars === Handlebars) {
-	      root.Handlebars = $Handlebars;
+	    if (globalThis.Handlebars === Handlebars) {
+	      globalThis.Handlebars = $Handlebars;
 	    }
 	    return Handlebars;
 	  };
-	  if(!root.Handlebars  || !root.Handlebars.create){
-		root.Handlebars = Handlebars.create();
+	  if(!globalThis.Handlebars  || !globalThis.Handlebars.create){
+	        globalThis.Handlebars = Handlebars.create();
 	  }
 	};
 
 	module.exports = exports['default'];
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }),
-/* 45 */
+/* 83 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -1902,10 +2650,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 46 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
+
+	var _Object$keys = __webpack_require__(60)['default'];
 
 	var _interopRequireDefault = __webpack_require__(1)['default'];
 
@@ -1915,17 +2665,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.parseWithoutProcessing = parseWithoutProcessing;
 	exports.parse = parse;
 
-	var _parser = __webpack_require__(47);
+	var _parser = __webpack_require__(85);
 
 	var _parser2 = _interopRequireDefault(_parser);
 
-	var _whitespaceControl = __webpack_require__(48);
+	var _whitespaceControl = __webpack_require__(86);
 
 	var _whitespaceControl2 = _interopRequireDefault(_whitespaceControl);
 
-	var _helpers = __webpack_require__(50);
+	var _helpers = __webpack_require__(88);
 
 	var Helpers = _interopRequireWildcard(_helpers);
+
+	var _exception = __webpack_require__(6);
+
+	var _exception2 = _interopRequireDefault(_exception);
 
 	var _utils = __webpack_require__(5);
 
@@ -1937,6 +2691,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	function parseWithoutProcessing(input, options) {
 	  // Just return if an already-compiled AST was passed in.
 	  if (input.type === 'Program') {
+	    // When a pre-parsed AST is passed in, validate all node values to prevent
+	    // code injection via type-confused literals.
+	    validateInputAst(input);
 	    return input;
 	  }
 
@@ -1959,8 +2716,60 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return strip.accept(ast);
 	}
 
+	function validateInputAst(ast) {
+	  validateAstNode(ast);
+	}
+
+	function validateAstNode(node) {
+	  if (node == null) {
+	    return;
+	  }
+
+	  if (Array.isArray(node)) {
+	    node.forEach(validateAstNode);
+	    return;
+	  }
+
+	  if (typeof node !== 'object') {
+	    return;
+	  }
+
+	  if (node.type === 'PathExpression') {
+	    if (!isValidDepth(node.depth)) {
+	      throw new _exception2['default']('Invalid AST: PathExpression.depth must be an integer');
+	    }
+	    if (!Array.isArray(node.parts)) {
+	      throw new _exception2['default']('Invalid AST: PathExpression.parts must be an array');
+	    }
+	    for (var i = 0; i < node.parts.length; i++) {
+	      if (typeof node.parts[i] !== 'string') {
+	        throw new _exception2['default']('Invalid AST: PathExpression.parts must only contain strings');
+	      }
+	    }
+	  } else if (node.type === 'NumberLiteral') {
+	    if (typeof node.value !== 'number' || !isFinite(node.value)) {
+	      throw new _exception2['default']('Invalid AST: NumberLiteral.value must be a number');
+	    }
+	  } else if (node.type === 'BooleanLiteral') {
+	    if (typeof node.value !== 'boolean') {
+	      throw new _exception2['default']('Invalid AST: BooleanLiteral.value must be a boolean');
+	    }
+	  }
+
+	  _Object$keys(node).forEach(function (propertyName) {
+	    if (propertyName === 'loc') {
+	      return;
+	    }
+	    validateAstNode(node[propertyName]);
+	  });
+	}
+
+	function isValidDepth(depth) {
+	  return typeof depth === 'number' && isFinite(depth) && Math.floor(depth) === depth && depth >= 0;
+	}
+
 /***/ }),
-/* 47 */
+/* 85 */
 /***/ (function(module, exports) {
 
 	// File ignored in coverage tests via setting in .istanbul.yml
@@ -2701,7 +3510,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports["default"];
 
 /***/ }),
-/* 48 */
+/* 86 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -2710,7 +3519,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	exports.__esModule = true;
 
-	var _visitor = __webpack_require__(49);
+	var _visitor = __webpack_require__(87);
 
 	var _visitor2 = _interopRequireDefault(_visitor);
 
@@ -2925,7 +3734,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 49 */
+/* 87 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3068,7 +3877,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 50 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3299,14 +4108,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 51 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint-disable new-cap */
 
 	'use strict';
 
-	var _Object$create = __webpack_require__(34)['default'];
+	var _Object$create = __webpack_require__(74)['default'];
 
 	var _interopRequireDefault = __webpack_require__(1)['default'];
 
@@ -3321,7 +4130,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _utils = __webpack_require__(5);
 
-	var _ast = __webpack_require__(45);
+	var _ast = __webpack_require__(83);
 
 	var _ast2 = _interopRequireDefault(_ast);
 
@@ -3870,12 +4679,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 52 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var _Object$keys = __webpack_require__(13)['default'];
+	var _Object$keys = __webpack_require__(60)['default'];
 
 	var _interopRequireDefault = __webpack_require__(1)['default'];
 
@@ -3889,7 +4698,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _utils = __webpack_require__(5);
 
-	var _codeGen = __webpack_require__(53);
+	var _codeGen = __webpack_require__(91);
 
 	var _codeGen2 = _interopRequireDefault(_codeGen);
 
@@ -4034,12 +4843,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var decorators = _context.decorators;
 
 	      for (i = 0, l = programs.length; i < l; i++) {
-	        if (programs[i]) {
-	          ret[i] = programs[i];
-	          if (decorators[i]) {
-	            ret[i + '_d'] = decorators[i];
-	            ret.useDecorators = true;
-	          }
+	        ret[i] = programs[i];
+	        if (decorators[i]) {
+	          ret[i + '_d'] = decorators[i];
+	          ret.useDecorators = true;
 	        }
 	      }
 
@@ -4365,20 +5172,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this.resolvePath('data', parts, 0, true, strict);
 	  },
 
-	  resolvePath: function resolvePath(type, parts, i, falsy, strict) {
+	  resolvePath: function resolvePath(type, parts, startPartIndex, falsy, strict) {
 	    // istanbul ignore next
 
 	    var _this2 = this;
 
 	    if (this.options.strict || this.options.assumeObjects) {
-	      this.push(strictLookup(this.options.strict && strict, this, parts, type));
+	      this.push(strictLookup(this.options.strict && strict, this, parts, startPartIndex, type));
 	      return;
 	    }
 
 	    var len = parts.length;
-	    for (; i < len; i++) {
+
+	    var _loop = function (i) {
 	      /* eslint-disable no-loop-func */
-	      this.replaceStack(function (current) {
+	      _this2.replaceStack(function (current) {
 	        var lookup = _this2.nameLookup(current, parts[i], type);
 	        // We want to ensure that zero and false are handled properly if the context (falsy flag)
 	        // needs to have the special handling for these values.
@@ -4390,6 +5198,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	      });
 	      /* eslint-enable no-loop-func */
+	    };
+
+	    for (var i = startPartIndex; i < len; i++) {
+	      _loop(i);
 	    }
 	  },
 
@@ -4507,7 +5319,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var foundDecorator = this.nameLookup('decorators', name, 'decorator'),
 	        options = this.setupHelperArgs(name, paramSize);
 
-	    this.decorators.push(['fn = ', this.decorators.functionCall(foundDecorator, '', ['fn', 'props', 'container', options]), ' || fn;']);
+	    // Store the resolved decorator in a variable and verify it is a function before
+	    // calling it. Without this, unregistered decorators can cause an unhandled TypeError
+	    // (calling undefined), which crashes the process — enabling Denial of Service.
+	    this.decorators.push(['var decorator = ', foundDecorator, ';']);
+	    this.decorators.push(['if (typeof decorator !== "function") { throw new Error(', this.quotedString('Missing decorator: "' + name + '"'), '); }']);
+	    this.decorators.push(['fn = ', this.decorators.functionCall('decorator', '', ['fn', 'props', 'container', options]), ' || fn;']);
 	  },
 
 	  // [invokeHelper]
@@ -4690,8 +5507,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var existing = this.matchExistingProgram(child);
 
 	      if (existing == null) {
-	        this.context.programs.push(''); // Placeholder to prevent name conflicts for nested children
-	        var index = this.context.programs.length;
+	        // Placeholder to prevent name conflicts for nested children
+	        var index = this.context.programs.push('') - 1;
 	        child.index = index;
 	        child.name = 'program' + index;
 	        this.context.programs[index] = compiler.compile(child, options, this.context, !this.precompile);
@@ -5011,20 +5828,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return !JavaScriptCompiler.RESERVED_WORDS[name] && /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name);
 	};
 
-	function strictLookup(requireTerminal, compiler, parts, type) {
+	function strictLookup(requireTerminal, compiler, parts, startPartIndex, type) {
 	  var stack = compiler.popStack(),
-	      i = 0,
 	      len = parts.length;
 	  if (requireTerminal) {
 	    len--;
 	  }
 
-	  for (; i < len; i++) {
+	  for (var i = startPartIndex; i < len; i++) {
 	    stack = compiler.nameLookup(stack, parts[i], type);
 	  }
 
 	  if (requireTerminal) {
-	    return [compiler.aliasable('container.strict'), '(', stack, ', ', compiler.quotedString(parts[i]), ', ', JSON.stringify(compiler.source.currentLocation), ' )'];
+	    return [compiler.aliasable('container.strict'), '(', stack, ', ', compiler.quotedString(parts[len]), ', ', JSON.stringify(compiler.source.currentLocation), ' )'];
 	  } else {
 	    return stack;
 	  }
@@ -5034,13 +5850,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = exports['default'];
 
 /***/ }),
-/* 53 */
+/* 91 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	/* global define */
+	/* global define, require */
 	'use strict';
 
-	var _Object$keys = __webpack_require__(13)['default'];
+	var _Object$keys = __webpack_require__(60)['default'];
 
 	exports.__esModule = true;
 
@@ -5051,7 +5867,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	try {
 	  /* istanbul ignore next */
 	  if (false) {
-	    // We don't support this in AMD environments. For these environments, we asusme that
+	    // We don't support this in AMD environments. For these environments, we assume that
 	    // they are running on the browser and thus have no need for the source-map library.
 	    var SourceMap = require('source-map');
 	    SourceNode = SourceMap.SourceNode;

--- a/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
+++ b/impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js
@@ -226,7 +226,7 @@
     }
   };
 
-  requirePaths["common-ui/handlebars"] = basePath + "/handlebars/handlebars-v4.7.7";
+  requirePaths["common-ui/handlebars"] = basePath + "/handlebars/handlebars-v4.7.9";
   requireShim["common-ui/handlebars"] = ["common-ui/jquery"];
 
   requirePaths["common-ui/jquery-i18n"] = basePath + "/jquery/jquery.i18n.properties-min";


### PR DESCRIPTION
## CVE fix: handlebars 4.7.7 -> 4.7.9 in common-ui

Tracking (Jira): PPP-6364 (https://hv-eng.atlassian.net/browse/PPP-6364)
Advisory: CVE-2026-33916 (GHSA-2qvq-rjwj-gvw9), CVE-2026-33937 (GHSA-2w6w-674q-4c4q),
CVE-2026-33938 (GHSA-3mfm-83xf-c92r), CVE-2026-33939 (GHSA-9cx6-37pm-9jff),
CVE-2026-33940 (GHSA-xhpv-hc6g-r9c6), CVE-2026-33941 (GHSA-xjpj-3mr7-gcpf)
Change: handlebars (npm) 4.7.7 -> 4.7.9 (minimal clearing version; fixed in 4.7.9)
Build affected: pentaho-server (pdia-master@11.1.0.0-326)

### What changed
handlebars is a **vendored** (checked-in) dist library in this repo, not an
npm-resolved dependency. The fix:

- Replaced `impl/client/src/main/javascript/web/handlebars/handlebars-v4.7.7.js`
  with `handlebars-v4.7.9.js`. The new file is **byte-identical to the authentic
  npm `handlebars@4.7.9` `dist/handlebars.js`** except for the same 3-line Pentaho
  `globalThis.Handlebars = Handlebars.create()` registration patch the 4.7.7 file
  carried (adapted `root` -> `globalThis` to match 4.7.9's `globalThis`-based
  bootstrap).
- Updated the two RequireJS/webpackage path references from `handlebars-v4.7.7`
  to `handlebars-v4.7.9`:
  - `impl/client/src/main/resources-filtered/web/common-ui-require-js-cfg.js`
  - `assemblies/webpackage/src/main/resources-filtered/common-ui/package.json`

### Proof the CVE is gone
- New vendored file reports `VERSION = '4.7.9'`; **0** occurrences of `4.7.7`
  remain in the file or anywhere in the repo.
- `diff` against authentic npm `dist/handlebars.js` 4.7.9 shows **only** the
  3-line Pentaho patch -- confirming it is the genuine fixed upstream library.
- Org-wide sweep (pentaho + webdetails): this is the only vendored
  `handlebars-v4.7.7.js`; no other copies to fix.

### Tests
The consumer (`impl/client/.../util/HandlebarsCompiler.js`) uses only the stable
`Handlebars.compile()` API, so this is a contained patch bump. A comparative
behavioral harness over that API surface passed identically on the 4.7.7 baseline
and on 4.7.9 (9 assertions: compile/render, HTML-escaping, triple-stache,
`registerHelper`, block helpers, partials, `SafeString`, and the Pentaho
global-registration patch). The repo's karma/jasmine suite has no pre-existing
handlebars coverage; CI will exercise the full build.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.