### PR TITLE
fix[BACKLOG-50609]: Restore common UI query compatibility

### DIFF
--- a/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
+++ b/impl/server/src/main/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGenerator.java
@@ -19,26 +19,96 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.metadata.datatable.DataTable;
+import org.pentaho.metadata.model.thin.Condition;
+import org.pentaho.metadata.model.thin.Element;
 import org.pentaho.metadata.model.thin.MetadataModelsService;
 import org.pentaho.metadata.model.thin.Model;
 import org.pentaho.metadata.model.thin.ModelInfo;
+import org.pentaho.metadata.model.thin.Order;
+import org.pentaho.metadata.model.thin.Parameter;
 import org.pentaho.metadata.model.thin.Query;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.engine.services.solution.SimpleContentGenerator;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.OptBoolean;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 public class MetadataModelsContentGenerator extends SimpleContentGenerator {
 
   private static final long serialVersionUID = -3934988366302705814L;
+  private static final String QUERY_TYPE = "org.pentaho.metadata.model.thin.Query";
+  private static final String ELEMENT_TYPE = "org.pentaho.metadata.model.thin.Element";
+  private static final String CONDITION_TYPE = "org.pentaho.metadata.model.thin.Condition";
+  private static final String LEGACY_CONDITION_TYPE = "org.pentaho.common.ui.metadata.model.impl.Condition";
+  private static final String ORDER_TYPE = "org.pentaho.metadata.model.thin.Order";
+  private static final String PARAMETER_TYPE = "org.pentaho.metadata.model.thin.Parameter";
+  private static final String LEGACY_PARAMETER_TYPE = "org.pentaho.common.ui.metadata.model.impl.Parameter";
+
+  @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class",
+      requireTypeIdForSubtypes = OptBoolean.FALSE )
+  @JsonSubTypes( @JsonSubTypes.Type( value = Query.class, name = QUERY_TYPE ) )
+  private abstract static class QueryMixin {
+  }
+
+  @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class",
+      requireTypeIdForSubtypes = OptBoolean.FALSE )
+  @JsonSubTypes( @JsonSubTypes.Type( value = Element.class, name = ELEMENT_TYPE ) )
+  private abstract static class ElementMixin {
+    @JsonAlias( "defaultAggType" )
+    abstract void setDefaultAggregation( String defaultAggregation );
+  }
+
+  @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class",
+      requireTypeIdForSubtypes = OptBoolean.FALSE )
+  @JsonSubTypes( {
+    @JsonSubTypes.Type( value = Condition.class, name = CONDITION_TYPE ),
+    @JsonSubTypes.Type( value = Condition.class, name = LEGACY_CONDITION_TYPE )
+  } )
+  private abstract static class ConditionMixin {
+    @JsonAlias( "selectedAggType" )
+    abstract void setSelectedAggregation( String selectedAggregation );
+  }
+
+  @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class",
+      requireTypeIdForSubtypes = OptBoolean.FALSE )
+  @JsonSubTypes( @JsonSubTypes.Type( value = Order.class, name = ORDER_TYPE ) )
+  private abstract static class OrderMixin {
+  }
+
+  @JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class",
+      requireTypeIdForSubtypes = OptBoolean.FALSE )
+  @JsonSubTypes( {
+    @JsonSubTypes.Type( value = Parameter.class, name = PARAMETER_TYPE ),
+    @JsonSubTypes.Type( value = Parameter.class, name = LEGACY_PARAMETER_TYPE )
+  } )
+  private abstract static class ParameterMixin {
+  }
+
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper QUERY_OBJECT_MAPPER = createQueryObjectMapper();
 
   private Log logger = LogFactory.getLog( MetadataModelsContentGenerator.class );
 
   public static final String LIST_MODELS_ACTION = "listmodels"; //$NON-NLS-1$
   public static final String GET_MODEL_ACTION = "getmodel"; //$NON-NLS-1$
   public static final String QUERY_ACTION = "query"; //$NON-NLS-1$
+
+  static ObjectMapper createQueryObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.enable( JsonParser.Feature.STRICT_DUPLICATE_DETECTION );
+    // Legacy Flexjson FQCNs are protocol identifiers, not classes that Jackson may load dynamically.
+    mapper.addMixIn( Query.class, QueryMixin.class );
+    mapper.addMixIn( Element.class, ElementMixin.class );
+    mapper.addMixIn( Condition.class, ConditionMixin.class );
+    mapper.addMixIn( Order.class, OrderMixin.class );
+    mapper.addMixIn( Parameter.class, ParameterMixin.class );
+    return mapper;
+  }
 
   @Override
   public void createContent( OutputStream output ) throws Exception {
@@ -61,7 +131,7 @@ public class MetadataModelsContentGenerator extends SimpleContentGenerator {
     } else if ( QUERY_ACTION.equals( action ) ) {
       String queryStr = params.getStringParameter( "query", null ); //$NON-NLS-1$
       int rowLimit = (int) params.getLongParameter( "rowlimit", -1 ); //$NON-NLS-1$
-      Query query = OBJECT_MAPPER.readValue( queryStr, Query.class );
+      Query query = QUERY_OBJECT_MAPPER.readValue( queryStr, Query.class );
       MetadataModelsService svc = new MetadataModelsService();
       DataTable table = svc.executeQuery( query, rowLimit );
       writeJson( table, output );

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
@@ -192,7 +192,6 @@ public class MetadataModelsContentGeneratorTest {
       + "{\"class\":\"org.pentaho.metadata.model.thin.Element\",\"id\":\"element1\"},"
       + "{\"class\":\"org.pentaho.metadata.model.thin.Element\",\"id\":\"element2\"}"
       + "]}";
-    System.out.println( queryJson );
     requestParams.setParameter( "query", queryJson );
 
     parameterProviders.put( IParameterProvider.SCOPE_REQUEST, requestParams );
@@ -203,7 +202,6 @@ public class MetadataModelsContentGeneratorTest {
     cg.createContent( output );
 
     String result = output.toString();
-    System.out.println( result );
     DataTable table = OBJECT_MAPPER.readValue( result, DataTable.class );
 
     Assert.assertNotNull( "Data table is null", table );

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorTest.java
@@ -158,6 +158,7 @@ public class MetadataModelsContentGeneratorTest {
     // Jackson output no longer contains Flexjson "class" metadata; validate actual payload fields.
     Assert.assertEquals( "Wrong model id", id, OBJECT_MAPPER.readTree( result ).path( "id" ).asText() );
     Assert.assertTrue( "Wrong contents", OBJECT_MAPPER.readTree( result ).path( "elements" ).isArray() );
+    Assert.assertFalse( "Response unexpectedly contains Flexjson class metadata", result.contains( "\"class\"" ) );
 
   }
 
@@ -183,7 +184,14 @@ public class MetadataModelsContentGeneratorTest {
 
     SimpleParameterProvider requestParams = new SimpleParameterProvider();
     requestParams.setParameter( "action", MetadataModelsContentGenerator.QUERY_ACTION );
-    String queryJson = OBJECT_MAPPER.writeValueAsString( query );
+    // Mirror the payload produced by impl/client/src/main/javascript/web/dataapi/models-svc.js.
+    String queryJson = "{"
+      + "\"class\":\"org.pentaho.metadata.model.thin.Query\","
+      + "\"sourceId\":\"" + id + "\","
+      + "\"elements\":["
+      + "{\"class\":\"org.pentaho.metadata.model.thin.Element\",\"id\":\"element1\"},"
+      + "{\"class\":\"org.pentaho.metadata.model.thin.Element\",\"id\":\"element2\"}"
+      + "]}";
     System.out.println( queryJson );
     requestParams.setParameter( "query", queryJson );
 

--- a/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorThinQueryTest.java
+++ b/impl/server/src/test/java/org/pentaho/common/ui/metadata/service/MetadataModelsContentGeneratorThinQueryTest.java
@@ -1,0 +1,117 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.common.ui.metadata.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.pentaho.metadata.model.thin.Query;
+
+/**
+ * Compatibility and security coverage for the legacy browser query contract migrated in PPP-6483.
+ */
+public class MetadataModelsContentGeneratorThinQueryTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = MetadataModelsContentGenerator.createQueryObjectMapper();
+
+  @Test
+  public void deserializesBrowserQueryPayload() throws Exception {
+    String json = "{"
+      + "\"class\":\"org.pentaho.metadata.model.thin.Query\","
+      + "\"sourceId\":\"model1\","
+      + "\"elements\":[{"
+      + "\"class\":\"org.pentaho.metadata.model.thin.Element\","
+      + "\"id\":\"el1\",\"parentId\":\"cat1\",\"defaultAggType\":\"SUM\"}],"
+      + "\"conditions\":[{"
+      + "\"class\":\"org.pentaho.common.ui.metadata.model.impl.Condition\","
+      + "\"elementId\":\"el1\",\"parentId\":\"cat1\",\"operator\":\"EQUAL\","
+      + "\"value\":[\"x\"],\"combinationType\":\"AND\",\"selectedAggType\":\"SUM\"}],"
+      + "\"orders\":[{"
+      + "\"class\":\"org.pentaho.metadata.model.thin.Order\","
+      + "\"elementId\":\"el1\",\"parentId\":\"cat1\",\"orderType\":\"ASC\"}],"
+      + "\"parameters\":[{"
+      + "\"class\":\"org.pentaho.common.ui.metadata.model.impl.Parameter\","
+      + "\"elementId\":\"el1\",\"name\":\"p1\",\"type\":\"STRING\",\"value\":[\"x\"]}]"
+      + "}";
+
+    Query result = OBJECT_MAPPER.readValue( json, Query.class );
+
+    assertEquals( "model1", result.getSourceId() );
+    assertEquals( 1, result.getElements().length );
+    assertEquals( "el1", result.getElements()[ 0 ].getId() );
+    assertEquals( "SUM", result.getElements()[ 0 ].getDefaultAggregation() );
+    assertEquals( 1, result.getConditions().length );
+    assertEquals( "SUM", result.getConditions()[ 0 ].getSelectedAggregation() );
+    assertEquals( 1, result.getOrders().length );
+    assertEquals( "ASC", result.getOrders()[ 0 ].getOrderType() );
+    assertEquals( 1, result.getParameters().length );
+    assertEquals( "p1", result.getParameters()[ 0 ].getName() );
+  }
+
+  @Test
+  public void deserializesClasslessQueryPayload() throws Exception {
+    Query result = OBJECT_MAPPER.readValue(
+      "{\"sourceId\":\"model1\",\"elements\":[{\"id\":\"el1\"}]}", Query.class );
+
+    assertEquals( "model1", result.getSourceId() );
+    assertEquals( "el1", result.getElements()[ 0 ].getId() );
+  }
+
+  @Test
+  public void deserializesFlexjsonThinTypeIds() throws Exception {
+    String json = "{\"class\":\"org.pentaho.metadata.model.thin.Query\","
+      + "\"conditions\":[{\"class\":\"org.pentaho.metadata.model.thin.Condition\","
+      + "\"elementId\":\"el1\"}],"
+      + "\"parameters\":[{\"class\":\"org.pentaho.metadata.model.thin.Parameter\","
+      + "\"elementId\":\"el1\",\"name\":\"p1\"}]}";
+
+    Query result = OBJECT_MAPPER.readValue( json, Query.class );
+
+    assertEquals( "el1", result.getConditions()[ 0 ].getElementId() );
+    assertEquals( "p1", result.getParameters()[ 0 ].getName() );
+  }
+
+  @Test
+  public void rejectsUnknownLegacyTypeId() {
+    String json = "{\"class\":\"java.lang.Runtime\",\"sourceId\":\"model1\"}";
+
+    assertThrows( InvalidTypeIdException.class, () -> OBJECT_MAPPER.readValue( json, Query.class ) );
+  }
+
+  @Test
+  public void rejectsCrossFamilyTypeId() {
+    String json = "{\"class\":\"org.pentaho.metadata.model.thin.Element\",\"sourceId\":\"model1\"}";
+
+    assertThrows( InvalidTypeIdException.class, () -> OBJECT_MAPPER.readValue( json, Query.class ) );
+  }
+
+  @Test
+  public void rejectsUnknownNestedTypeId() {
+    String json = "{\"class\":\"org.pentaho.metadata.model.thin.Query\","
+      + "\"elements\":[{\"class\":\"java.lang.Runtime\",\"id\":\"el1\"}]}";
+
+    assertThrows( InvalidTypeIdException.class, () -> OBJECT_MAPPER.readValue( json, Query.class ) );
+  }
+
+  @Test
+  public void rejectsDuplicateTypeId() {
+    String json = "{\"class\":\"org.pentaho.metadata.model.thin.Query\","
+      + "\"class\":\"org.pentaho.metadata.model.thin.Query\"}";
+
+    assertThrows( JsonParseException.class, () -> OBJECT_MAPPER.readValue( json, Query.class ) );
+  }
+}


### PR DESCRIPTION
## Summary

- restore deserialization of the legacy browser query payload after the PPP-6483 Flexjson-to-Jackson migration
- interpret the existing FQCN `class` values as explicit `JsonTypeInfo.Id.NAME` protocol identifiers through mapper-local mix-ins
- preserve browser aliases `defaultAggType` and `selectedAggType` without annotating shared metadata model classes
- isolate the compatibility reader from the response writer so service output remains free of Flexjson class metadata

## Root cause

`models-svc.js` still sends `class` metadata for `Query`, `Element`, `Condition`, `Order`, and `Parameter`. The bare Jackson mapper introduced by PPP-6483 rejects the root `class` field with `UnrecognizedPropertyException`, so a real browser query fails before execution. The prior unit test generated its input with Jackson and therefore omitted the browser metadata.

## Compatibility and security

- allow-lists only the exact legacy query-family identifiers; no input value is used for dynamic class loading
- accepts the historical thin-model IDs and the common-ui Condition/Parameter IDs emitted by the browser
- continues to accept class-less concrete query payloads
- rejects unknown, cross-family, nested-unknown, and duplicate type identifiers
- retains strict unknown-property handling for all other fields

## Validation

- `mvn -pl impl/server test`
- 39 tests run, 0 failures, 0 errors, 0 skipped

## Related work

- PPP-6483 / #1866
- BACKLOG-50609
- pentaho/data-access#1360
- pentaho/pentaho-platform-plugin-interactive-reporting#1196